### PR TITLE
Add some execution-related macro utilities.

### DIFF
--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -17,6 +17,7 @@ enable_timings() = (TimerOutputs.enable_debug_timings(GPUCompiler); return)
 
 include("utils.jl")
 
+# compiler interface and implementations
 include("interface.jl")
 include("error.jl")
 include("native.jl")
@@ -25,6 +26,7 @@ include("gcn.jl")
 
 include("runtime.jl")
 
+# compiler implementation
 include("irgen.jl")
 include("optim.jl")
 include("validation.jl")
@@ -32,7 +34,10 @@ include("rtlib.jl")
 include("mcgen.jl")
 include("debug.jl")
 include("driver.jl")
+
+# other reusable functionality
 include("cache.jl")
+include("execution.jl")
 include("reflection.jl")
 
 function __init__()

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -1,0 +1,54 @@
+# reusable functionality to implement code execution
+
+export split_kwargs, assign_args!
+
+
+## macro tools
+
+# split keyword arguments expressions into groups. returns vectors of keyword argument
+# values, one more than the number of groups (unmatched keywords in the last vector).
+# intended for use in macros; the resulting groups can be used in expressions.
+function split_kwargs(kwargs, kw_groups...)
+    kwarg_groups = ntuple(_->[], length(kw_groups) + 1)
+    for kwarg in kwargs
+        # decode
+        Meta.isexpr(kwarg, :(=)) || throw(ArgumentError("non-keyword argument like option '$kwarg'"))
+        key, val = kwarg.args
+        isa(key, Symbol) || throw(ArgumentError("non-symbolic keyword '$key'"))
+
+        # find a matching group
+        group = length(kw_groups)
+        for (i, kws) in enumerate(kw_groups)
+            if key in kws
+                group = i
+                break
+            end
+        end
+        push!(kwarg_groups[group], kwarg)
+    end
+
+    return kwarg_groups
+end
+
+# assign arguments to variables, handle splatting
+function assign_args!(code, args)
+    # handle splatting
+    splats = map(arg -> Meta.isexpr(arg, :(...)), args)
+    args = map(args, splats) do arg, splat
+        splat ? arg.args[1] : arg
+    end
+
+    # assign arguments to variables
+    vars = Tuple(gensym() for arg in args)
+    map(vars, args) do var,arg
+        push!(code.args, :($var = $arg))
+    end
+
+    # convert the arguments, compile the function and call the kernel
+    # while keeping the original arguments alive
+    var_exprs = map(vars, args, splats) do var, arg, splat
+         splat ? Expr(:(...), var) : var
+    end
+
+    return vars, var_exprs
+end


### PR DESCRIPTION
Used by CUDAnative and AMDGPUnative.
@jpsamaroo I slightly changed 'split_kwargs!' so you pass in the kwarg groups instead.