### PR TITLE
Redesign the compiler interfaces yet again.

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -3,18 +3,18 @@
 export KernelError, InternalCompilerError
 
 struct KernelError <: Exception
-    job::AbstractCompilerJob
+    job::CompilerJob
     message::String
     help::Union{Nothing,String}
     bt::StackTraces.StackTrace
 
-    KernelError(job::AbstractCompilerJob, message::String, help=nothing;
+    KernelError(job::CompilerJob, message::String, help=nothing;
                 bt=StackTraces.StackTrace()) =
         new(job, message, help, bt)
 end
 
 function Base.showerror(io::IO, err::KernelError)
-    println(io, "GPU compilation of ", source(err.job), " failed")
+    println(io, "GPU compilation of ", err.job.source, " failed")
     println(io, "KernelError: $(err.message)")
     println(io)
     println(io, something(err.help, "Try inspecting the generated code with any of the @device_code_... macros."))
@@ -23,7 +23,7 @@ end
 
 
 struct InternalCompilerError <: Exception
-    job::AbstractCompilerJob
+    job::CompilerJob
     message::String
     meta::Dict
     InternalCompilerError(job, message; kwargs...) = new(job, message, kwargs)

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -2,7 +2,7 @@
 
 # final preparations for the module to be compiled to PTX
 # these passes should not be run when e.g. compiling to write to disk.
-function prepare_execution!(job::AbstractCompilerJob, mod::LLVM.Module)
+function prepare_execution!(job::CompilerJob, mod::LLVM.Module)
     let pm = ModulePassManager()
         global current_job
         current_job = job
@@ -30,7 +30,7 @@ end
 #
 # this pass performs that resolution at link time.
 function resolve_cpu_references!(mod::LLVM.Module)
-    job = current_job::AbstractCompilerJob
+    job = current_job::CompilerJob
     changed = false
 
     for f in functions(mod)
@@ -67,8 +67,8 @@ function resolve_cpu_references!(mod::LLVM.Module)
 end
 
 
-function mcgen(job::AbstractCompilerJob, mod::LLVM.Module, f::LLVM.Function, format=LLVM.API.LLVMAssemblyFile)
-    tm = llvm_machine(target(job))
+function mcgen(job::CompilerJob, mod::LLVM.Module, f::LLVM.Function, format=LLVM.API.LLVMAssemblyFile)
+    tm = llvm_machine(job.target)
 
     return String(emit(tm, mod, format))
 end

--- a/src/native.jl
+++ b/src/native.jl
@@ -25,24 +25,4 @@ end
 
 ## job
 
-export NativeCompilerJob
-
-Base.@kwdef struct NativeCompilerJob <: AbstractCompilerJob
-    target::AbstractCompilerTarget
-    source::FunctionSpec
-end
-
-target(job::NativeCompilerJob) = job.target
-source(job::NativeCompilerJob) = job.source
-
-Base.similar(job::NativeCompilerJob, source::FunctionSpec) =
-    NativeCompilerJob(target=job.target, source=source)
-
-function Base.show(io::IO, job::NativeCompilerJob)
-    print(io, "Native CompilerJob of ", source(job))
-    print(io, " for $(target(job).cpu) $(target(job).features)")
-end
-
-runtime_slug(job::NativeCompilerJob) = "native_$(Base.parent(target(job)).cpu)-$(hash(Base.parent(target(job)).features))"
-
-add_lowering_passes!(::NativeCompilerJob, pm::LLVM.PassManager) = return
+runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))"

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -1,7 +1,7 @@
 # LLVM IR optimization
 
-function optimize!(job::AbstractCompilerJob, mod::LLVM.Module, entry::LLVM.Function)
-    tm = llvm_machine(target(job))
+function optimize!(job::CompilerJob, mod::LLVM.Module, entry::LLVM.Function)
+    tm = llvm_machine(job.target)
     entry_fn = LLVM.name(entry)
 
     function initialize!(pm)
@@ -84,7 +84,7 @@ end
 # such IR is hard to clean-up, so we probably will need to have the GC lowering pass emit
 # lower-level intrinsics which then can be lowered to architecture-specific code.
 function lower_gc_frame!(fun::LLVM.Function)
-    job = current_job::AbstractCompilerJob
+    job = current_job::CompilerJob
     mod = LLVM.parent(fun)
     changed = false
 
@@ -142,7 +142,7 @@ end
 # TODO: maybe don't have Julia emit actual uses of the TLS, but use intrinsics instead,
 #       making it easier to remove or reimplement that functionality here.
 function lower_ptls!(mod::LLVM.Module)
-    job = current_job::AbstractCompilerJob
+    job = current_job::CompilerJob
     changed = false
 
     if haskey(functions(mod), "julia.ptls_states")

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -5,28 +5,28 @@ using InteractiveUtils, Cthulhu
 # code_* replacements
 #
 
-code_lowered(job::AbstractCompilerJob; kwargs...) =
-    InteractiveUtils.code_lowered(source(job).f, source(job).tt; kwargs...)
+code_lowered(job::CompilerJob; kwargs...) =
+    InteractiveUtils.code_lowered(job.source.f, job.source.tt; kwargs...)
 
-function code_typed(job::AbstractCompilerJob; interactive::Bool=false, kwargs...)
+function code_typed(job::CompilerJob; interactive::Bool=false, kwargs...)
     # TODO: use the compiler driver to get the Julia method instance (we might rewrite it)
     if interactive
-        descend_code_typed(source(job).f, source(job).tt; kwargs...)
+        descend_code_typed(job.source.f, job.source.tt; kwargs...)
     else
-        InteractiveUtils.code_typed(source(job).f, source(job).tt; kwargs...)
+        InteractiveUtils.code_typed(job.source.f, job.source.tt; kwargs...)
     end
 end
 
-function code_warntype(io::IO, job::AbstractCompilerJob; interactive::Bool=false, kwargs...)
+function code_warntype(io::IO, job::CompilerJob; interactive::Bool=false, kwargs...)
     # TODO: use the compiler driver to get the Julia method instance (we might rewrite it)
     if interactive
         @assert io == stdout
-        descend_code_warntype(source(job).f, source(job).tt; kwargs...)
+        descend_code_warntype(job.source.f, job.source.tt; kwargs...)
     else
-        InteractiveUtils.code_warntype(io, source(job).f, source(job).tt; kwargs...)
+        InteractiveUtils.code_warntype(io, job.source.f, job.source.tt; kwargs...)
     end
 end
-code_warntype(job::AbstractCompilerJob; kwargs...) = code_warntype(stdout, job; kwargs...)
+code_warntype(job::CompilerJob; kwargs...) = code_warntype(stdout, job; kwargs...)
 
 """
     code_llvm([io], job; optimize=true, raw=false, dump_module=false, strict=false)
@@ -43,7 +43,7 @@ The following keyword arguments are supported:
 
 See also: [`@device_code_llvm`](@ref), InteractiveUtils.code_llvm
 """
-function code_llvm(io::IO, job::AbstractCompilerJob; optimize::Bool=true, raw::Bool=false,
+function code_llvm(io::IO, job::CompilerJob; optimize::Bool=true, raw::Bool=false,
                    debuginfo::Symbol=:default, dump_module::Bool=false, strict::Bool=false)
     # NOTE: jl_dump_function_ir supports stripping metadata, so don't do it in the driver
     ir, entry = GPUCompiler.codegen(:llvm, job; optimize=optimize, strip=false, strict=strict)
@@ -52,7 +52,7 @@ function code_llvm(io::IO, job::AbstractCompilerJob; optimize::Bool=true, raw::B
                 LLVM.ref(entry), !raw, dump_module, debuginfo)
     print(io, str)
 end
-code_llvm(job::AbstractCompilerJob; kwargs...) = code_llvm(stdout, job; kwargs...)
+code_llvm(job::CompilerJob; kwargs...) = code_llvm(stdout, job; kwargs...)
 
 """
     code_native([io], f, types; cap::VersionNumber, kernel=false, raw=false, strict=false)
@@ -68,11 +68,11 @@ The following keyword arguments are supported:
 
 See also: [`@device_code_native`](@ref), InteractiveUtils.code_llvm
 """
-function code_native(io::IO, job::AbstractCompilerJob; raw::Bool=false, strict::Bool=false)
+function code_native(io::IO, job::CompilerJob; raw::Bool=false, strict::Bool=false)
     asm, _ = GPUCompiler.codegen(:asm, job; strip=!raw, strict=strict)
     print(io, asm)
 end
-code_native(job::AbstractCompilerJob; kwargs...) =
+code_native(job::CompilerJob; kwargs...) =
     code_native(stdout, func, types; kwargs...)
 
 
@@ -122,7 +122,7 @@ See also: InteractiveUtils.@code_lowered
 macro device_code_lowered(ex...)
     quote
         buf = Any[]
-        function hook(job::AbstractCompilerJob)
+        function hook(job::CompilerJob)
             append!(buf, code_lowered(job))
         end
         $(emit_hooked_compilation(:hook, ex...))
@@ -140,8 +140,8 @@ See also: InteractiveUtils.@code_typed
 """
 macro device_code_typed(ex...)
     quote
-        output = Dict{AbstractCompilerJob,Any}()
-        function hook(job::AbstractCompilerJob)
+        output = Dict{CompilerJob,Any}()
+        function hook(job::CompilerJob)
             output[job] = code_typed(job)
         end
         $(emit_hooked_compilation(:hook, ex...))
@@ -158,7 +158,7 @@ InteractiveUtils.code_warntype to `io` for every compiled GPU kernel.
 See also: InteractiveUtils.@code_warntype
 """
 macro device_code_warntype(ex...)
-    function hook(job::AbstractCompilerJob; io::IO=stdout, kwargs...)
+    function hook(job::CompilerJob; io::IO=stdout, kwargs...)
         println(io, "$job")
         println(io)
         code_warntype(io, job; kwargs...)
@@ -176,7 +176,7 @@ to `io` for every compiled GPU kernel. For other supported keywords, see
 See also: InteractiveUtils.@code_llvm
 """
 macro device_code_llvm(ex...)
-    function hook(job::AbstractCompilerJob; io::IO=stdout, kwargs...)
+    function hook(job::CompilerJob; io::IO=stdout, kwargs...)
         println(io, "; $job")
         code_llvm(io, job; kwargs...)
     end
@@ -191,7 +191,7 @@ for every compiled GPU kernel. For other supported keywords, see
 [`GPUCompiler.code_native`](@ref).
 """
 macro device_code_native(ex...)
-    function hook(job::AbstractCompilerJob; io::IO=stdout, kwargs...)
+    function hook(job::CompilerJob; io::IO=stdout, kwargs...)
         println(io, "// $job")
         println(io)
         code_native(io, job; kwargs...)
@@ -208,8 +208,8 @@ Evaluates the expression `ex` and dumps all intermediate forms of code to the di
 macro device_code(ex...)
     only(xs) = (@assert length(xs) == 1; first(xs))
     localUnique = 1
-    function hook(job::AbstractCompilerJob; dir::AbstractString)
-        name = something(source(job).name, nameof(source(job).f))
+    function hook(job::CompilerJob; dir::AbstractString)
+        name = something(job.source.name, nameof(job.source.f))
         fn = "$(name)_$(localUnique)"
         mkpath(dir)
 

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -95,7 +95,7 @@ end
 
 ## functionality to build the runtime library
 
-function emit_function!(mod, job::AbstractCompilerJob, f, types, name)
+function emit_function!(mod, job::CompilerJob, f, types, name)
     tt = Base.to_tuple_type(types)
     new_mod, entry = codegen(:llvm, similar(job, FunctionSpec(f, tt, #=kernel=# false));
                              libraries=false, strict=false)
@@ -122,13 +122,13 @@ function emit_function!(mod, job::AbstractCompilerJob, f, types, name)
     LLVM.name!(entry, name)
 end
 
-function build_runtime(job::AbstractCompilerJob)
+function build_runtime(job::CompilerJob)
     mod = LLVM.Module("GPUCompiler run-time library", JuliaContext())
 
     for method in values(Runtime.methods)
         def = if isa(method.def, Symbol)
-            isdefined(runtime_module(target(job)), method.def) || continue
-            getfield(runtime_module(target(job)), method.def)
+            isdefined(runtime_module(job), method.def) || continue
+            getfield(runtime_module(job), method.def)
         else
             method.def
         end
@@ -138,7 +138,7 @@ function build_runtime(job::AbstractCompilerJob)
     mod
 end
 
-function load_runtime(job::AbstractCompilerJob)
+function load_runtime(job::CompilerJob)
     # find the first existing cache directory (for when dealing with layered depots)
     cachedirs = [cachedir(depot) for depot in DEPOT_PATH]
     filter!(isdir, cachedirs)

--- a/test/definitions/gcn.jl
+++ b/test/definitions/gcn.jl
@@ -7,29 +7,6 @@ end
 
 # create a GCN-based test compiler, and generate reflection methods for it
 
-struct GCNTestCompilerTarget <: CompositeCompilerTarget
-    parent::GCNCompilerTarget
-
-    GCNTestCompilerTarget(dev_isa::String) = new(GCNCompilerTarget(dev_isa))
-end
-
-Base.parent(target::GCNTestCompilerTarget) = target.parent
-
-struct GCNTestCompilerJob <: CompositeCompilerJob
-    parent::AbstractCompilerJob
-end
-
-GPUCompiler.runtime_module(target::GCNTestCompilerTarget) = TestRuntime
-
-GCNTestCompilerJob(target::AbstractCompilerTarget, source::FunctionSpec; kwargs...) =
-    GCNTestCompilerJob(GCNCompilerJob(target, source; kwargs...))
-
-Base.similar(job::GCNTestCompilerJob, source::FunctionSpec; kwargs...) =
-    GCNTestCompilerJob(similar(job.parent, source; kwargs...))
-
-Base.parent(job::GCNTestCompilerJob) = job.parent
-
-gcn_dev_isa = "gfx900"
 for method in (:code_typed, :code_warntype, :code_llvm, :code_native)
     # only code_typed doesn't take a io argument
     args = method == :code_typed ? (:job,) : (:io, :job)
@@ -39,8 +16,9 @@ for method in (:code_typed, :code_warntype, :code_llvm, :code_native)
         function $gcn_method(io::IO, @nospecialize(func), @nospecialize(types);
                              kernel::Bool=false, kwargs...)
             source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
-            target = GCNTestCompilerTarget($gcn_dev_isa)
-            job = GCNTestCompilerJob(target, source)
+            target = GCNCompilerTarget("gfx900")
+            params = TestCompilerParams()
+            job = CompilerJob(target, source, params)
             GPUCompiler.$method($(args...); kwargs...)
         end
         $gcn_method(@nospecialize(func), @nospecialize(types); kwargs...) =

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -7,29 +7,6 @@ end
 
 # create a PTX-based test compiler, and generate reflection methods for it
 
-struct PTXTestCompilerTarget <: CompositeCompilerTarget
-    parent::PTXCompilerTarget
-
-    PTXTestCompilerTarget(cap::VersionNumber) = new(PTXCompilerTarget(cap))
-end
-
-Base.parent(target::PTXTestCompilerTarget) = target.parent
-
-struct PTXTestCompilerJob <: CompositeCompilerJob
-    parent::AbstractCompilerJob
-end
-
-GPUCompiler.runtime_module(target::PTXTestCompilerTarget) = TestRuntime
-
-PTXTestCompilerJob(target::AbstractCompilerTarget, source::FunctionSpec; kwargs...) =
-    PTXTestCompilerJob(PTXCompilerJob(target, source; kwargs...))
-
-Base.similar(job::PTXTestCompilerJob, source::FunctionSpec; kwargs...) =
-    PTXTestCompilerJob(similar(job.parent, source; kwargs...))
-
-Base.parent(job::PTXTestCompilerJob) = job.parent
-
-ptx_cap = v"7.0"
 for method in (:code_typed, :code_warntype, :code_llvm, :code_native)
     # only code_typed doesn't take a io argument
     args = method == :code_typed ? (:job,) : (:io, :job)
@@ -40,10 +17,11 @@ for method in (:code_typed, :code_warntype, :code_llvm, :code_native)
                              kernel::Bool=false, minthreads=nothing, maxthreads=nothing,
                              blocks_per_sm=nothing, maxregs=nothing, kwargs...)
             source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
-            target = PTXTestCompilerTarget($ptx_cap)
-            job = PTXTestCompilerJob(target, source;
-                                     minthreads=minthreads, maxthreads=maxthreads,
-                                     blocks_per_sm=blocks_per_sm, maxregs=maxregs)
+            target = PTXCompilerTarget(cap=v"7.0",
+                                       minthreads=minthreads, maxthreads=maxthreads,
+                                       blocks_per_sm=blocks_per_sm, maxregs=maxregs)
+            params = TestCompilerParams()
+            job = CompilerJob(target, source, params)
             GPUCompiler.$method($(args...); kwargs...)
         end
         $ptx_method(@nospecialize(func), @nospecialize(types); kwargs...) =

--- a/test/util.jl
+++ b/test/util.jl
@@ -43,3 +43,6 @@ module TestRuntime
     # for validation
     sin(x) = Base.sin(x)
 end
+
+struct TestCompilerParams <: AbstractCompilerParams end
+GPUCompiler.runtime_module(::CompilerJob{<:Any,TestCompilerParams}) = TestRuntime


### PR DESCRIPTION
Basically, use a concrete `CompilerJob` that's parameterized both on `CompilerTarget` (defined in GPUCompilers.jl) and a `CompilerParams` (for external packages). Makes it much cleaner to extent.

The only remaining ugly part is when extending an interface that already has an implementation in GPUCompilers.jl:

```julia
struct CUDACompilerParams <: AbstractCompilerParams end
CUDACompilerJob = CompilerJob{PTXCompilerTarget,CUDACompilerParams}

function GPUCompiler.process_module!(job::CUDACompilerJob, mod::LLVM.Module)
    invoke(GPUCompiler.process_module!,
           Tuple{CompilerJob{PTXCompilerTarget}, typeof(mod)},
           job, mod)
    emit_exception_flag!(mod)
end
```

But maybe that's just a badly designed interface.