### PR TITLE
Check the types of emitted runtime functions.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -103,15 +103,15 @@ function codegen(output::Symbol, job::CompilerJob;
             @timeit_debug to "target libraries" link_libraries!(job, ir, undefined_fns)
         end
 
-        if optimize
-            kernel = @timeit_debug to "optimization" optimize!(job, ir, kernel)
-        end
-
         if libraries
             undefined_fns = LLVM.name.(decls(ir))
             if any(fn -> fn in runtime_fns, undefined_fns)
                 @timeit_debug to "runtime library" link_library!(ir, runtime)
             end
+        end
+
+        if optimize
+            kernel = @timeit_debug to "optimization" optimize!(job, ir, kernel)
         end
 
         if ccall(:jl_is_debugbuild, Cint, ()) == 1

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -110,6 +110,8 @@ function codegen(output::Symbol, job::CompilerJob;
             end
         end
 
+        finish_module!(job, ir)
+
         if optimize
             kernel = @timeit_debug to "optimization" optimize!(job, ir, kernel)
         end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -122,6 +122,9 @@ process_module!(::CompilerJob, mod::LLVM.Module) = return
 # early processing of the newly identified LLVM kernel function
 process_kernel!(::CompilerJob, mod::LLVM.Module, kernel::LLVM.Function) = return
 
+# late processing of the LLVM IR module, after linking libraries but before optimization
+finish_module!(::CompilerJob, mod::LLVM.Module) = return
+
 add_lowering_passes!(::CompilerJob, pm::LLVM.PassManager) = return
 
 add_optimization_passes!(::CompilerJob, pm::LLVM.PassManager) = return


### PR DESCRIPTION
They should match the definitions.

Also emit without optimization, or address spaces would be stripped on 1.5+