### PR TITLE
Disable byval for GCN kernels

### DIFF
--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -35,8 +35,10 @@ const gcn_intrinsics = () # TODO: ("vprintf", "__assertfail", "malloc", "free")
 isintrinsic(::CompilerJob{GCNCompilerTarget}, fn::String) = in(fn, gcn_intrinsics)
 
 function process_kernel!(job::CompilerJob{GCNCompilerTarget}, mod::LLVM.Module, kernel::LLVM.Function)
+    kernel = wrap_entry!(job, mod, kernel)
     # AMDGPU kernel calling convention
     callconv!(kernel, LLVM.API.LLVMCallConv(91))
+    kernel
 end
 
 function add_lowering_passes!(job::CompilerJob{GCNCompilerTarget}, pm::LLVM.PassManager)
@@ -127,4 +129,130 @@ function emit_trap!(job::CompilerJob{GCNCompilerTarget}, builder, mod, inst)
         store!(builder, rl_val, rl_bc)
     end
     call!(builder, trap)
+end
+
+# manual implementation of byval, as the backend doesn't support it for kernel args
+# https://reviews.llvm.org/D79744
+function wrapper_type(julia_t::Type, codegen_t::LLVMType)::LLVMType
+    if !isbitstype(julia_t)
+        # don't pass jl_value_t by value; it's an opaque structure
+        return codegen_t
+    elseif isa(codegen_t, LLVM.PointerType) && !(julia_t <: Ptr)
+        # we didn't specify a pointer, but codegen passes one anyway.
+        # make the wrapper accept the underlying value instead.
+        return eltype(codegen_t)
+    else
+        return codegen_t
+    end
+end
+# generate a kernel wrapper to fix & improve argument passing
+function wrap_entry!(job::CompilerJob, mod::LLVM.Module, entry_f::LLVM.Function)
+    entry_ft = eltype(llvmtype(entry_f)::LLVM.PointerType)::LLVM.FunctionType
+    @compiler_assert return_type(entry_ft) == LLVM.VoidType(JuliaContext()) job
+
+    # filter out types which don't occur in the LLVM function signatures
+    sig = Base.signature_type(job.source.f, job.source.tt)::Type
+    julia_types = Type[]
+    for dt::Type in sig.parameters
+        if !isghosttype(dt) && (VERSION < v"1.5.0-DEV.581" || !Core.Compiler.isconstType(dt))
+            push!(julia_types, dt)
+        end
+    end
+
+    # generate the wrapper function type & definition
+    wrapper_types = LLVM.LLVMType[wrapper_type(julia_t, codegen_t)
+                                  for (julia_t, codegen_t)
+                                  in zip(julia_types, parameters(entry_ft))]
+    wrapper_fn = LLVM.name(entry_f)
+    LLVM.name!(entry_f, wrapper_fn * ".inner")
+    wrapper_ft = LLVM.FunctionType(LLVM.VoidType(JuliaContext()), wrapper_types)
+    wrapper_f = LLVM.Function(mod, wrapper_fn, wrapper_ft)
+
+    # emit IR performing the "conversions"
+    let builder = Builder(JuliaContext())
+        entry = BasicBlock(wrapper_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        wrapper_args = Vector{LLVM.Value}()
+
+        # perform argument conversions
+        codegen_types = parameters(entry_ft)
+        wrapper_params = parameters(wrapper_f)
+        param_index = 0
+        for (julia_t, codegen_t, wrapper_t, wrapper_param) in
+            zip(julia_types, codegen_types, wrapper_types, wrapper_params)
+            param_index += 1
+            if codegen_t != wrapper_t
+                # the wrapper argument doesn't match the kernel parameter type.
+                # this only happens when codegen wants to pass a pointer.
+                @compiler_assert isa(codegen_t, LLVM.PointerType) job
+                @compiler_assert eltype(codegen_t) == wrapper_t job
+
+                # copy the argument value to a stack slot, and reference it.
+                ptr = alloca!(builder, wrapper_t)
+                if LLVM.addrspace(codegen_t) != 0
+                    ptr = addrspacecast!(builder, ptr, codegen_t)
+                end
+                store!(builder, wrapper_param, ptr)
+                push!(wrapper_args, ptr)
+            else
+                push!(wrapper_args, wrapper_param)
+                for attr in collect(parameter_attributes(entry_f, param_index))
+                    push!(parameter_attributes(wrapper_f, param_index), attr)
+                end
+            end
+        end
+
+        call!(builder, entry_f, wrapper_args)
+
+        ret!(builder)
+
+        dispose(builder)
+    end
+
+    # early-inline the original entry function into the wrapper
+    push!(function_attributes(entry_f), EnumAttribute("alwaysinline", 0, JuliaContext()))
+    linkage!(entry_f, LLVM.API.LLVMInternalLinkage)
+
+    fixup_metadata!(entry_f)
+    ModulePassManager() do pm
+        always_inliner!(pm)
+        run!(pm, mod)
+    end
+
+    return wrapper_f
+end
+# HACK: get rid of invariant.load and const TBAA metadata on loads from pointer args,
+#       since storing to a stack slot violates the semantics of those attributes.
+# TODO: can we emit a wrapper that doesn't violate Julia's metadata?
+function fixup_metadata!(f::LLVM.Function)
+    for param in parameters(f)
+        if isa(llvmtype(param), LLVM.PointerType)
+            # collect all uses of the pointer
+            worklist = Vector{LLVM.Instruction}(user.(collect(uses(param))))
+            while !isempty(worklist)
+                value = popfirst!(worklist)
+
+                # remove the invariant.load attribute
+                md = metadata(value)
+                if haskey(md, LLVM.MD_invariant_load)
+                    delete!(md, LLVM.MD_invariant_load)
+                end
+                if haskey(md, LLVM.MD_tbaa)
+                    delete!(md, LLVM.MD_tbaa)
+                end
+
+                # recurse on the output of some instructions
+                if isa(value, LLVM.BitCastInst) ||
+                   isa(value, LLVM.GetElementPtrInst) ||
+                   isa(value, LLVM.AddrSpaceCastInst)
+                    append!(worklist, user.(collect(uses(value))))
+                end
+
+                # IMPORTANT NOTE: if we ever want to inline functions at the LLVM level,
+                # we need to recurse into call instructions here, and strip metadata from
+                # called functions (see CUDAnative.jl#238).
+            end
+        end
+    end
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -120,7 +120,7 @@ runtime_slug(::CompilerJob) = error("Not implemented")
 process_module!(::CompilerJob, mod::LLVM.Module) = return
 
 # early processing of the newly identified LLVM kernel function
-process_kernel!(::CompilerJob, mod::LLVM.Module, kernel::LLVM.Function) = return
+process_kernel!(::CompilerJob, mod::LLVM.Module, kernel::LLVM.Function) = return kernel
 
 # late processing of the LLVM IR module, after linking libraries but before optimization
 finish_module!(::CompilerJob, mod::LLVM.Module) = return

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -583,7 +583,7 @@ function promote_kernel!(job::CompilerJob, mod::LLVM.Module, kernel::LLVM.Functi
     end
 
     # target-specific processing
-    process_kernel!(job, mod, kernel)
+    kernel = process_kernel!(job, mod, kernel)
 
     return kernel
 end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -96,6 +96,8 @@ function process_kernel!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module, 
         callconv!(kernel, LLVM.API.LLVMPTXDeviceCallConv)
     end
     callconv!(kernel, LLVM.API.LLVMPTXKernelCallConv)
+
+    return kernel
 end
 
 function add_lowering_passes!(job::CompilerJob{PTXCompilerTarget}, pm::LLVM.PassManager)


### PR DESCRIPTION
For the AMDGPU target, the `byval` attribute is not (yet) valid for kernel arguments, so the removal of the `wrap_entry!` functionality in #16 broke the GCN compiler by making the target emit code expecting a pointer instead of an inlined struct. This PR pulls back in the logic for `wrap_entry` just for GCN, and replaces usage of `byval`, until the AMDGPU target has gotten `byval` working again.