### PR TITLE
Avoid OOB linetable access on pre-1.5.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,25 +17,28 @@ asserts:1.4:
 # TODO: add 1.5.0 once it has LLVM+asserts artifacts
 
 
-# CUDAnative.jl
+# CUDA.jl
 
-.test_cudanative:
+.test_cuda:
   extends: .test
   variables:
+    JULIA_NUM_THREADS: '2'
+    CI_APT_INSTALL: 'libgomp1'
     NVIDIA_VISIBLE_DEVICES: 'all'
-    NVIDIA_DRIVER_CAPABILITIES: 'all'
+    NVIDIA_DRIVER_CAPABILITIES: 'compute,utility'
+    JULIA_CUDA_USE_BINARYBUILDER: 'false' # reduce CI network traffic
   script:
     - julia -e 'using Pkg;
                 Pkg.develop(PackageSpec(path=pwd()));
                 Pkg.build();'
     - julia -e 'using Pkg;
-                Pkg.add(PackageSpec(name="CUDAnative", rev="master"));
-                Pkg.test("CUDAnative");'
+                Pkg.add(PackageSpec(name="CUDA", rev="master"));
+                Pkg.test("CUDA");'
 
-cudanative:1.4:
+cuda:1.4:
   extends:
     - .julia:1.4
-    - .test_cudanative
+    - .test_cuda
   tags:
     - nvidia
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -53,7 +53,7 @@ specialization_counter = 0
     new_ci = copy(ci)
     empty!(new_ci.code)
     empty!(new_ci.codelocs)
-    empty!(new_ci.linetable)
+    resize!(new_ci.linetable, 1)    # codegen assumes at least one entry on <1.5
     empty!(new_ci.ssaflags)
     new_ci.ssavaluetypes = 0
     new_ci.edges = MethodInstance[mi]


### PR DESCRIPTION
I think this was the cause for nonsensical stack traces like:

```
 Error During Test at /builds/JuliaGPU/CUDA.jl/test/device/cuda.jl:907
  Got exception outside of a @test
  CUDA error: out of memory (code 2, ERROR_OUT_OF_MEMORY)
  Stacktrace:
   [1] throw_api_error(::CUDA.cudaError_enum) at /builds/JuliaGPU/CUDA.jl/lib/cuda/error.jl:103
   [2] CuModule(::Array{UInt8,1}, ::Dict{CUDA.CUjit_option_enum,Any}) at /builds/JuliaGPU/CUDA.jl/lib/cuda/module.jl:42
   [3] CuModule(::CuLinkImage, ::Dict{CUDA.CUjit_option_enum,Any}) at /builds/JuliaGPU/CUDA.jl/lib/cuda/module/linker.jl:142
   [4] _cufunction(::GPUCompiler.FunctionSpec{var"#3908#kernel#593",Tuple{}}; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /builds/JuliaGPU/CUDA.jl/src/compiler/execution.jl:335
   [5] _cufunction at /builds/JuliaGPU/CUDA.jl/src/compiler/execution.jl:302 [inlined]
   [6] #75 at /builds/JuliaGPU/CUDA.jl/.julia/packages/GPUCompiler/lqbF2/src/cache.jl:21 [inlined]
   [7] get!(::GPUCompiler.var"#75#76"{Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},typeof(CUDA._cufunction),GPUCompiler.FunctionSpec{var"#3908#kernel#593",Tuple{}}}, ::Dict{UInt64,Any}, ::UInt64) at ./dict.jl:452
   [8] macro expansion at ./lock.jl:183 [inlined]
   [9] check_cache(::typeof(CUDA._cufunction), ::GPUCompiler.FunctionSpec{var"#3908#kernel#593",Tuple{}}, ::UInt64; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /builds/JuliaGPU/CUDA.jl/.julia/packages/GPUCompiler/lqbF2/src/cache.jl:19
   [10] + at ./int.jl:53 [inlined]
   [11] hash_64_64 at ./hashing.jl:35 [inlined]
   [12] hash_uint64 at ./hashing.jl:62 [inlined]
   [13] hx at ./float.jl:568 [inlined]
   [14] hash at ./float.jl:571 [inlined]
   [15] cached_compilation(::typeof(CUDA._cufunction), ::GPUCompiler.FunctionSpec{var"#3908#kernel#593",Tuple{}}, ::UInt64; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /builds/JuliaGPU/CUDA.jl/.julia/packages/GPUCompiler/lqbF2/src/cache.jl:0
   [16] cached_compilation(::Function, ::GPUCompiler.FunctionSpec{var"#3908#kernel#593",Tuple{}}, ::UInt64) at /builds/JuliaGPU/CUDA.jl/.julia/packages/GPUCompiler/lqbF2/src/cache.jl:37
   [17] cufunction(::Function, ::Type; name::Nothing, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /builds/JuliaGPU/CUDA.jl/src/compiler/execution.jl:296
   [18] cufunction(::Function, ::Type{T} where T) at /builds/JuliaGPU/CUDA.jl/src/compiler/execution.jl:291
   [19] top-level scope at /builds/JuliaGPU/CUDA.jl/src/compiler/execution.jl:108
   [20] top-level scope at /builds/JuliaGPU/CUDA.jl/test/device/cuda.jl:909
   [21] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113
   [22] top-level scope at /builds/JuliaGPU/CUDA.jl/test/device/cuda.jl:908
   [23] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113
   [24] top-level scope at /builds/JuliaGPU/CUDA.jl/test/device/cuda.jl:5
   [25] include(::String) at ./client.jl:439
   [26] #11 at /builds/JuliaGPU/CUDA.jl/test/runtests.jl:73 [inlined]
   [27] macro expansion at /builds/JuliaGPU/CUDA.jl/test/setup.jl:43 [inlined]
   [28] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113 [inlined]
   [29] macro expansion at /builds/JuliaGPU/CUDA.jl/test/setup.jl:43 [inlined]
   [30] macro expansion at /builds/JuliaGPU/CUDA.jl/src/utilities.jl:14 [inlined]
   [31] macro expansion at /builds/JuliaGPU/CUDA.jl/src/memory.jl:415 [inlined]
   [32] top-level scope at /builds/JuliaGPU/CUDA.jl/test/setup.jl:42
   [33] eval at ./boot.jl:331 [inlined]
   [34] runtests(::Function, ::String, ::CuDevice, ::Nothing) at /builds/JuliaGPU/CUDA.jl/test/setup.jl:53
   [35] (::Distributed.var"#104#106"{Distributed.CallMsg{:call_fetch}})() at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Distributed/src/process_messages.jl:294
   [36] run_work_thunk(::Distributed.var"#104#106"{Distributed.CallMsg{:call_fetch}}, ::Bool) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Distributed/src/process_messages.jl:79
   [37] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.4/Distributed/src/process_messages.jl:294 [inlined]
   [38] (::Distributed.var"#103#105"{Distributed.CallMsg{:call_fetch},Distributed.MsgHeader,Sockets.TCPSocket})() at ./task.jl:358
```