### PR TITLE
Support lowering non-runtime throw functions.

### DIFF
--- a/test/native.jl
+++ b/test/native.jl
@@ -140,6 +140,12 @@ end
     native_code_llvm(devnull, D32593, Tuple{Ptr{D32593_struct}})
 end
 
+@testset "Julia-level throw lowering" begin
+    kernel(ptr) = (unsafe_store!(ptr, sqrt(unsafe_load(ptr))); nothing)
+
+    native_code_execution(kernel, Tuple{Ptr{Float32}})
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDA.jl/issues/54.

@jpsamaroo the GCN compiler has similar functionality, I suppose we can merge this now. But do you really need to rewrite all those exceptions (e.g. `julia_bounds_error`)? Those just work for CUDA.