### PR TITLE
Add support for dump_module to code_native.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -23,19 +23,22 @@ The following keyword arguments are supported:
 - `optimize`: optimize the code (default: true)
 - `strip`: strip non-functional metadata and debug information (default: false)
 - `validate`: validate the generated IR before emitting machine code (default: true)
+- `only_entry`: only keep the entry function, remove all others (default: false).
+  This option is only for internal use, to implement reflection's `dump_module`.
 
 Other keyword arguments can be found in the documentation of [`cufunction`](@ref).
 """
 function compile(target::Symbol, job::CompilerJob;
                  libraries::Bool=true, deferred_codegen::Bool=true,
-                 optimize::Bool=true, strip::Bool=false, validate::Bool=true)
+                 optimize::Bool=true, strip::Bool=false, validate::Bool=true,
+                 only_entry::Bool=false)
     if compile_hook[] != nothing
         compile_hook[](job)
     end
 
     return codegen(target, job;
                    libraries=libraries, deferred_codegen=deferred_codegen,
-                   optimize=optimize, strip=strip, validate=validate)
+                   optimize=optimize, strip=strip, validate=validate, only_entry=only_entry)
 end
 
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
@@ -54,7 +57,7 @@ end
 
 function codegen(output::Symbol, job::CompilerJob;
                  libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
-                 strip::Bool=false, validate::Bool=true)
+                 strip::Bool=false, validate::Bool=true, only_entry::Bool=false)
     ## Julia IR
 
     @timeit_debug to "validation" check_method(job)
@@ -122,6 +125,19 @@ function codegen(output::Symbol, job::CompilerJob;
             @timeit_debug to "verification" verify(ir)
         end
 
+        if only_entry
+            # replace non-entry function definitions with a declaration
+            for f in functions(ir)
+                f == kernel && continue
+                isdeclaration(f) && continue
+                intrinsic_id(f) != 0 && continue
+                fn = LLVM.name(f)
+                LLVM.name!(f, "")
+                f′ = LLVM.Function(ir, fn, eltype(llvmtype(f)))
+                replace_uses!(f, f′)
+            end
+        end
+
         # remove everything except for the kernel
         @timeit_debug to "clean-up" begin
             exports = String[kernel_fn]
@@ -140,7 +156,7 @@ function codegen(output::Symbol, job::CompilerJob;
     end
 
     # deferred code generation
-    if deferred_codegen && haskey(functions(ir), "deferred_codegen")
+    if !only_entry && deferred_codegen && haskey(functions(ir), "deferred_codegen")
         dyn_marker = functions(ir)["deferred_codegen"]
 
         cache = Dict{CompilerJob, String}(job => kernel_fn)

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -131,9 +131,19 @@ function codegen(output::Symbol, job::CompilerJob;
                 f == kernel && continue
                 isdeclaration(f) && continue
                 intrinsic_id(f) != 0 && continue
+                # FIXME: expose llvm::Function::deleteBody with a C API
                 fn = LLVM.name(f)
                 LLVM.name!(f, "")
                 f′ = LLVM.Function(ir, fn, eltype(llvmtype(f)))
+                for attr in collect(function_attributes(f))
+                    push!(function_attributes(f′), attr)
+                end
+                for attr in collect(return_attributes(f))
+                    push!(return_attributes(f′), attr)
+                end
+                for i in 1:length(parameters(f)), attr in collect(parameter_attributes(f, i))
+                    push!(parameter_attributes(f′, i), attr)
+                end
                 replace_uses!(f, f′)
             end
         end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -75,8 +75,8 @@ The following keyword arguments are supported:
 
 See also: [`@device_code_native`](@ref), `InteractiveUtils.code_llvm`
 """
-function code_native(io::IO, job::CompilerJob; raw::Bool=false)
-    asm, _ = GPUCompiler.codegen(:asm, job; strip=!raw, validate=false)
+function code_native(io::IO, job::CompilerJob; raw::Bool=false, dump_module::Bool=false)
+    asm, _ = GPUCompiler.codegen(:asm, job; strip=!raw, only_entry=!dump_module, validate=false)
     print(io, asm)
 end
 code_native(job::CompilerJob; kwargs...) =

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -50,7 +50,7 @@ end
         return
     end
 
-    asm = sprint(io->gcn_code_native(io, parent, Tuple{Int64}))
+    asm = sprint(io->gcn_code_native(io, parent, Tuple{Int64}; dump_module=true))
     @test occursin(r"s_add_u32.*julia_child_.*@rel32@lo\+4", asm)
     @test occursin(r"s_addc_u32.*julia_child_.*@rel32@hi\+4", asm)
 end
@@ -62,7 +62,7 @@ end
         return
     end
 
-    asm = sprint(io->gcn_code_native(io, entry, Tuple{Int64}; kernel=true))
+    asm = sprint(io->gcn_code_native(io, entry, Tuple{Int64}; dump_module=true, kernel=true))
     @test occursin(r"\.amdgpu_hsa_kernel .*julia_entry", asm)
     @test !occursin(r"\.amdgpu_hsa_kernel .*julia_nonentry", asm)
     @test occursin(r"\.type.*julia_nonentry_\d*,@function", asm)
@@ -78,7 +78,7 @@ end
         return
     end
 
-    asm = sprint(io->gcn_code_native(io, parent1, Tuple{Int}))
+    asm = sprint(io->gcn_code_native(io, parent1, Tuple{Int}; dump_module=true))
     @test occursin(r"\.type.*julia__\d*_child_\d*,@function", asm)
 
     function parent2(i)
@@ -86,7 +86,7 @@ end
         return
     end
 
-    asm = sprint(io->gcn_code_native(io, parent2, Tuple{Int}))
+    asm = sprint(io->gcn_code_native(io, parent2, Tuple{Int}; dump_module=true))
     @test occursin(r"\.type.*julia__\d*_child_\d*,@function", asm)
 end
 


### PR DESCRIPTION
```
julia> using CUDA
[ Info: Precompiling CUDA [052768ef-5323-5732-b1bb-66c8b64840ba]

julia> a = CuArray([1 2 3])
1×3 CuArray{Int64,2,Nothing}:
 1  2  3

julia> @device_code_ptx a .= 5
// PTX CompilerJob of kernel broadcast(CUDA.CuKernelContext, CuDeviceArray{Int64,2,CUDA.AS.Global}, Base.Broadcast.Broadcasted{Nothing,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},typeof(identity),Tuple{Int64}}) for sm_75

//
// Generated by LLVM NVPTX Back-End
//

.version 6.3
.target sm_75
.address_size 64

        // .globl       _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE // -- Begin function _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE
.extern .func julia_throw_boundserror_2694
()
;
.extern .func gpu_report_exception
(
        .param .b64 gpu_report_exception_param_0
)
;
.extern .func gpu_signal_exception
()
;
.global .align 1 .b8 exception5[10] = {101, 120, 99, 101, 112, 116, 105, 111, 110, 0};
.weak .global .align 8 .u64 exception_flag;
                                        // @_Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE
.visible .entry _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE(
        .param .align 8 .b8 _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_0[24],
        .param .align 8 .b8 _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_1[24]
)
{
        .reg .pred      %p<4>;
        .reg .b32       %r<5>;
        .reg .b64       %rd<21>;

// %bb.0:                               // %top
        mov.b64         %rd7, _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_0;
        ld.param.u64    %rd2, [%rd7];
        ld.param.u64    %rd3, [%rd7+8];
        mov.u32         %r2, %ctaid.x;
        mov.u32         %r3, %ntid.x;
        mul.wide.u32    %rd5, %r3, %r2;
        mov.u32         %r1, %tid.x;
        add.s32         %r4, %r1, 1;
        cvt.u64.u32     %rd9, %r4;
        add.s64         %rd6, %rd5, %rd9;
        mul.lo.s64      %rd10, %rd3, %rd2;
        setp.ge.s64     %p1, %rd10, %rd6;
        @%p1 bra        LBB0_2;
        bra.uni         LBB0_1;
LBB0_2:                                 // %L34
        mov.b64         %rd8, _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_1;
        ld.param.u64    %rd1, [%rd8];
        ld.param.u64    %rd4, [%rd7+16];
        max.s64         %rd11, %rd2, 0;
        max.s64         %rd12, %rd3, 0;
        mul.lo.s64      %rd13, %rd12, %rd11;
        max.s64         %rd14, %rd13, 0;
        setp.le.s64     %p2, %rd6, %rd14;
        @%p2 bra        LBB0_4;
// %bb.3:                               // %L59
        { // callseq 0, 0
        .reg .b32 temp_param_reg;
        call.uni 
        julia_throw_boundserror_2694, 
        (
        );
        } // callseq 0
        // begin inline asm
        exit;
        // end inline asm
LBB0_4:                                 // %L62
        setp.gt.s64     %p3, %rd2, 0;
        @%p3 bra        LBB0_6;
// %bb.5:                               // %fail
        mov.u64         %rd15, exception5;
        cvta.global.u64         %rd16, %rd15;
        { // callseq 1, 0
        .reg .b32 temp_param_reg;
        .param .b64 param0;
        st.param.b64    [param0+0], %rd16;
        call.uni 
        gpu_report_exception, 
        (
        param0
        );
        } // callseq 1
        { // callseq 2, 0
        .reg .b32 temp_param_reg;
        call.uni 
        gpu_signal_exception, 
        (
        );
        } // callseq 2
        // begin inline asm
        exit;
        // end inline asm
LBB0_6:                                 // %pass
        cvt.u64.u32     %rd17, %r1;
        add.s64         %rd18, %rd5, %rd17;
        shl.b64         %rd19, %rd18, 3;
        add.s64         %rd20, %rd19, %rd4;
        st.global.u64   [%rd20], %rd1;
LBB0_1:                                 // %L33
        ret;
                                        // -- End function
}
```

vs

```
julia> @device_code_ptx dump_module=true a .= 5
// PTX CompilerJob of kernel broadcast(CUDA.CuKernelContext, CuDeviceArray{Int64,2,CUDA.AS.Global}, Base.Broadcast.Broadcasted{Nothing,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},typeof(identity),Tuple{Int64}}) for sm_75

//
// Generated by LLVM NVPTX Back-End
//

.version 6.3
.target sm_75
.address_size 64

        // .globl       _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE // -- Begin function _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE
.func julia_throw_boundserror_2885
()
;
.func gpu_report_exception
(
        .param .b64 gpu_report_exception_param_0
)
;
.extern .func  (.param .b32 func_retval0) vprintf
(
        .param .b64 vprintf_param_0,
        .param .b64 vprintf_param_1
)
;
.func gpu_signal_exception
()
;
.global .align 1 .b8 exception5[10] = {101, 120, 99, 101, 112, 116, 105, 111, 110, 0};
.global .align 1 .b8 __unnamed_1[108] = {69, 82, 82, 79, 82, 58, 32, 97, 32, 37, 115, 32, 119, 97, 115, 32, 116, 104, 114, 111, 119, 110, 32, 100, 117, 114, 105, 110, 103, 32, 107, 101, 114, 110, 101, 108, 32, 101, 120, 101, 99, 117, 116, 105, 111, 110, 46, 10, 32, 32, 32, 32, 32, 32, 32, 82, 117, 110, 32, 74, 117, 108, 105, 97, 32, 111, 110, 32, 100, 101, 98, 117, 103, 32, 108, 101, 118, 101, 108, 32, 50, 32, 102, 111, 114, 32, 100, 101, 118, 105, 99, 101, 32, 115, 116, 97, 99, 107, 32, 116, 114, 97, 99, 101, 115, 46, 10, 0};
.global .align 1 .b8 __unnamed_2[110] = {87, 65, 82, 78, 73, 78, 71, 58, 32, 99, 111, 117, 108, 100, 32, 110, 111, 116, 32, 115, 105, 103, 110, 97, 108, 32, 101, 120, 99, 101, 112, 116, 105, 111, 110, 32, 115, 116, 97, 116, 117, 115, 32, 116, 111, 32, 116, 104, 101, 32, 104, 111, 115, 116, 44, 32, 101, 120, 101, 99, 117, 116, 105, 111, 110, 32, 119, 105, 108, 108, 32, 99, 111, 110, 116, 105, 110, 117, 101, 46, 10, 32, 32, 32, 32, 32, 32, 32, 32, 32, 80, 108, 101, 97, 115, 101, 32, 102, 105, 108, 101, 32, 97, 32, 98, 117, 103, 46, 10, 0};
.weak .global .align 8 .u64 exception_flag;
                                        // @_Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE
.visible .entry _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE(
        .param .align 8 .b8 _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_0[24],
        .param .align 8 .b8 _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_1[24]
)
{
        .reg .pred      %p<4>;
        .reg .b32       %r<5>;
        .reg .b64       %rd<21>;

// %bb.0:                               // %top
        mov.b64         %rd7, _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_0;
        ld.param.u64    %rd2, [%rd7];
        ld.param.u64    %rd3, [%rd7+8];
        mov.u32         %r2, %ctaid.x;
        mov.u32         %r3, %ntid.x;
        mul.wide.u32    %rd5, %r3, %r2;
        mov.u32         %r1, %tid.x;
        add.s32         %r4, %r1, 1;
        cvt.u64.u32     %rd9, %r4;
        add.s64         %rd6, %rd5, %rd9;
        mul.lo.s64      %rd10, %rd3, %rd2;
        setp.ge.s64     %p1, %rd10, %rd6;
        @%p1 bra        LBB0_2;
        bra.uni         LBB0_1;
LBB0_2:                                 // %L34
        mov.b64         %rd8, _Z15julia_broadcast15CuKernelContext13CuDeviceArrayI5Int64Li2E6GlobalE11BroadcastedIv5TupleI5OneToI5Int64E5OneToI5Int64EE9_identity5TupleI5Int64EE_param_1;
        ld.param.u64    %rd1, [%rd8];
        ld.param.u64    %rd4, [%rd7+16];
        max.s64         %rd11, %rd2, 0;
        max.s64         %rd12, %rd3, 0;
        mul.lo.s64      %rd13, %rd12, %rd11;
        max.s64         %rd14, %rd13, 0;
        setp.le.s64     %p2, %rd6, %rd14;
        @%p2 bra        LBB0_4;
// %bb.3:                               // %L59
        { // callseq 10, 0
        .reg .b32 temp_param_reg;
        call.uni 
        julia_throw_boundserror_2885, 
        (
        );
        } // callseq 10
        // begin inline asm
        exit;
        // end inline asm
LBB0_4:                                 // %L62
        setp.gt.s64     %p3, %rd2, 0;
        @%p3 bra        LBB0_6;
// %bb.5:                               // %fail
        mov.u64         %rd15, exception5;
        cvta.global.u64         %rd16, %rd15;
        { // callseq 11, 0
        .reg .b32 temp_param_reg;
        .param .b64 param0;
        st.param.b64    [param0+0], %rd16;
        call.uni 
        gpu_report_exception, 
        (
        param0
        );
        } // callseq 11
        { // callseq 12, 0
        .reg .b32 temp_param_reg;
        call.uni 
        gpu_signal_exception, 
        (
        );
        } // callseq 12
        // begin inline asm
        exit;
        // end inline asm
LBB0_6:                                 // %pass
        cvt.u64.u32     %rd17, %r1;
        add.s64         %rd18, %rd5, %rd17;
        shl.b64         %rd19, %rd18, 3;
        add.s64         %rd20, %rd19, %rd4;
        st.global.u64   [%rd20], %rd1;
LBB0_1:                                 // %L33
        ret;
                                        // -- End function
}
.func julia_throw_boundserror_2885()    // -- Begin function julia_throw_boundserror_2885
                                        // @julia_throw_boundserror_2885
{
        .reg .b64       %rd<3>;

// %bb.0:                               // %top
        mov.u64         %rd1, exception5;
        cvta.global.u64         %rd2, %rd1;
        { // callseq 13, 0
        .reg .b32 temp_param_reg;
        .param .b64 param0;
        st.param.b64    [param0+0], %rd2;
        call.uni 
        gpu_report_exception, 
        (
        param0
        );
        } // callseq 13
        { // callseq 14, 0
        .reg .b32 temp_param_reg;
        call.uni 
        gpu_signal_exception, 
        (
        );
        } // callseq 14
        // begin inline asm
        exit;
        // end inline asm
                                        // -- End function
}
.func gpu_report_exception(
        .param .b64 gpu_report_exception_param_0
)                                       // -- Begin function gpu_report_exception
                                        // @gpu_report_exception
{
        .local .align 8 .b8     __local_depot2[8];
        .reg .b64       %SP;
        .reg .b64       %SPL;
        .reg .b32       %r<3>;
        .reg .b64       %rd<6>;

// %bb.0:                               // %top
        mov.u64         %SPL, __local_depot2;
        cvta.local.u64  %SP, %SPL;
        ld.param.u64    %rd1, [gpu_report_exception_param_0];
        add.u64         %rd2, %SP, 0;
        add.u64         %rd3, %SPL, 0;
        st.local.u64    [%rd3], %rd1;
        mov.u64         %rd4, __unnamed_1;
        cvta.global.u64         %rd5, %rd4;
        { // callseq 15, 0
        .reg .b32 temp_param_reg;
        .param .b64 param0;
        st.param.b64    [param0+0], %rd5;
        .param .b64 param1;
        st.param.b64    [param1+0], %rd2;
        .param .b32 retval0;
        call.uni (retval0), 
        vprintf, 
        (
        param0, 
        param1
        );
        ld.param.b32    %r1, [retval0+0];
        } // callseq 15
        ret;
                                        // -- End function
}
.func gpu_signal_exception()            // -- Begin function gpu_signal_exception
                                        // @gpu_signal_exception
{
        .reg .pred      %p<2>;
        .reg .b32       %r<3>;
        .reg .b64       %rd<7>;

// %bb.0:                               // %top
        ld.global.u64   %rd1, [exception_flag];
        setp.eq.s64     %p1, %rd1, 0;
        @%p1 bra        LBB3_2;
// %bb.1:                               // %L5
        mov.u64         %rd2, 0;
        st.u8   [%rd1+7], %rd2;
        st.u8   [%rd1+6], %rd2;
        st.u8   [%rd1+5], %rd2;
        st.u8   [%rd1+4], %rd2;
        st.u8   [%rd1+3], %rd2;
        st.u8   [%rd1+2], %rd2;
        st.u8   [%rd1+1], %rd2;
        mov.u64         %rd3, 1;
        st.u8   [%rd1], %rd3;
        membar.sys;
        bra.uni         LBB3_3;
LBB3_2:                                 // %L9
        mov.u64         %rd4, __unnamed_2;
        cvta.global.u64         %rd5, %rd4;
        mov.u64         %rd6, 0;
        { // callseq 16, 0
        .reg .b32 temp_param_reg;
        .param .b64 param0;
        st.param.b64    [param0+0], %rd5;
        .param .b64 param1;
        st.param.b64    [param1+0], %rd6;
        .param .b32 retval0;
        call.uni (retval0), 
        vprintf, 
        (
        param0, 
        param1
        );
        ld.param.b32    %r1, [retval0+0];
        } // callseq 16
LBB3_3:                                 // %L11
        ret;
                                        // -- End function
}
```