### PR TITLE
Fix compilecache CI lineinfo to improve backtraces

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -53,7 +53,7 @@ specialization_counter = 0
     new_ci = copy(ci)
     empty!(new_ci.code)
     empty!(new_ci.codelocs)
-    resize!(new_ci.linetable, 1)    # codegen assumes at least one entry on <1.5
+    resize!(new_ci.linetable, 1)                # see note below
     empty!(new_ci.ssaflags)
     new_ci.ssavaluetypes = 0
     new_ci.edges = MethodInstance[mi]
@@ -76,8 +76,13 @@ specialization_counter = 0
                           Expr(:call, hash, env, id),
                           Expr(:call, SSAValue(1), SSAValue(2), check_cache, driver, spec, SSAValue(3)),
                           Expr(:return, SSAValue(4))])
-    append!(new_ci.codelocs, [0, 0, 0, 0, 0])
+    append!(new_ci.codelocs, [1, 1, 1, 1, 1])   # see note below
     new_ci.ssavaluetypes += 5
+
+    # NOTE: we keep the first entry of the original linetable, and use it for location info
+    #       on the call to check_cache. we can't not have a codeloc (using 0 causes
+    #       corruption of the back trace), and reusing the target function's info
+    #       has as advantage that we see the name of the kernel in the backtraces.
 
     return new_ci
 end


### PR DESCRIPTION
Before:

```
ZeKernel at /home/tim/Julia/pkg/oneAPI/lib/level-zero/module.jl:78
get at /home/tim/Julia/pkg/oneAPI/lib/level-zero/module.jl:122
getindex at ./abstractdict.jl:490
unknown function (ip: 0x7f2fc638c7f5)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
#_compile#32 at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:127
_compile at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:119 [inlined]
#100 at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:21 [inlined]
get! at ./dict.jl:450
macro expansion at ./lock.jl:183 [inlined]
#check_cache#99 at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:19
unknown function (ip: 0x7f2fc634d829)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
check_cache##kw at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:11
unknown function (ip: 0x7f2fc6328490)
+ at ./int.jl:86 [inlined]
hash_64_64 at ./hashing.jl:35 [inlined]
hash_uint64 at ./hashing.jl:62 [inlined]
hx at ./float.jl:568 [inlined]
hash at ./float.jl:571 [inlined]
#cached_compilation#102 at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:0
unknown function (ip: 0x7f2fc6328309)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
cached_compilation at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:33
unknown function (ip: 0x7f2fc63280ef)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
#compile#31 at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:115
compile##kw at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:111 [inlined]
macro expansion at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:34 [inlined]
#gpu_call#49 at /home/tim/Julia/pkg/oneAPI/src/gpuarrays.jl:28
unknown function (ip: 0x7f2fc6327a60)
gpu_call##kw at /home/tim/Julia/pkg/oneAPI/src/gpuarrays.jl:21 [inlined]
#gpu_call#1 at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:61 [inlined]
gpu_call at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:46 [inlined]
```

After:

```
ZeKernel at /home/tim/Julia/pkg/oneAPI/lib/level-zero/module.jl:78
get at /home/tim/Julia/pkg/oneAPI/lib/level-zero/module.jl:122
getindex at ./abstractdict.jl:490
unknown function (ip: 0x7f27dca131e5)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
#_compile#32 at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:127
_compile at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:119 [inlined]
#check_cache#99 at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:24
unknown function (ip: 0x7f27dc9d40a9)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
check_cache##kw at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:11
unknown function (ip: 0x7f27dc9af9e0)
index_kernel at /home/tim/Julia/pkg/GPUArrays/src/host/indexing.jl:119 [inlined]
#cached_compilation#100 at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:0
unknown function (ip: 0x7f27dc9af859)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
cached_compilation at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:40
unknown function (ip: 0x7f27dc9af63f)
_jl_invoke at /buildworker/worker/package_linux64/build/src/gf.c:2231 [inlined]
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2398
#compile#31 at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:115
compile##kw at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:111 [inlined]
macro expansion at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:34 [inlined]
#gpu_call#49 at /home/tim/Julia/pkg/oneAPI/src/gpuarrays.jl:28
unknown function (ip: 0x7f27dc9aefb0)
gpu_call##kw at /home/tim/Julia/pkg/oneAPI/src/gpuarrays.jl:21 [inlined]
#gpu_call#1 at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:61 [inlined]
gpu_call at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:46 [inlined]
```

Wrong entries are gone. We fake one entry though, this code never actually 'calls' the `index_kernel`, but its convenient to have it there and be able to see what kernel was being called.

For regular traces, the effect is even better (this is with an abort from interpreted code):

```
 [1] error(::String) at ./error.jl:33
 [2] _compile(::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:119
 [3] _compile(::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}) at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:119
 [4] check_cache(::typeof(oneAPI._compile), ::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}, ::UInt64; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:24
 [5] index_kernel at /home/tim/Julia/pkg/GPUArrays/src/host/indexing.jl:119 [inlined]
 [6] cached_compilation(::typeof(oneAPI._compile), ::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}, ::UInt64; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:0
 [7] cached_compilation(::Function, ::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}, ::UInt64) at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:40
 [8] compile(::Function, ::Type{T} where T; name::Nothing, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:115
 [9] macro expansion at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:34 [inlined]
 [10] gpu_call(::oneAPI.oneArrayBackend, ::Function, ::Tuple{oneArray{Int64,1},oneArray{Int64,1},Tuple{Int64},Tuple{UnitRange{Int64}}}, ::Int64; name::Nothing) at /home/tim/Julia/pkg/oneAPI/src/gpuarrays.jl:28
 [11] #gpu_call#1 at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:61 [inlined]
 [12] gpu_call at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:46 [inlined]
```

Not sure where that `cache.jl:0` entry comes from though. Before it was like:

```
 [1] error(::String) at ./error.jl:33
 [2] _compile(::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:119
 [3] _compile(::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}) at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:119
 [4] (::GPUCompiler.var"#100#101"{Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},typeof(oneAPI._compile),GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}})() at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:21
 [5] get! at ./dict.jl:450 [inlined]
 [6] macro expansion at ./lock.jl:183 [inlined]
 [7] check_cache(::typeof(oneAPI._compile), ::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}, ::UInt64; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:19
 [8] + at ./int.jl:86 [inlined]
 [9] hash_64_64 at ./hashing.jl:35 [inlined]
 [10] hash_uint64 at ./hashing.jl:62 [inlined]
 [11] hx at ./float.jl:568 [inlined]
 [12] hash at ./float.jl:571 [inlined]
 [13] cached_compilation(::typeof(oneAPI._compile), ::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}, ::UInt64; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:0
 [14] cached_compilation(::Function, ::GPUCompiler.FunctionSpec{typeof(GPUArrays.index_kernel),Tuple{oneAPI.oneKernelContext,oneDeviceArray{Int64,1,1},oneDeviceArray{Int64,1,1},Tuple{Int64},Tuple{UnitRange{Int64}}}}, ::UInt64) at /home/tim/Julia/pkg/GPUCompiler/src/cache.jl:33
 [15] compile(::Function, ::Type{T} where T; name::Nothing, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:115
 [16] macro expansion at /home/tim/Julia/pkg/oneAPI/src/compiler/execution.jl:34 [inlined]
 [17] gpu_call(::oneAPI.oneArrayBackend, ::Function, ::Tuple{oneArray{Int64,1},oneArray{Int64,1},Tuple{Int64},Tuple{UnitRange{Int64}}}, ::Int64; name::Nothing) at /home/tim/Julia/pkg/oneAPI/src/gpuarrays.jl:28
 [18] #gpu_call#1 at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:61 [inlined]
 [19] gpu_call at /home/tim/Julia/pkg/GPUArrays/src/device/execution.jl:46 [inlined]
```

So this gets rid of 7 frames of lineinfo.