### PR TITLE
Add the CUDA toolkit to the PTX compiler params.

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -108,8 +108,8 @@ function compile_method_instance(job::CompilerJob, method_instance::Core.MethodI
         end
 
         # LLVM's debug info crashes older CUDA assemblers
-        if job.target isa PTXCompilerTarget # && driver_version(job.target) < v"10.2"
-            # FIXME: this was supposed to be fixed on 10.2
+        # NOTE: I'm not sure exactly when this got fixed, but it works on LLVM 9 / CUDA 11
+        if job.target isa PTXCompilerTarget && (LLVM.version() < v"8.0" || job.target.cuda < v"11")
             @debug "Incompatibility detected between CUDA and LLVM 8.0+; disabling debug info emission" maxlog=1
             debug_info_kind = LLVM.API.LLVMDebugEmissionKindNoDebug
         end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -6,6 +6,7 @@ export PTXCompilerTarget
 
 Base.@kwdef struct PTXCompilerTarget <: AbstractCompilerTarget
     cap::VersionNumber
+    cuda::VersionNumber
 
     # optional properties
     minthreads::Union{Nothing,Int,NTuple{<:Any,Int}} = nothing
@@ -43,6 +44,7 @@ llvm_datalayout(::PTXCompilerTarget) = Int===Int64 ?
 function Base.show(io::IO, job::CompilerJob{PTXCompilerTarget})
     print(io, "PTX CompilerJob of ", job.source)
     print(io, " for sm_$(job.target.cap.major)$(job.target.cap.minor)")
+    print(io, " on CUDA $(job.cuda.major).$(job.cuda.minor)")
 
     job.target.minthreads !== nothing && print(io, ", minthreads=$(job.target.minthreads)")
     job.target.maxthreads !== nothing && print(io, ", maxthreads=$(job.target.maxthreads)")
@@ -55,7 +57,9 @@ isintrinsic(::CompilerJob{PTXCompilerTarget}, fn::String) = in(fn, ptx_intrinsic
 
 # TODO: encode debug build or not in the compiler job
 #       https://github.com/JuliaGPU/CUDAnative.jl/issues/368
-runtime_slug(job::CompilerJob{PTXCompilerTarget}) = "ptx-sm_$(job.target.cap.major)$(job.target.cap.minor)"
+runtime_slug(job::CompilerJob{PTXCompilerTarget}) =
+    "ptx-sm_$(job.target.cap.major)$(job.target.cap.minor)" *
+       "-cuda$(job.target.cuda.major).$(job.target.cuda.minor)"
 
 function process_kernel!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module, kernel::LLVM.Function)
     # property annotations

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -11,7 +11,7 @@ function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                  minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
                  maxregs=nothing, kwargs...)
     source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
-    target = PTXCompilerTarget(cap=v"7.0",
+    target = PTXCompilerTarget(cap=v"7.0", cuda=v"10.2",
                                minthreads=minthreads, maxthreads=maxthreads,
                                blocks_per_sm=blocks_per_sm, maxregs=maxregs)
     params = TestCompilerParams()


### PR DESCRIPTION
Use it to conditionally emit debug info. Still crashes though, even on CUDA 11 with CUDA 9.