### PR TITLE
Don't rename unofficial LLVM intrinsics.

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -371,6 +371,7 @@ function irgen(job::CompilerJob, method_instance::Core.MethodInstance, world)
         LLVM.isintrinsic(f) && continue
         llvmfn = LLVM.name(f)
         startswith(llvmfn, "julia.") && continue # Julia intrinsics
+        startswith(llvmfn, "llvm.") && continue # unofficial LLVM intrinsics
         llvmfn′ = safe_name(llvmfn)
         if llvmfn != llvmfn′
             @assert !haskey(functions(mod), llvmfn′)


### PR DESCRIPTION
`llvm.julia.gc_preserve_begin` etc