### PR TITLE
[GCN] Fake target early, rewrite allocas later

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -137,11 +137,12 @@ function process_kernel!(job::CompilerJob, mod::LLVM.Module, kernel::LLVM.Functi
     return kernel
 end
 
+# post-Julia optimization processing of the module
+optimize_module!(::CompilerJob, mod::LLVM.Module) = return
+
 # final processing of the IR module, right before validation and machine-code generation
 finish_module!(::CompilerJob, mod::LLVM.Module) = return
 
 add_lowering_passes!(::CompilerJob, pm::LLVM.PassManager) = return
-
-add_optimization_passes!(::CompilerJob, pm::LLVM.PassManager) = return
 
 link_libraries!(::CompilerJob, mod::LLVM.Module, undefined_fns::Vector{String}) = return

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -37,21 +37,15 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
 
         remove_julia_addrspaces!(pm)
 
-        run!(pm, mod)
-    end
-
-    # target-specific optimizations
-    ModulePassManager() do pm
-        initialize!(pm)
-
         # Julia's operand bundles confuse the inliner, so repeat here now they are gone.
         # FIXME: we should fix the inliner so that inlined code gets optimized early-on
         always_inliner!(pm)
 
-        add_optimization_passes!(job, pm)
-
         run!(pm, mod)
     end
+
+    # target-specific optimizations
+    optimize_module!(job, mod)
 
     # we compile a module containing the entire call graph,
     # so perform some interprocedural optimizations.

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -126,25 +126,33 @@ function add_lowering_passes!(job::CompilerJob{PTXCompilerTarget}, pm::LLVM.Pass
     add!(pm, ModulePass("HideTrap", hide_trap!))
 end
 
-function add_optimization_passes!(job::CompilerJob{PTXCompilerTarget}, pm::LLVM.PassManager)
-    # NVPTX's target machine info enables runtime unrolling,
-    # but Julia's pass sequence only invokes the simple unroller.
-    loop_unroll!(pm)
-    instruction_combining!(pm)  # clean-up redundancy
-    licm!(pm)                   # the inner runtime check might be outer loop invariant
+function optimize_module!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module)
+    tm = llvm_machine(job.target)
+    ModulePassManager() do pm
+        add_library_info!(pm, triple(mod))
+        add_transform_info!(pm, tm)
 
-    # the above loop unroll pass might have unrolled regular, non-runtime nested loops.
-    # that code still needs to be optimized (arguably, multiple unroll passes should be
-    # scheduled by the Julia optimizer). do so here, instead of re-optimizing entirely.
-    early_csemem_ssa!(pm) # TODO: gvn instead? see NVPTXTargetMachine.cpp::addEarlyCSEOrGVNPass
-    dead_store_elimination!(pm)
+        # NVPTX's target machine info enables runtime unrolling,
+        # but Julia's pass sequence only invokes the simple unroller.
+        loop_unroll!(pm)
+        instruction_combining!(pm)  # clean-up redundancy
+        licm!(pm)                   # the inner runtime check might be outer loop invariant
 
-    constant_merge!(pm)
+        # the above loop unroll pass might have unrolled regular, non-runtime nested loops.
+        # that code still needs to be optimized (arguably, multiple unroll passes should be
+        # scheduled by the Julia optimizer). do so here, instead of re-optimizing entirely.
+        early_csemem_ssa!(pm) # TODO: gvn instead? see NVPTXTargetMachine.cpp::addEarlyCSEOrGVNPass
+        dead_store_elimination!(pm)
 
-    cfgsimplification!(pm)
+        constant_merge!(pm)
 
-    # get rid of the internalized functions; now possible unused
-    global_dce!(pm)
+        cfgsimplification!(pm)
+
+        # get rid of the internalized functions; now possible unused
+        global_dce!(pm)
+
+        run!(pm, mod)
+    end
 end
 
 

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -24,7 +24,7 @@ end
     end
 
     ir = sprint(io->gcn_code_llvm(io, kernel, Tuple{Int64}; dump_module=true))
-    @test occursin(r"alloca i64, (align 8,)? addrspace\(5\)$"m, ir)
+    @test occursin(r"alloca i64, (align 8, )?addrspace\(5\)$"m, ir)
     @test !occursin(r"alloca i64(, align \d)?$"m, ir)
 end
 


### PR DESCRIPTION
Because Julia's optimization passes don't handle certain nuances of the AMDGPU target, we need to lie about our target during optimization. Afterwards (and before target-specifications optimizations are run) we switch back to the real target.

I'm hoping that this will reduce the number of assertions hit with the GCN backend, by letting Julia's optimization passes work on IR that is closer to what they were designed for. We can easily fixup things that deviate from the target's expectations later (such as alloca addrspaces) since we get more pass-friendly code after Julia optim.