### PR TITLE
More byval work

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -32,7 +32,7 @@ function compile(target::Symbol, @nospecialize(job::CompilerJob);
                  libraries::Bool=true, deferred_codegen::Bool=true,
                  optimize::Bool=true, strip::Bool=false, validate::Bool=true,
                  only_entry::Bool=false)
-    if compile_hook[] != nothing
+    if compile_hook[] !== nothing
         compile_hook[](job)
     end
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -85,14 +85,14 @@ function process_kernel!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module, 
     append!(annotations, [MDString("kernel"), ConstantInt(Int32(1), ctx)])
 
     ## expected CTA sizes
-    if job.target.minthreads != nothing
+    if job.target.minthreads !== nothing
         for (dim, name) in enumerate([:x, :y, :z])
             bound = dim <= length(job.target.minthreads) ? job.target.minthreads[dim] : 1
             append!(annotations, [MDString("reqntid$name"),
                                   ConstantInt(Int32(bound), ctx)])
         end
     end
-    if job.target.maxthreads != nothing
+    if job.target.maxthreads !== nothing
         for (dim, name) in enumerate([:x, :y, :z])
             bound = dim <= length(job.target.maxthreads) ? job.target.maxthreads[dim] : 1
             append!(annotations, [MDString("maxntid$name"),
@@ -100,12 +100,12 @@ function process_kernel!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module, 
         end
     end
 
-    if job.target.blocks_per_sm != nothing
+    if job.target.blocks_per_sm !== nothing
         append!(annotations, [MDString("minctasm"),
                               ConstantInt(Int32(job.target.blocks_per_sm), ctx)])
     end
 
-    if job.target.maxregs != nothing
+    if job.target.maxregs !== nothing
         append!(annotations, [MDString("maxnreg"),
                               ConstantInt(Int32(job.target.maxregs), ctx)])
     end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -70,6 +70,14 @@ end
 function process_kernel!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module, kernel::LLVM.Function)
     ctx = context(mod)
 
+    # pass all bitstypes by value
+    args = classify_arguments(job, kernel)
+    for arg in args
+        if arg.cc == BITS_REF
+            push!(parameter_attributes(kernel, arg.codegen.i), EnumAttribute("byval"))
+        end
+    end
+
     # property annotations
     annotations = LLVM.Value[kernel]
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -133,7 +133,7 @@ function emit_hooked_compilation(inner_hook, ex...)
             $inner_hook(job; $(map(esc, user_kwargs)...))
         end
 
-        if GPUCompiler.compile_hook[] != nothing
+        if GPUCompiler.compile_hook[] !== nothing
             error("Chaining multiple @device_code calls is unsupported")
         end
         try

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -172,13 +172,15 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry_f::
 
         # perform argument conversions
         for arg in args
+            param = parameters(wrapper_f)[arg.codegen.i]
+            attrs = parameter_attributes(wrapper_f, arg.codegen.i)
             if arg.cc == BITS_REF
-                push!(parameter_attributes(wrapper_f, arg.codegen.i), EnumAttribute("byval"))
-                ptr = struct_gep!(builder, parameters(wrapper_f)[arg.codegen.i], 0)
+                push!(attrs, EnumAttribute("byval"))
+                ptr = struct_gep!(builder, param, 0)
                 push!(wrapper_args, ptr)
             else
-                push!(wrapper_args, parameters(wrapper_f)[arg.codegen.i])
-                for attr in collect(parameter_attributes(entry_f, arg.codegen.i))
+                push!(wrapper_args, param)
+                for attr in collect(attrs)
                     push!(parameter_attributes(wrapper_f, arg.codegen.i), attr)
                 end
             end

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -152,7 +152,7 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry_f::
     for arg in args
         typ = if arg.cc == BITS_REF
             st = LLVM.StructType([eltype(arg.codegen.typ)])
-            LLVM.PointerType(st)
+            LLVM.PointerType(st, addrspace(arg.codegen.typ))
         else
             arg.typ
         end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -104,7 +104,7 @@ function Base.showerror(io::IO, err::InvalidIRError)
     print(io, "InvalidIRError: compiling ", err.job.source, " resulted in invalid LLVM IR")
     for (kind, bt, meta) in err.errors
         print(io, "\nReason: unsupported $kind")
-        if meta != nothing
+        if meta !== nothing
             if kind == RUNTIME_FUNCTION || kind == UNKNOWN_FUNCTION || kind == POINTER_FUNCTION || kind == DYNAMIC_CALL
                 print(io, " (call to ", meta, ")")
             elseif kind == DELAYED_BINDING


### PR DESCRIPTION
Don't emit `byval` if we'll do custom wrapping using an inner function, because leaving the `byval` on the inner function breaks the following:

```llvm
define void @outer({ i32 } addrspace(11)* %arg) {
  call void @inner({ i32 } addrspace(11)* %arg)
  ret void
}

define void @inner({ i32 } addrspace(11)* byval %arg) #0 {
  %tmp = getelementptr { i32 }, { i32 } addrspace(11)* %arg, i32 0, i32 0
  ret void
}

attributes #0 = { alwaysinline }
```

```
$ opt -verify reduce.ll -o /dev/null
# all is good

$ opt -always-inline -verify reduce.ll -o /dev/null
GEP address space doesn't match type
  %tmp.i = getelementptr { i32 }, { i32 }* %arg1, i32 0, i32 0
in function outer
LLVM ERROR: Broken function found, compilation aborted!
```

This only happens with struct gep (i.e. `{ i32 }` and not `i32`), so looks like an LLVM bug? @vchuravy 