### PR TITLE
Create structs and enums in the correct context.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -123,12 +123,14 @@ process_module!(::CompilerJob, mod::LLVM.Module) = return
 
 # early processing of the newly identified LLVM kernel function
 function process_kernel!(job::CompilerJob, mod::LLVM.Module, kernel::LLVM.Function)
+    ctx = context(mod)
+
     # pass all bitstypes by value; by default Julia passes aggregates by reference
     # (this improves performance, and is mandated by certain back-ends like SPIR-V).
     args = classify_arguments(job, kernel)
     for arg in args
         if arg.cc == BITS_REF
-            push!(parameter_attributes(kernel, arg.codegen.i), EnumAttribute("byval"))
+            push!(parameter_attributes(kernel, arg.codegen.i), EnumAttribute("byval", 0, ctx))
         end
     end
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -74,7 +74,7 @@ function process_kernel!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module, 
     args = classify_arguments(job, kernel)
     for arg in args
         if arg.cc == BITS_REF
-            push!(parameter_attributes(kernel, arg.codegen.i), EnumAttribute("byval"))
+            push!(parameter_attributes(kernel, arg.codegen.i), EnumAttribute("byval", 0, ctx))
         end
     end
 

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -151,7 +151,7 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry_f::
     wrapper_types = LLVM.LLVMType[]
     for arg in args
         typ = if arg.cc == BITS_REF
-            st = LLVM.StructType([eltype(arg.codegen.typ)])
+            st = LLVM.StructType([eltype(arg.codegen.typ)], ctx)
             LLVM.PointerType(st, addrspace(arg.codegen.typ))
         else
             arg.typ
@@ -175,7 +175,7 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry_f::
             param = parameters(wrapper_f)[arg.codegen.i]
             attrs = parameter_attributes(wrapper_f, arg.codegen.i)
             if arg.cc == BITS_REF
-                push!(attrs, EnumAttribute("byval"))
+                push!(attrs, EnumAttribute("byval", 0, ctx))
                 ptr = struct_gep!(builder, param, 0)
                 push!(wrapper_args, ptr)
             else


### PR DESCRIPTION
Not doing so ~~can~~ does make LLVM hang during optimization.