### PR TITLE
Allow callable structs in FSpec

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -53,7 +53,7 @@ export FunctionSpec
 # what we'll be compiling
 
 struct FunctionSpec{F,TT}
-    f::Base.Callable
+    f::F
     tt::DataType
     kernel::Bool
     name::Union{Nothing,String}

--- a/test/native.jl
+++ b/test/native.jl
@@ -58,6 +58,14 @@ include("definitions/native.jl")
         @test eltype(output[4][2].type) isa LLVM.LLVMFloat
         @test !output[4][2].external
     end
+
+    @testset "Callable structs" begin
+        struct MyCallable end
+        (::MyCallable)(a, b) = a+b
+
+        (CI, rt) = native_code_typed(MyCallable(), (Int, Int), kernel=false)[1]
+        @test CI.slottypes[1] == Core.Compiler.Const(MyCallable())
+    end
 end
 
 ############################################################################################


### PR DESCRIPTION
Will add a test before merging. Motivation is to allow

```
struct MyCallable end

(::MyCallable)(a, b) = a+b
const mycallable = MyCallable()

FunctionSpec(mycallable, Tuple{Int, Int}, false, nothing)
```