### PR TITLE
Method overrides using a method overlay table.

### DIFF
--- a/wip.jl
+++ b/wip.jl
@@ -1,0 +1,19 @@
+using GPUCompiler
+
+include("test/definitions/native.jl")
+
+original() = :original_value
+
+kernel() = original()
+
+replaced() = :replaced_value
+GPUCompiler.CI_CACHE.overrides[typeof(original)] = [typeof(replaced)]
+
+function main()
+    @show kernel()
+
+    empty!(GPUCompiler.CI_CACHE.dict)
+    native_code_llvm(kernel, Tuple{}; debuginfo=:none)
+end
+
+isinteractive() || main()

--- a/wip.jl
+++ b/wip.jl
@@ -2,12 +2,16 @@ using GPUCompiler
 
 include("test/definitions/native.jl")
 
-original() = :original_value
+original() = 1
+
+using Base.Experimental: @overlay
+
+# TODO: short function def
+@overlay GPUCompiler.mt function original()
+    2
+end
 
 kernel() = original()
-
-replaced() = :replaced_value
-GPUCompiler.CI_CACHE.overrides[typeof(original)] = [typeof(replaced)]
 
 function main()
     @show kernel()


### PR DESCRIPTION
Just prototyping. This overrides MethodInstance->CodeInstance lookups by hacking the cache lookup:
```
julia> foo() = 0
julia> kernel() = foo()
julia> @show kernel()
kernel() = 0

julia> bar() = 42
julia> GPUCompiler.CI_CACHE.overrides[foo] = [bar]
julia> native_code_llvm(kernel, Tuple{}; debuginfo=:none)
define dso_local i64 @julia_kernel_3647() local_unnamed_addr {
top:
  ret i64 42
}
```

Not ideal because the cache isn't really meant for this, I think. But it works. I'd rather specialize some functionality from abstract interpretation, but that doesn't seem to work with the IR we emit:

```julia
function Core.Compiler.abstract_call_gf_by_type(interp::GPUInterpreter,
                                                @nospecialize(f),
                                                argtypes::Vector{Any},
                                                @nospecialize(atype),
                                                sv::InferenceState,
                                                max_methods::Int = InferenceParams(interp).MAX_METHODS)
    tt = argtypes[2:end]
    if haskey(CI_CACHE.overrides, f)
        for new_f in CI_CACHE.overrides[f]
            hasmethod(new_f, tt) || continue
            @safe_info "Override call to $f with $new_f"
            f = new_f
            argtypes[1] = Core.Compiler.Const(f)
            atype = Tuple{typeof(f), tt...}
        end
    end
    return invoke(Core.Compiler.abstract_call_gf_by_type,
                    Tuple{AbstractInterpreter, typeof(f), typeof(argtypes),
                          typeof(atype), typeof(sv), typeof(max_methods)},
                    interp, f, argtypes, atype, sv, max_methods)
end

function Core.Compiler.transform_result_for_cache(interp::GPUInterpreter, linfo::MethodInstance,
                                    @nospecialize(inferred_result))
    @safe_info "prepare for cache" linfo inferred_result
    invoke(Core.Compiler.transform_result_for_cache, Tuple{AbstractInterpreter, typeof(linfo), typeof(inferred_result)}, interp, linfo, inferred_result)
end
```

We successfully convince inference to use `bar`, but the IR still contains references to `foo`, resulting in bad code:
```
[ Info: Override call to foo with bar
┌ Info: prepare for cache
│   linfo = MethodInstance for bar()
└   inferred_result = Core.Const(42)
┌ Info: prepare for cache
│   linfo = MethodInstance for kernel()
│   inferred_result =
│    CodeInfo(
│        @ /home/tim/Julia/pkg/GPUCompiler/wip.jl:7 within `kernel'
│    1 ─ %1 = Main.foo::typeof(foo)
│    │   %2 = (isa)(%1, typeof(bar))::Bool
│    └──      goto #3 if not %2
│    2 ─      goto #4
│    3 ─ %5 = Main.foo()::Int64
│    └──      goto #4
│    4 ┄ %7 = φ (#2 => 42, #3 => %5)::Int64
│    └──      return %7
└    )

define dso_local i64 @julia_kernel_2753() local_unnamed_addr {
top:
  %0 = call nonnull {}* @jl_apply_generic({}* inttoptr (i64 140004316834848 to {}*), {}** null, i32 0)
  %1 = bitcast {}* %0 to i64*
  %2 = load i64, i64* %1, align 8
  ret i64 %2
}
```

I had hoped that we would not need to rewrite the code when using the interpreter.