### PR TITLE
Add imaging_mode support (static compilation)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,9 +21,10 @@ TimerOutputs = "0.5"
 julia = "1.6"
 
 [extras]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 SPIRV_LLVM_Translator_jll = "4a5d46fc-d8cf-5151-a261-86b458210efb"
 SPIRV_Tools_jll = "6ac6d60f-d740-5983-97d7-a4482c0689f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SPIRV_LLVM_Translator_jll", "SPIRV_Tools_jll"]
+test = ["Test", "SPIRV_LLVM_Translator_jll", "SPIRV_Tools_jll", "Distributed"]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -197,3 +197,6 @@ function llvm_debug_info(@nospecialize(job::CompilerJob))
         LLVM.API.LLVMDebugEmissionKindFullDebug
     end
 end
+
+# whether we should compile in imaging mode
+extern_policy(::CompilerJob) = false

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -7,11 +7,15 @@ function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
         global current_job
         current_job = job
 
+        add!(pm, ModulePass("ExternalizeJuliaGlobals",
+                            externalize_julia_globals!))
         global_optimizer!(pm)
 
         add!(pm, ModulePass("ResolveCPUReferences", resolve_cpu_references!))
 
         global_dce!(pm)
+        add!(pm, ModulePass("InternalizeJuliaGlobals",
+                            internalize_julia_globals!))
         strip_dead_prototypes!(pm)
 
         run!(pm, mod)

--- a/src/native.jl
+++ b/src/native.jl
@@ -9,7 +9,7 @@ Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
     features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
     always_inline::Bool=false # will mark the job function as always inline
     reloc::LLVM.API.LLVMRelocMode=LLVM.API.LLVMRelocDefault
-    extern::Bool
+    extern::Bool=false
 end
 
 llvm_triple(::NativeCompilerTarget) = Sys.MACHINE

--- a/src/native.jl
+++ b/src/native.jl
@@ -7,7 +7,9 @@ export NativeCompilerTarget
 Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
     cpu::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
     features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
-    always_inline::Bool=false # will mark the job function as always inline 
+    always_inline::Bool=false # will mark the job function as always inline
+    reloc::LLVM.API.LLVMRelocMode=LLVM.API.LLVMRelocDefault
+    extern::Bool
 end
 
 llvm_triple(::NativeCompilerTarget) = Sys.MACHINE
@@ -17,7 +19,9 @@ function llvm_machine(target::NativeCompilerTarget)
 
     t = Target(triple=triple)
 
-    tm = TargetMachine(t, triple, target.cpu, target.features)
+    optlevel = LLVM.API.LLVMCodeGenLevelDefault
+    reloc = target.reloc
+    tm = TargetMachine(t, triple, target.cpu, target.features, optlevel, reloc)
     asm_verbosity!(tm, true)
 
     return tm
@@ -29,6 +33,9 @@ function process_entry!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module
     end
     invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 end
+
+GPUCompiler.extern_policy(job::CompilerJob{NativeCompilerTarget,P} where P) =
+    job.target.extern
 
 ## job
 

--- a/test/native.jl
+++ b/test/native.jl
@@ -332,7 +332,7 @@ function generate_shlib_fptr(f, tt, name=GPUCompiler.safe_name(repr(f)))
     end
 end
 
-@static if VERSION >= v"1.7.0-DEV.600"
+@static if VERSION >= v"1.7.0-DEV.600" && Sys.isunix()
 @testset "shared library emission" begin
     f1(x) = x+1
     @test ccall(generate_shlib_fptr(f1, (Int,)), Int, (Int,), 1) == 2


### PR DESCRIPTION
Requires https://github.com/JuliaLang/julia/pull/38642

We can tell Julia that we want it to emit symbols instead of session-specific pointers, making our code (potentially) relocatable. I'm not locked in on this API, but it was pretty easy to implement. Known issues include `Symbol`s embedded in the IR; they show up as `{}* null` in the LLVM IR for some reason. I've tested that I can roundtrip very simple functions (including closures) through `codegen(:obj, ...)`+`dlopen/dlsym`.