### PR TITLE
Clean-up identical constants.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -160,6 +160,9 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                 global_dce!(pm)
                 strip_dead_prototypes!(pm)
 
+                # merge constants (such as exception messages) from the runtime
+                constant_merge!(pm)
+
                 run!(pm, ir)
             end
         end
@@ -216,6 +219,13 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                     unsafe_delete!(LLVM.parent(call), call)
                 end
             end
+        end
+
+        # merge constants (such as exception messages) from each kernel
+        ModulePassManager() do pm
+            constant_merge!(pm)
+
+            run!(pm, ir)
         end
 
         # all deferred compilations should have been resolved

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -56,6 +56,8 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     #
     # these might not always be safe, as Julia's IR metadata isn't designed for IPO.
     ModulePassManager() do pm
+        initialize!(pm)
+
         dead_arg_elimination!(pm)   # parent doesn't use return value --> ret void
 
         run!(pm, mod)

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -147,8 +147,6 @@ function optimize_module!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module)
         early_csemem_ssa!(pm) # TODO: gvn instead? see NVPTXTargetMachine.cpp::addEarlyCSEOrGVNPass
         dead_store_elimination!(pm)
 
-        constant_merge!(pm)
-
         cfgsimplification!(pm)
 
         # get rid of the internalized functions; now possible unused


### PR DESCRIPTION
These frequently occur from exception messages. Merge them after linking the runtime, and when doing deferred codegen.

e.g. before

```llvm
@0 = internal unnamed_addr constant [75 x i8] c"ERROR: a CUDA error was thrown during kernel execution: %s (code %ld, %s)\0A\00", align 1
@__dynamic_shmem_617 = external addrspace(3) global [0 x i64], align 32
@__dynamic_shmem_618 = external addrspace(3) global [0 x float], align 32
@exception17 = private unnamed_addr constant [10 x i8] c"exception\00", align 1
@exception42 = private unnamed_addr constant [13 x i8] c"InexactError\00", align 1
@1 = internal unnamed_addr constant [108 x i8] c"ERROR: a %s was thrown during kernel execution.\0A       Run Julia on debug level 2 for device stack traces.\0A\00", align 1
@2 = internal unnamed_addr constant [110 x i8] c"WARNING: could not signal exception status to the host, execution will continue.\0A         Please file a bug.\0A\00", align 1
@__dynamic_shmem_673 = external addrspace(3) global [0 x i64], align 32
@__dynamic_shmem_674 = external addrspace(3) global [0 x float], align 32
@exception9 = private unnamed_addr constant [10 x i8] c"exception\00", align 1
@3 = internal unnamed_addr constant [110 x i8] c"WARNING: could not signal exception status to the host, execution will continue.\0A         Please file a bug.\0A\00", align 1
@4 = internal unnamed_addr constant [108 x i8] c"ERROR: a %s was thrown during kernel execution.\0A       Run Julia on debug level 2 for device stack traces.\0A\00", align 1
@exception20 = private unnamed_addr constant [10 x i8] c"exception\00", align 1
@exception45 = private unnamed_addr constant [13 x i8] c"InexactError\00", align 1
@5 = internal unnamed_addr constant [75 x i8] c"ERROR: a CUDA error was thrown during kernel execution: %s (code %ld, %s)\0A\00", align 1
@6 = internal unnamed_addr constant [110 x i8] c"WARNING: could not signal exception status to the host, execution will continue.\0A         Please file a bug.\0A\00", align 1
@7 = internal unnamed_addr constant [108 x i8] c"ERROR: a %s was thrown during kernel execution.\0A       Run Julia on debug level 2 for device stack traces.\0A\00", align 1
@exception26 = private unnamed_addr constant [10 x i8] c"exception\00", align 1
@exception61 = private unnamed_addr constant [13 x i8] c"InexactError\00", align 1
@8 = internal unnamed_addr constant [75 x i8] c"ERROR: a CUDA error was thrown during kernel execution: %s (code %ld, %s)\0A\00", align 1
@9 = internal unnamed_addr constant [110 x i8] c"WARNING: could not signal exception status to the host, execution will continue.\0A         Please file a bug.\0A\00", align 1
@10 = internal unnamed_addr constant [108 x i8] c"ERROR: a %s was thrown during kernel execution.\0A       Run Julia on debug level 2 for device stack traces.\0A\00", align 1
```

after

```llvm
@__dynamic_shmem_617 = external addrspace(3) global [0 x i64], align 32
@__dynamic_shmem_618 = external addrspace(3) global [0 x float], align 32
@__dynamic_shmem_673 = external addrspace(3) global [0 x i64], align 32
@__dynamic_shmem_674 = external addrspace(3) global [0 x float], align 32
@exception26 = private unnamed_addr constant [10 x i8] c"exception\00", align 1
@exception61 = private unnamed_addr constant [13 x i8] c"InexactError\00", align 1
@0 = internal unnamed_addr constant [75 x i8] c"ERROR: a CUDA error was thrown during kernel execution: %s (code %ld, %s)\0A\00", align 1
@1 = internal unnamed_addr constant [110 x i8] c"WARNING: could not signal exception status to the host, execution will continue.\0A         Please file a bug.\0A\00", align 1
@2 = internal unnamed_addr constant [108 x i8] c"ERROR: a %s was thrown during kernel execution.\0A       Run Julia on debug level 2 for device stack traces.\0A\00", align 1
```