### PR TITLE
Don't internalize global variables.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -148,11 +148,14 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
             end
         end
 
-        # remove everything except for the kernel
+        # remove everything except for the kernel and any exported global variables
         @timeit_debug to "clean-up" begin
             exports = String[kernel_fn]
+            for gvar in globals(ir)
+                push!(exports, LLVM.name(gvar))
+            end
+
             ModulePassManager() do pm
-                # internalize all functions that aren't exports
                 internalize!(pm, exports)
 
                 # eliminate all unused internal functions

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -67,7 +67,13 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
         current_job = job
 
         linkage!(entry, LLVM.API.LLVMExternalLinkage)
-        internalize!(pm, [LLVM.name(entry)])
+
+        # internalize all functions, but keep exported global variables
+        exports = String[LLVM.name(entry)]
+        for gvar in globals(mod)
+            push!(exports, LLVM.name(gvar))
+        end
+        internalize!(pm, exports)
 
         can_throw(job) || add!(pm, ModulePass("LowerThrow", lower_throw!))
 


### PR DESCRIPTION
In https://github.com/JuliaGPU/CUDA.jl/pull/552 I noticed that the purposefully-exported constant memory symbol was getting internalized, in part because of GPUCompiler (and in part because of Julia itself). This is one part of the fix to that.