### PR TITLE
Lock codegen for multithreaded compilation.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -42,6 +42,11 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
+[[ExprTools]]
+git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.3"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.9.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -7,6 +7,8 @@ using DataStructures
 
 using TimerOutputs
 
+using ExprTools
+
 using Libdl
 
 const to = TimerOutput()

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -84,20 +84,6 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     error("Unknown compilation output $output")
 end
 
-# Lock codegen to prevent races on the LLVM context
-macro locked(ex)
-    def = splitdef(ex)
-    def[:body] = quote
-        ccall(:jl_typeinf_begin, Cvoid, ())
-        try
-            $(def[:body])
-        finally
-            ccall(:jl_typeinf_end, Cvoid, ())
-        end
-    end
-    esc(combinedef(def))
-end
-
 function emit_julia(@nospecialize(job::CompilerJob))
     @timeit_debug to "validation" check_method(job)
 

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -61,8 +61,8 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module)
     end
 end
 
-function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module, f::LLVM.Function,
-               format=LLVM.API.LLVMAssemblyFile)
+@unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module, f::LLVM.Function,
+                         format=LLVM.API.LLVMAssemblyFile)
     # write the bitcode to a temporary file (the SPIRV Translator library doesn't have a C API)
     mktemp() do input, input_io
         write(input_io, mod)


### PR DESCRIPTION
Rebase of https://github.com/JuliaGPU/GPUCompiler.jl/pull/120. Didn't like the whitespace change so made it a macro.
Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/21.