### PR TITLE
Take compiler lock during inference.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -84,7 +84,7 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     error("Unknown compilation output $output")
 end
 
-function emit_julia(@nospecialize(job::CompilerJob))
+@locked function emit_julia(@nospecialize(job::CompilerJob))
     @timeit_debug to "validation" check_method(job)
 
     @timeit_debug to "Julia front-end" begin


### PR DESCRIPTION
I've been triggering https://github.com/JuliaLang/julia/blob/a7848a28e5d450dcc48ef99320d3220618dba501/src/aotcompile.cpp#L264-L266, `Refusing to automatically run type inference with custom cache lookup.`, which looks like a race on the CI cache.