### PR TITLE
Make sure the runtime is generated only on one task.

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -5,8 +5,6 @@ using Base: _methods_by_ftype
 
 using Serialization, Scratch
 
-const compilelock = ReentrantLock()
-
 # whether to cache compiled kernels on disk or not
 const disk_cache = Ref(false)
 
@@ -16,7 +14,7 @@ const disk_cache = Ref(false)
     force_compilation = compile_hook[] !== nothing
 
     # NOTE: no use of lock(::Function)/@lock/get! to keep stack traces clean
-    lock(compilelock)
+    ccall(:jl_typeinf_begin, Cvoid, ())
     try
         obj = get(cache, key, nothing)
         if obj === nothing || force_compilation
@@ -56,7 +54,7 @@ const disk_cache = Ref(false)
         end
         obj
     finally
-        unlock(compilelock)
+        ccall(:jl_typeinf_end, Cvoid, ())
     end
 end
 

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -131,7 +131,7 @@ function build_runtime(@nospecialize(job::CompilerJob), ctx)
     mod
 end
 
-function load_runtime(@nospecialize(job::CompilerJob), ctx)
+@locked function load_runtime(@nospecialize(job::CompilerJob), ctx)
     # find the first existing cache directory (for when dealing with layered depots)
     cachedirs = [cachedir(depot) for depot in DEPOT_PATH]
     filter!(isdir, cachedirs)


### PR DESCRIPTION
Otherwise each task started doing tens of compilation jobs that all trampled over one another, ballooning the time to compile by a factor of `nthreads`.