### PR TITLE
Method overrides for Julia 1.6 and 1.7.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -158,3 +158,6 @@ link_libraries!(::CompilerJob, mod::LLVM.Module, undefined_fns::Vector{String}) 
 
 # whether pointer is a valid call target
 valid_function_pointer(::CompilerJob, ptr::Ptr{Cvoid}) = false
+
+# the codeinfo cache to use
+ci_cache(::CompilerJob) = GLOBAL_CI_CACHE

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -161,3 +161,6 @@ valid_function_pointer(::CompilerJob, ptr::Ptr{Cvoid}) = false
 
 # the codeinfo cache to use
 ci_cache(::CompilerJob) = GLOBAL_CI_CACHE
+
+# the method table to use
+method_table(::CompilerJob) = GLOBAL_METHOD_TABLE

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -41,6 +41,8 @@ end
 
 Base.empty!(cc::CodeCache) = empty!(cc.dict)
 
+const GLOBAL_CI_CACHE = CodeCache()
+
 
 ## method invalidations
 
@@ -316,8 +318,6 @@ end
 
 ## codegen/inference integration
 
-const CI_CACHE = CodeCache()
-
 # No need to do any locking since we're not putting our results into the runtime cache
 Core.Compiler.lock_mi_inference(ni::GPUInterpreter, mi::MethodInstance) = nothing
 Core.Compiler.unlock_mi_inference(ni::GPUInterpreter, mi::MethodInstance) = nothing
@@ -352,7 +352,7 @@ end
 function compile_method_instance(@nospecialize(job::CompilerJob),
                                  method_instance::MethodInstance, world)
     # populate the cache
-    cache = CI_CACHE
+    cache = ci_cache(job)
     if ci_cache_lookup(cache, method_instance, world, world) === nothing
         ci_cache_populate(cache, method_instance, world, world)
     end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -4,12 +4,26 @@
 
 using Core.Compiler: CodeInstance, MethodInstance
 
+if VERSION >= v"1.7-"
+
 struct CodeCache
     dict::Dict{MethodInstance,Vector{CodeInstance}}
+
+    CodeCache() = new(Dict{MethodInstance,Vector{CodeInstance}}())
+end
+
+else
+
+struct CodeCache
+    dict::Dict{MethodInstance,Vector{CodeInstance}}
+
     override_table::Dict{Type,Function}
     override_aliases::Dict{Method,Type}
+
     CodeCache() = new(Dict{MethodInstance,Vector{CodeInstance}}(),
                       Dict{Type,Function}(), Dict{Method,Type}())
+end
+
 end
 
 function Base.show(io::IO, ::MIME"text/plain", cc::CodeCache)
@@ -90,6 +104,18 @@ end
 
 ## method overrides
 
+@static if VERSION >= v"1.7-"
+
+# use an overlay method table
+
+Base.Experimental.@MethodTable(GLOBAL_METHOD_TABLE)
+
+else
+
+# spoof the codeinstance cache
+
+const GLOBAL_METHOD_TABLE = nothing
+
 # conceptually, for each overridden function `f` the cache has a method table used to find
 # the replacement method using familiar dispatch semantics.
 #
@@ -131,7 +157,6 @@ function add_override!(cache::CodeCache,
     jl_method_def(argdata(sig, source), ci, getmodule(mt))
     # NOTE: we use jl_method_def instead of Expr(:method) as we have the signature already
 
-    # FIXME: on 1.7, jl_method_def returns the actual method
     meth = which(mt, tt)
     @assert meth.sig === sig
     cache.override_aliases[meth] = typeof(f′)
@@ -142,57 +167,8 @@ function add_override!(cache::CodeCache,
     return
 end
 
-# parse a call expression used to point to a method instance into a function and tuple type
-# (e.g., `foo(::Int, ::T...) where T` -> `foo` and `Tuple{Int, Vararg{T}) where T`)
-function parse_override_source(ex)
-    # split the source function expression into the function, list of types, and typevars
-    if Meta.isexpr(ex, :call)
-        f, types... = ex.args
-        tvs = []
-    elseif Meta.isexpr(old, :where)
-        call, tvs... = ex.args
-        f, types... = call.args
-    else
-        error("Unsupported call expression $ex")
-    end
-
-    # convert list of typed arguments (e.g. `(::Float64, ::Int...)` into tuple type components
-    argtypes = []
-    for typ in types
-        if Meta.isexpr(typ, :(::))
-            typex = typ.args[1]
-        elseif Meta.isexpr(typ, :(...)) && Meta.isexpr(typ.args[1], :(::))
-            typex = :(Vararg{$(typ.args[1].args[1])})
-        else
-            error("Unsupported call expression $ex, containing invalid type assertion $typ")
-        end
-        push!(argtypes, typex)
-    end
-
-    # create the tuple type expression
-    tt = if isempty(tvs)
-        :(Tuple{$(argtypes...)})
-    else
-        :(Tuple{$(argtypes...)} where {$(tvs...)})
-    end
-
-    return f, tt
-end
-
-"""
-    @override cache source_function(::ArgTyp...) replacement_function
-"""
-macro override(cache, old, new_f)
-    old_f, tt = parse_override_source(old)
-
-    quote
-        GPUCompiler.add_override!($(esc(cache)), $(esc(old_f)), $(esc(new_f)), $(esc(tt)),
-                                  LineNumberNode($(__source__.line), $(QuoteNode(__source__.file))))
-    end
-end
-
 # get the replacement function type for a signature, or nothing
-function get_override(cache, @nospecialize(sig); world=typemax(UInt))
+function get_override(cache::CodeCache, @nospecialize(sig); world=typemax(UInt))
     ft, t... = [sig.parameters...]
 
     # do we have overrides for this function?
@@ -206,6 +182,39 @@ function get_override(cache, @nospecialize(sig); world=typemax(UInt))
     return cache.override_aliases[match]
 end
 
+end
+
+"""
+    @override cache mt source_function(::ArgTyp...) replacement_function
+"""
+macro override(cache, mt, ex)
+    if VERSION >= v"1.7-"
+        esc(quote
+            Base.Experimental.@overlay $mt $ex
+        end)
+    else
+        def = splitdef(ex)
+        f = def[:name]
+
+        # recombine into a replacement function
+        new_f = gensym()
+        def[:name] = new_f
+        new_ex = combinedef(def)
+
+        quote
+            $(esc(new_ex))
+
+            # use the newly-defined method to find the tuple type (without parsing `ex`)
+            new_method = first(methods($(esc(new_f))))
+            tt = Tuple{new_method.sig.parameters[2:end]...}
+
+            GPUCompiler.add_override!($(esc(cache)), $(esc(f)), $(esc(new_f)), tt,
+                                      LineNumberNode($(__source__.line),
+                                      $(QuoteNode(__source__.file))))
+        end
+    end
+end
+
 
 ## interpreter
 
@@ -213,6 +222,7 @@ using Core.Compiler: AbstractInterpreter, InferenceResult, InferenceParams, Infe
 
 struct GPUInterpreter <: AbstractInterpreter
     global_cache::CodeCache
+    method_table::Union{Nothing,Core.MethodTable}
 
     # Cache of inference results for this particular interpreter
     local_cache::Vector{InferenceResult}
@@ -223,11 +233,12 @@ struct GPUInterpreter <: AbstractInterpreter
     inf_params::InferenceParams
     opt_params::OptimizationParams
 
-    function GPUInterpreter(cache::CodeCache, world::UInt)
+    function GPUInterpreter(cache::CodeCache, mt::Union{Nothing,Core.MethodTable}, world::UInt)
         @assert world <= Base.get_world_counter()
 
         return new(
             cache,
+            mt,
 
             # Initially empty cache
             Vector{InferenceResult}(),
@@ -253,6 +264,11 @@ Core.Compiler.may_discard_trees(ni::GPUInterpreter) = true
 Core.Compiler.add_remark!(ni::GPUInterpreter, sv::InferenceState, msg) = nothing # TODO
 Core.Compiler.code_cache(ni::GPUInterpreter) = WorldView(ni.global_cache, ni.world)
 
+if VERSION >= v"1.7-"
+Core.Compiler.method_table(ni::GPUInterpreter, sv::InferenceState) =
+    Core.Compiler.OverlayMethodTable(ni.world, ni.method_table)
+end
+
 
 ## world view of the cache
 
@@ -271,58 +287,60 @@ function Core.Compiler.get(wvc::WorldView{CodeCache}, mi::MethodInstance, defaul
         end
     end
 
-    sig = Base.unwrap_unionall(mi.specTypes)
+    if VERSION < v"1.7-"
+        sig = Base.unwrap_unionall(mi.specTypes)
 
-    # check if we have any overrides for this method instance's function type
-    actual_mi = mi
-    ft′ = get_override(wvc.cache, sig; world=wvc.worlds.min_world)
-    if ft′ !== nothing
-        sig′ = Tuple{ft′, sig.parameters[2:end]...}
-        meth = which(sig′)
+        # check if we have any overrides for this method instance's function type
+        actual_mi = mi
+        ft′ = get_override(wvc.cache, sig; world=wvc.worlds.min_world)
+        if ft′ !== nothing
+            sig′ = Tuple{ft′, sig.parameters[2:end]...}
+            meth = which(sig′)
 
-        (ti, env) = ccall(:jl_type_intersection_with_env, Any,
-                            (Any, Any), sig′, meth.sig)::Core.SimpleVector
-        meth = Base.func_for_method_checked(meth, ti, env)
-        actual_mi = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance},
-            (Any, Any, Any, UInt), meth, ti, env, wvc.worlds.min_world)
-    end
-
-    # if we want to override a method instance, eagerly put its replacement in the cache.
-    # this is necessary, because we generally don't populate the cache, inference does,
-    # and it won't put the replacement method instance in the cache by itself.
-    if mi !== actual_mi
-        # XXX: is this OK to do? shouldn't we _inform_ the compiler about the replacement
-        # method instead of just spoofing the code instance? I tried to do so using a
-        # MethodTableView, but the fact that the resulting MethodMatch referred the
-        # replacement function, while there was still a GlobalRef in the IR pointing to
-        # the original function, resulted in optimizer confusion.
-        ci = ci_cache_populate(wvc.cache, actual_mi, wvc.worlds.min_world, wvc.worlds.max_world)
-
-        # make sure to recompress any IR in the CodeInstance we'll be spoofing,
-        # as the process uses both the CodeInstance and its parent Method
-        # (values are encoded as indices into the method->roots array).
-        src = if ci.inferred isa Vector{UInt8}
-            temp = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any),
-                         actual_mi.def, C_NULL, ci.inferred)
-            ccall(:jl_compress_ir, Any, (Any, Any), mi.def, temp)
-        else
-            copy(ci.inferred)
+            (ti, env) = ccall(:jl_type_intersection_with_env, Any,
+                                (Any, Any), sig′, meth.sig)::Core.SimpleVector
+            meth = Base.func_for_method_checked(meth, ti, env)
+            actual_mi = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance},
+                (Any, Any, Any, UInt), meth, ti, env, wvc.worlds.min_world)
         end
 
-        # copy the CodeInstance we'll be spoofing to ensure no cross-method effects
-        # (such as IR compression) end up in the cache of the original method.
-        if isdefined(ci, :rettype_const)
-            const_flags = 0x2
-            inferred_const = ci.rettype_const
-        else
-            const_flags = 0x0
-            inferred_const = nothing
-        end
-        ci′ = Core.CodeInstance(mi, ci.rettype, inferred_const, src,
-                               Int32(const_flags), ci.min_world, ci.max_world)
+        # if we want to override a method instance, eagerly put its replacement in the cache.
+        # this is necessary, because we generally don't populate the cache, inference does,
+        # and it won't put the replacement method instance in the cache by itself.
+        if mi !== actual_mi
+            # XXX: is this OK to do? shouldn't we _inform_ the compiler about the replacement
+            # method instead of just spoofing the code instance? I tried to do so using a
+            # MethodTableView, but the fact that the resulting MethodMatch referred the
+            # replacement function, while there was still a GlobalRef in the IR pointing to
+            # the original function, resulted in optimizer confusion.
+            ci = ci_cache_populate(wvc.cache, nothing, actual_mi, wvc.worlds.min_world, wvc.worlds.max_world)
 
-        Core.Compiler.setindex!(wvc.cache, ci′, mi)
-        return ci′
+            # make sure to recompress any IR in the CodeInstance we'll be spoofing,
+            # as the process uses both the CodeInstance and its parent Method
+            # (values are encoded as indices into the method->roots array).
+            src = if ci.inferred isa Vector{UInt8}
+                temp = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any),
+                            actual_mi.def, C_NULL, ci.inferred)
+                ccall(:jl_compress_ir, Any, (Any, Any), mi.def, temp)
+            else
+                copy(ci.inferred)
+            end
+
+            # copy the CodeInstance we'll be spoofing to ensure no cross-method effects
+            # (such as IR compression) end up in the cache of the original method.
+            if isdefined(ci, :rettype_const)
+                const_flags = 0x2
+                inferred_const = ci.rettype_const
+            else
+                const_flags = 0x0
+                inferred_const = nothing
+            end
+            ci′ = Core.CodeInstance(mi, ci.rettype, inferred_const, src,
+                                Int32(const_flags), ci.min_world, ci.max_world)
+
+            Core.Compiler.setindex!(wvc.cache, ci′, mi)
+            return ci′
+        end
     end
 
     return default
@@ -345,8 +363,8 @@ end
 Core.Compiler.lock_mi_inference(ni::GPUInterpreter, mi::MethodInstance) = nothing
 Core.Compiler.unlock_mi_inference(ni::GPUInterpreter, mi::MethodInstance) = nothing
 
-function ci_cache_populate(cache, mi, min_world, max_world)
-    interp = GPUInterpreter(cache, min_world)
+function ci_cache_populate(cache, mt, mi, min_world, max_world)
+    interp = GPUInterpreter(cache, mt, min_world)
     src = Core.Compiler.typeinf_ext_toplevel(interp, mi)
 
     # inference populates the cache, so we don't need to jl_get_method_inferred
@@ -376,8 +394,9 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
                                  method_instance::MethodInstance, world)
     # populate the cache
     cache = ci_cache(job)
+    mt = method_table(job)
     if ci_cache_lookup(cache, method_instance, world, world) === nothing
-        ci_cache_populate(cache, method_instance, world, world)
+        ci_cache_populate(cache, mt, method_instance, world, world)
     end
 
     # set-up the compiler interface

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -88,7 +88,7 @@ end
 
 ## method overrides
 
-@static if VERSION >= v"1.7-"
+@static if isdefined(Base.Experimental, Symbol("@overlay"))
 
 # use an overlay method table
 
@@ -141,7 +141,7 @@ end
     by a check to `ccall(:jl_generating_output, Cint, ()) != 0`).
 """
 macro override(mt, ex)
-    if VERSION >= v"1.7-"
+    if isdefined(Base.Experimental, Symbol("@overlay"))
         esc(quote
             Base.Experimental.@overlay $mt $ex
         end)
@@ -222,7 +222,7 @@ if VERSION >= v"1.7.0-DEV.577"
 Core.Compiler.verbose_stmt_info(interp::GPUInterpreter) = false
 end
 
-if VERSION >= v"1.7-"
+if isdefined(Base.Experimental, Symbol("@overlay"))
 Core.Compiler.method_table(interp::GPUInterpreter, sv::InferenceState) =
     Core.Compiler.OverlayMethodTable(interp.world, interp.method_table)
 else

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -261,11 +261,7 @@ macro device_code(ex...)
         end
 
         open(joinpath(dir, "$fn.typed.jl"), "w") do io
-            if VERSION >= v"1.1.0"
-                code = only(code_typed(job; debuginfo=:source))
-            else
-                code = only(code_typed(job))
-            end
+            code = only(code_typed(job; debuginfo=:source))
             println(io, code)
         end
 

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -86,7 +86,7 @@ function compile(def, return_type, types, llvm_return_type=nothing, llvm_types=n
     if def isa Symbol
         args = [gensym() for typ in types]
         @eval @inline $def($(args...)) =
-            ccall($"extern $llvm_name", llvmcall, $return_type, ($(types...),), $(args...))
+            ccall($("extern $llvm_name"), llvmcall, $return_type, ($(types...),), $(args...))
     end
 
     return
@@ -112,28 +112,8 @@ compile(:report_exception_name, Nothing, (Ptr{Cchar},))
 
 ## GC
 
-if VERSION < v"1.4"
-
-@enum AddressSpace begin
-    Generic         = 1
-    Tracked         = 10
-    Derived         = 11
-    CalleeRooted    = 12
-    Loaded          = 13
-end
-
-# LLVM type of a tracked pointer
-function T_prjlvalue(ctx)
-    T_pjlvalue = convert(LLVMType, Any, ctx; allow_boxed=true)
-    LLVM.PointerType(eltype(T_pjlvalue), Tracked)
-end
-
-else
-
-# FIXME: once we only support 1.4, get rid of this and allow boxed types
+# FIXME: get rid of this and allow boxed types
 T_prjlvalue(ctx) = convert(LLVMType, Any, ctx; allow_boxed=true)
-
-end
 
 function gc_pool_alloc(sz::Csize_t)
     ptr = malloc(sz)

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -194,11 +194,7 @@ end
     asm = sprint(io->gcn_code_native(io, ref_kernel, Tuple{Ptr{Int64}, Int}))
 
 
-    if VERSION < v"1.2.0-DEV.375"
-        @test_broken !occursin("gpu_gc_pool_alloc", asm)
-    else
-        @test !occursin("gpu_gc_pool_alloc", asm)
-    end
+    @test !occursin("gpu_gc_pool_alloc", asm)
 end
 =#
 

--- a/test/native.jl
+++ b/test/native.jl
@@ -124,7 +124,6 @@ end
     native_code_llvm(devnull, kernel, Tuple{Vector{Int}}; kernel=true)
 end
 
-if VERSION >= v"1.0.2"
 @testset "CUDAnative.jl#278" begin
     # codegen idempotency
     # NOTE: this isn't fixed, but surfaces here due to bad inference of checked_sub
@@ -136,7 +135,6 @@ if VERSION >= v"1.0.2"
     # breaking recursion in print_to_string makes it possible to compile
     # even in the presence of the above bug
     native_code_llvm(devnull, Base.print_to_string, Tuple{Int,Int}; optimize=false)
-end
 end
 
 @testset "LLVM D32593" begin

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -25,11 +25,7 @@ end
     end
 
     ir = sprint(io->ptx_code_llvm(io, kernel, Tuple{Aggregate}))
-    if VERSION < v"1.5.0-DEV.802"
-        @test occursin(r"@.*julia_kernel.+\(({ i64 }|\[1 x i64\]) addrspace\(\d+\)?\*", ir)
-    else
-        @test occursin(r"@.*julia_kernel.+\(({ i64 }|\[1 x i64\])\*", ir)
-    end
+    @test occursin(r"@.*julia_kernel.+\(({ i64 }|\[1 x i64\])\*", ir)
 
     ir = sprint(io->ptx_code_llvm(io, kernel, Tuple{Aggregate}; kernel=true))
     @test occursin(r"@.*julia_kernel.+\(({ i64 }|\[1 x i64\])", ir)
@@ -247,11 +243,7 @@ end
     asm = sprint(io->ptx_code_native(io, ref_kernel, Tuple{Ptr{Int64}, Int}))
 
 
-    if VERSION < v"1.2.0-DEV.375"
-        @test_broken !occursin("gpu_gc_pool_alloc", asm)
-    else
-        @test !occursin("gpu_gc_pool_alloc", asm)
-    end
+    @test !occursin("gpu_gc_pool_alloc", asm)
 end
 
 @testset "float boxes" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/112.

Experimentation here and in #122 has shown that an overlay table is the way to go, as spoofing the codeinstance cache is unreliable (https://github.com/JuliaGPU/GPUCompiler.jl/pull/151#issuecomment-791313921). At the same time, we can't be returning a different function when replacing method lookup in the table, doing so thoroughly confuses the compiler (https://github.com/JuliaGPU/GPUCompiler.jl/pull/122#issue-529571645). So we need to keep the function type the same, but somehow convince Julia to select a different method. On 1.7, we can use a different method table for that, and use a method table view during inference that first consults the external table before querying the internal one. On 1.6, we don't have that mechanism, and we abuse world ages by putting the overrides in an otherwise unreachable world (`~0-1`), and again use a method table view to first check that specific world age before falling back to the regular range.

The approach on 1.6 has a couple of issues, https://github.com/JuliaGPU/GPUCompiler.jl/pull/151#issuecomment-791433825, but it's temporary, and much closer to the approach for 1.7 so easier to maintain for the time being.