### PR TITLE
Drive deferred codegen with CompilerJob

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -112,10 +112,10 @@ end
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
 # this could both be generalized (e.g. supporting actual function calls, instead of
 # returning a function pointer), and be integrated with the nonrecursive codegen.
-const deferred_codegen_jobs = Vector{Union{Tuple{Core.Function,Type}, CompilerJob}}()
+const deferred_codegen_jobs = Dict{Int, Union{FunctionSpec, CompilerJob}}()
 @generated function deferred_codegen(::Val{f}, ::Val{tt}) where {f,tt}
-    push!(deferred_codegen_jobs, (f,tt))
-    id = length(deferred_codegen_jobs)
+    id = length(deferred_codegen_jobs) + 1
+    deferred_codegen_jobs[id] = FunctionSpec(f,tt)
 
     quote
         # TODO: add an edge to this method instance to support method redefinitions

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -42,7 +42,7 @@ end
 
 function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                  libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
-                 strip::Bool=false, validate::Bool=true, only_entry::Bool=false, current_job::Union{Nothing, CompilerJob} = nothing)
+                 strip::Bool=false, validate::Bool=true, only_entry::Bool=false, parent_job::Union{Nothing, CompilerJob} = nothing)
     ## Julia IR
 
     method_instance, world = emit_julia(job)
@@ -251,7 +251,7 @@ end
                 # cached compilation
                 dyn_kernel_fn = get!(cache, dyn_job) do
                     dyn_ir, dyn_kernel = codegen(:llvm, dyn_job; optimize,
-                                                 deferred_codegen=false, current_job=job)
+                                                 deferred_codegen=false, parent_job=job)
                     dyn_kernel_fn = LLVM.name(dyn_kernel)
                     @assert context(dyn_ir) == ctx
                     link!(ir, dyn_ir)

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -42,7 +42,7 @@ end
 
 function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                  libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
-                 strip::Bool=false, validate::Bool=true, only_entry::Bool=false)
+                 strip::Bool=false, validate::Bool=true, only_entry::Bool=false, current_job::Union{Nothing, CompilerJob} = nothing)
     ## Julia IR
 
     method_instance, world = emit_julia(job)
@@ -251,7 +251,7 @@ end
                 # cached compilation
                 dyn_kernel_fn = get!(cache, dyn_job) do
                     dyn_ir, dyn_kernel = codegen(:llvm, dyn_job; optimize,
-                                                 deferred_codegen=false)
+                                                 deferred_codegen=false, current_job=job)
                     dyn_kernel_fn = LLVM.name(dyn_kernel)
                     @assert context(dyn_ir) == ctx
                     link!(ir, dyn_ir)

--- a/test/definitions/native.jl
+++ b/test/definitions/native.jl
@@ -48,3 +48,83 @@ function native_code_execution(@nospecialize(func), @nospecialize(types); kwargs
     job, kwargs = native_job(func, types; kernel=true, kwargs...)
     GPUCompiler.compile(:asm, job; kwargs...)
 end
+
+module LazyCodegen
+    using LLVM
+    using GPUCompiler
+
+    import ..native_job
+
+    # We have one global JIT and TM
+    const jit = Ref{LLVM.OrcJIT}()
+    const tm  = Ref{LLVM.TargetMachine}()
+
+    function __init__()
+        optlevel = LLVM.API.LLVMCodeGenLevelDefault
+
+        tm[] = GPUCompiler.JITTargetMachine(optlevel=optlevel)
+        LLVM.asm_verbosity!(tm[], true)
+
+        jit[] = LLVM.OrcJIT(tm[]) # takes ownership of tm
+        atexit() do
+            dispose(jit[])
+        end
+    end
+
+    import GPUCompiler: deferred_codegen_jobs, CompilerJob
+    mutable struct CallbackContext
+        job::CompilerJob
+        stub::String
+        compiled::Bool
+    end
+
+    const outstanding = IdDict{CallbackContext, Nothing}()
+
+    # Setup the lazy callback for creating a module
+    function callback(orc_ref::LLVM.API.LLVMOrcJITStackRef, callback_ctx::Ptr{Cvoid})
+        orc = LLVM.OrcJIT(orc_ref)
+        cc = Base.unsafe_pointer_to_objref(callback_ctx)::CallbackContext
+
+        @assert !cc.compiled
+        job = cc.job
+
+        ir, entry = GPUCompiler.codegen(:llvm, job; validate=false)
+        entry_name = name(entry)
+
+        jitted_mod = compile!(orc, ir)
+
+        addr = addressin(orc, jitted_mod, entry_name)
+        ptr  = pointer(addr)
+
+        cc.compiled = true
+        delete!(outstanding, cc)
+
+        # 4. Update the stub pointer to point to the recently compiled module
+        set_stub!(orc, cc.stub, ptr)
+
+        # 5. Return the address of the implementation, since we are going to call it now
+        return UInt64(reinterpret(UInt, ptr))
+    end
+
+    @generated function deferred_codegen(::Val{f}, ::Val{tt}) where {f,tt}
+        job, _ = native_job(f, tt)
+
+        cc = CallbackContext(job, String(gensym(:trampoline)), false)
+        outstanding[cc] = nothing
+
+        c_callback = @cfunction(callback, UInt64, (LLVM.API.LLVMOrcJITStackRef, Ptr{Cvoid}))
+
+        orc = jit[]
+        initial_addr = callback!(orc, c_callback, pointer_from_objref(cc))
+        create_stub!(orc, cc.stub, initial_addr)
+        addr = address(orc, cc.stub)
+        trampoline = pointer(addr)
+        id = Base.reinterpret(Int, trampoline)
+
+        deferred_codegen_jobs[id] = job
+
+        quote
+            ccall("extern deferred_codegen", llvmcall, Ptr{Cvoid}, (Ptr{Cvoid},), $trampoline)
+        end
+    end
+end


### PR DESCRIPTION
This is rather funky, but it enables Enzyme to inject a full CompilerJob into the deferred_codegen_jobs,
which is needed to do higher-order adjoints and potentially running Enzyme within a CUDA kernel. 


x-ref: https://github.com/wsmoses/Enzyme.jl/pull/54
