### PR TITLE
Inline after deferred codegeneration

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -275,7 +275,9 @@ end
 
         # merge constants (such as exception messages) from each kernel
         ModulePassManager() do pm
+            instruction_combining!(pm)
             constant_merge!(pm)
+            always_inliner!(pm)
 
             run!(pm, ir)
         end


### PR DESCRIPTION
For Enzyme it makes sense to inline the delayed code-generated function
this requires instcombine to get rid of the `inttoptr ptrtoing` sequence and then running the inliner.
