### PR TITLE
Parametrize jlgen with custom interpreters.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -132,6 +132,10 @@ runtime_module(::CompilerJob) = error("Not implemented")
 # check if a function is an intrinsic that can assumed to be always available
 isintrinsic(::CompilerJob, fn::String) = false
 
+# provide a specific interpreter to use.
+get_interpreter(job::CompilerJob) = GPUInterpreter(ci_cache(job), method_table(job),
+                                                   job.source.world)
+
 # does this target support throwing Julia exceptions with jl_throw?
 # if not, calls to throw will be replaced with calls to the GPU runtime
 can_throw(::CompilerJob) = false

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -276,8 +276,7 @@ end
 
 ## codegen/inference integration
 
-function ci_cache_populate(cache, mt, mi, min_world, max_world)
-    interp = GPUInterpreter(cache, mt, min_world)
+function ci_cache_populate(interp, cache, mt, mi, min_world, max_world)
     src = Core.Compiler.typeinf_ext_toplevel(interp, mi)
 
     # inference populates the cache, so we don't need to jl_get_method_inferred
@@ -315,8 +314,9 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     # populate the cache
     cache = ci_cache(job)
     mt = method_table(job)
+    interp = get_interpreter(job)
     if ci_cache_lookup(cache, method_instance, job.source.world, typemax(Cint)) === nothing
-        ci_cache_populate(cache, mt, method_instance, job.source.world, typemax(Cint))
+        ci_cache_populate(interp, cache, mt, method_instance, job.source.world, typemax(Cint))
     end
 
     # set-up the compiler interface


### PR DESCRIPTION
I'd like to re-use the `jlgen` hooks for compiling method instances -- but I'd like to parametrize the pipeline with my own interpreter. I think this might be generally useful, if downstream compiler creators would like to customize Julia's type inference but still use the relatively generic caching `Core.Compiler` overloads and pipeline.