### PR TITLE
Remove matching of Julia throw functions.

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -176,14 +176,6 @@ function lower_throw!(mod::LLVM.Module)
         "jl_bounds_error_unboxed_int"   => "bounds error",
         "jl_bounds_error_ints"          => "bounds error",
         "jl_eof_error"                  => "EOF error",
-        # Julia-level exceptions that use unsupported inputs like interpolated strings
-        r"julia_throw_exp_domainerror_\d+"      => "DomainError",
-        r"julia_throw_complex_domainerror_\d+"  => "DomainError",
-        r"julia_throw_domerr_powbysq_\d+"       => "DomainError",
-        r"julia_throw_overflowerr_binaryop_\d+" => "OverflowError",
-        r"julia_throw_overflowerr_negation_\d+" => "OverflowError",
-        r"julia_throw_inexacterror_\d+"         => "InexactError",
-        r"julia_throw_boundserror_\d+"          => "BoundsError",
     ]
 
     for f in functions(mod)
@@ -206,6 +198,7 @@ function lower_throw!(mod::LLVM.Module)
                 unsafe_delete!(LLVM.parent(call), call)
 
                 # HACK: kill the exceptions' unused arguments
+                #       this is needed for throwing objects with @nospecialize constructors.
                 for arg in call_args
                     # peek through casts
                     if isa(arg, LLVM.AddrSpaceCastInst)

--- a/test/native.jl
+++ b/test/native.jl
@@ -148,12 +148,6 @@ end
     native_code_llvm(devnull, D32593, Tuple{Ptr{D32593_struct}})
 end
 
-@testset "Julia-level throw lowering" begin
-    kernel(ptr) = (unsafe_store!(ptr, sqrt(unsafe_load(ptr))); nothing)
-
-    native_code_execution(kernel, Tuple{Ptr{Float32}})
-end
-
 end
 
 ############################################################################################


### PR DESCRIPTION
Now that we have contextual overrides, we don't need to match Julia-level functions anymore. We still need to override calls to the runtime, as we can't contextually override intrinsics like `throw`. Also, for now we still need the hack that removes arguments to those runtime functions because many exception objects (like `InexactError`) have `@nospecialize` constructors (we could define overrides for all these constructors, but I'm hoping we can do that automatically with 1.7's method table overrides, or by introducing another codegen hook).

This is obviously a breaking change.