### PR TITLE
Remove PTX debuginfo hack.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -180,3 +180,14 @@ ci_cache(::CompilerJob) = GLOBAL_CI_CACHE
 
 # the method table to use
 method_table(::CompilerJob) = GLOBAL_METHOD_TABLE
+
+# how much debuginfo to emit
+function llvm_debug_info(::CompilerJob)
+    if Base.JLOptions().debug_level == 0
+        LLVM.API.LLVMDebugEmissionKindNoDebug
+    elseif Base.JLOptions().debug_level == 1
+        LLVM.API.LLVMDebugEmissionKindLineTablesOnly
+    elseif Base.JLOptions().debug_level >= 2
+        LLVM.API.LLVMDebugEmissionKindFullDebug
+    end
+end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -320,16 +320,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     end
 
     # set-up the compiler interface
-    debug_info_kind = if Base.JLOptions().debug_level == 0
-        LLVM.API.LLVMDebugEmissionKindNoDebug
-    elseif Base.JLOptions().debug_level == 1
-        LLVM.API.LLVMDebugEmissionKindLineTablesOnly
-    elseif Base.JLOptions().debug_level >= 2
-        LLVM.API.LLVMDebugEmissionKindFullDebug
-    end
-    if job.target isa PTXCompilerTarget && !job.target.debuginfo
-        debug_info_kind = LLVM.API.LLVMDebugEmissionKindNoDebug
-    end
+    debug_info_kind = llvm_debug_info(job)
     lookup_fun = (mi, min_world, max_world) -> ci_cache_lookup(cache, mi, min_world, max_world)
     lookup_cb = @cfunction($lookup_fun, Any, (Any, UInt, UInt))
     params = Base.CodegenParams(;

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -59,9 +59,10 @@ end
 const ptx_intrinsics = ("vprintf", "__assertfail", "malloc", "free")
 isintrinsic(::CompilerJob{PTXCompilerTarget}, fn::String) = in(fn, ptx_intrinsics)
 
+# XXX: the debuginfo part should be handled by GPUCompiler as it applies to all back-ends.
 runtime_slug(job::CompilerJob{PTXCompilerTarget}) =
     "ptx-sm_$(job.target.cap.major)$(job.target.cap.minor)" *
-       "-debuginfo=$(job.target.debuginfo)" *
+       "-debuginfo=$(Int(llvm_debug_info(job)))" *
        "-exitable=$(job.target.exitable)"
 
 function process_module!(job::CompilerJob{PTXCompilerTarget}, mod::LLVM.Module)


### PR DESCRIPTION
We can now control the `debuginfo` argument from CUDA.jl, so don't need a hack here.