### PR TITLE
Copy the DI SubProgram when wrapping for ByVal.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -53,9 +53,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LLVM]]
 deps = ["CEnum", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "b616937c31337576360cb9fb872ec7633af7b194"
+git-tree-sha1 = "a220efe4a6bc1c71809d002eb9ed9209ce5a86fb"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "3.6.0"
+version = "3.7.0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 DataStructures = "0.15, 0.16, 0.17, 0.18"
 ExprTools = "0.1"
-LLVM = "3.0"
+LLVM = "3.7"
 Scratch = "1.0"
 TimerOutputs = "0.5"
 julia = "1.6"

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -423,6 +423,12 @@ function lower_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry_f:
     push!(function_attributes(entry_f), EnumAttribute("alwaysinline", 0, ctx))
     linkage!(entry_f, LLVM.API.LLVMInternalLinkage)
 
+    # copy debug info
+    sp = LLVM.get_subprogram(entry_f)
+    if sp !== nothing
+        LLVM.set_subprogram!(wrapper_f, sp)
+    end
+
     fixup_metadata!(entry_f)
     ModulePassManager() do pm
         always_inliner!(pm)


### PR DESCRIPTION
Otherwise LLVM segfaults when printing debug info for these functions.

Requires https://github.com/maleadt/LLVM.jl/pull/227.