### PR TITLE
Breaking changes

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -46,24 +46,23 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                  parent_job::Union{Nothing, CompilerJob} = nothing)
     ## Julia IR
 
-    method_instance, meta = emit_julia(job)
+    mi, mi_meta = emit_julia(job)
 
     if output == :julia
-        return method_instance, meta
+        return mi, meta
     end
 
 
     ## LLVM IR
 
-    ir, meta = emit_llvm(job, method_instance;
-                         libraries, deferred_codegen, optimize, only_entry)
+    ir, ir_meta = emit_llvm(job, mi; libraries, deferred_codegen, optimize, only_entry)
 
     if output == :llvm
         if strip
             @timeit_debug to "strip debug info" strip_debuginfo!(ir)
         end
 
-        return ir, meta
+        return ir, ir_meta
     end
 
 
@@ -76,10 +75,10 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     else
         error("Unknown assembly format $output")
     end
-    code, meta = emit_asm(job, ir, meta.entry; strip, validate, format)
+    asm, asm_meta = emit_asm(job, ir; strip, validate, format)
 
     if output == :asm || output == :obj
-        return code, meta
+        return asm, (; entry=LLVM.name(ir_meta.entry), asm_meta...)
     end
 
 
@@ -310,13 +309,13 @@ const __llvm_initialized = Ref(false)
     return ir, (; entry, compiled)
 end
 
-@locked function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module, entry::LLVM.Function;
+@locked function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module;
                           strip::Bool=false, validate::Bool=true, format::LLVM.API.LLVMCodeGenFileType)
     finish_module!(job, ir)
 
     if validate
         @timeit_debug to "validation" begin
-            check_invocation(job, entry)
+            check_invocation(job)
             check_ir(job, ir)
         end
     end
@@ -335,8 +334,8 @@ end
     @timeit_debug to "LLVM back-end" begin
         @timeit_debug to "preparation" prepare_execution!(job, ir)
 
-        code = @timeit_debug to "machine-code generation" mcgen(job, ir, entry, format)
+        code = @timeit_debug to "machine-code generation" mcgen(job, ir, format)
     end
 
-    return code, (; entry=LLVM.name(entry), undefined_fns, undefined_gbls)
+    return code, (; undefined_fns, undefined_gbls)
 end

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -78,7 +78,7 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     asm, asm_meta = emit_asm(job, ir; strip, validate, format)
 
     if output == :asm || output == :obj
-        return asm, (; entry=LLVM.name(ir_meta.entry), asm_meta...)
+        return asm, asm_meta
     end
 
 
@@ -320,12 +320,6 @@ end
         end
     end
 
-    # get a list of undefined stuff -- front-ends might need it to link additional libraries
-    undefined_fns = LLVM.name.(decls(ir))
-    undefined_gbls = map(x->(name=LLVM.name(x),
-                             type=llvmtype(x),
-                             external=isextinit(x)), LLVM.globals(ir))
-
     # NOTE: strip after validation to get better errors
     if strip
         @timeit_debug to "strip debug info" strip_debuginfo!(ir)
@@ -337,5 +331,5 @@ end
         code = @timeit_debug to "machine-code generation" mcgen(job, ir, format)
     end
 
-    return code, (; undefined_fns, undefined_gbls)
+    return code, ()
 end

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -107,8 +107,7 @@ end
         end
     end
 
-    # XXX: remove returned world for next breaking release
-    return method_instance, (; world=job.source.world)
+    return method_instance, ()
 end
 
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
@@ -135,13 +134,9 @@ end
 
 const __llvm_initialized = Ref(false)
 
-@locked function emit_llvm(@nospecialize(job::CompilerJob), @nospecialize(method_instance),
-                           world=job.source.world;
+@locked function emit_llvm(@nospecialize(job::CompilerJob), @nospecialize(method_instance);
                            libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
                            only_entry::Bool=false)
-    # XXX: remove world argument for next breaking release
-    @assert world == job.source.world
-
     if !__llvm_initialized[]
         InitializeAllTargets()
         InitializeAllTargetInfos()

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -68,7 +68,7 @@ function resolve_cpu_references!(mod::LLVM.Module)
 end
 
 
-function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.Function, format=LLVM.API.LLVMAssemblyFile)
+function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
     tm = llvm_machine(job.target)
 
     return String(emit(tm, mod, format))

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -61,7 +61,7 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module)
     end
 end
 
-@unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module, f::LLVM.Function,
+@unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
                          format=LLVM.API.LLVMAssemblyFile)
     # write the bitcode to a temporary file (the SPIRV Translator library doesn't have a C API)
     mktemp() do input, input_io

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -53,7 +53,7 @@ function explain_nonisbits(@nospecialize(dt), depth=1; maxdepth=10)
     return msg
 end
 
-function check_invocation(@nospecialize(job::CompilerJob), entry::LLVM.Function)
+function check_invocation(@nospecialize(job::CompilerJob))
     # make sure any non-isbits arguments are unused
     real_arg_i = 0
     sig = Base.signature_type(job.source.f, job.source.tt)::Type


### PR DESCRIPTION
Since https://github.com/JuliaGPU/GPUCompiler.jl/pull/196 was breaking, here's some more breaking changes:
- make each `emit_` method return a `meta::NamedTuple` for extensibility (so that we can at least return additional values without breaking the interface)
- remove the redundant `world` arguments -- this is part of the FunctionSpec now
- remove the undefined functions/globals metadata (cc @jpsamaroo), these are very easy to reconstruct from the outputs of `emit_llvm`. Note that back when this was introduced, it wasn't possible to call `emit_llvm` separately; the driver has since been split up.