### PR TITLE
Use the code info's objectid for specialization.

### DIFF
--- a/examples/kernel.jl
+++ b/examples/kernel.jl
@@ -16,8 +16,7 @@ end
 struct TestCompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,TestCompilerParams}) = TestRuntime
 
-
-function kernel() end
+kernel() = nothing
 
 function main()
     source = FunctionSpec(kernel)


### PR DESCRIPTION
Fewer global state modifications from generated functions is always nice.

@vchuravy See the comment, maybe you know how to get the world bounds where a code info is valid?