### PR TITLE
Hash structures by fields.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -67,6 +67,16 @@ struct FunctionSpec{F,TT}
     world_age::UInt
 end
 
+
+function Base.hash(spec::FunctionSpec, h::UInt)
+    h = hash(spec.f, h)
+    h = hash(spec.tt, h)
+    h = hash(spec.kernel, h)
+    h = hash(spec.name, h)
+    h = hash(spec.world_age, h)
+    h
+end
+
 # put the function and argument types in typevars
 # so that we can access it from generated functions
 # XXX: the default value of 0xffffffffffffffff is a hack, because we don't properly perform
@@ -119,6 +129,13 @@ Base.similar(@nospecialize(job::CompilerJob), @nospecialize(source::FunctionSpec
 
 function Base.show(io::IO, @nospecialize(job::CompilerJob{T})) where {T}
     print(io, "CompilerJob of ", job.source, " for ", T)
+end
+
+function Base.hash(job::CompilerJob, h::UInt)
+    h = hash(job.target, h)
+    h = hash(job.source, h)
+    h = hash(job.params, h)
+    h
 end
 
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -23,6 +23,22 @@ Base.@kwdef struct PTXCompilerTarget <: AbstractCompilerTarget
     maxregs::Union{Nothing,Int} = nothing
 end
 
+function Base.hash(target::PTXCompilerTarget, h::UInt)
+    h = hash(target.cap, h)
+    h = hash(target.ptx, h)
+
+    h = hash(target.debuginfo, h)
+    h = hash(target.unreachable, h)
+    h = hash(target.exitable, h)
+
+    h = hash(target.minthreads, h)
+    h = hash(target.maxthreads, h)
+    h = hash(target.blocks_per_sm, h)
+    h = hash(target.maxregs, h)
+
+    h
+end
+
 source_code(target::PTXCompilerTarget) = "ptx"
 
 llvm_triple(target::PTXCompilerTarget) = Int===Int64 ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda"


### PR DESCRIPTION
Objectid hash is apparently expensive (100ns), but also wrong, since we want to hit the cache on identical compilation requests.