### PR TITLE
Return pointer rather than integer for malloc

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -127,7 +127,7 @@ end
 compile(gc_pool_alloc, Any, (Csize_t,), T_prjlvalue)
 
 # expected functions for GC support
-compile(:malloc, Ptr{Nothing}, (Csize_t,))
+compile(:malloc, Core.LLVMPtr{Cvoid, 0}, (Csize_t,))
 
 
 ## boxing and unboxing


### PR DESCRIPTION
Using Julia Pointer causes the llvm to return an integer, which prevent's LLVM's targetlibraryinfo from recognizing this as a malloc, among other issues.

cc @vchuravy 