### PR TITLE
Rework the GPUCompiler interface to avoid needless compiler specialization

### DIFF
--- a/examples/kernel.jl
+++ b/examples/kernel.jl
@@ -14,15 +14,16 @@ module TestRuntime
 end
 
 struct TestCompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,TestCompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::Compiler{<:Any,TestCompilerParams}) = TestRuntime
 
 kernel() = nothing
 
 function main()
-    source = FunctionSpec(kernel)
     target = NativeCompilerTarget()
     params = TestCompilerParams()
-    job = CompilerJob(target, source, params)
+    compiler = Compiler(target, params)
+    source = FunctionSpec(kernel)
+    job = CompilerJob(compiler, source)
 
     println(GPUCompiler.compile(:asm, job)[1])
 end

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -48,4 +48,10 @@ include("reflection.jl")
 include("precompile.jl")
 _precompile_()
 
+function __init__()
+    __llvm_initialized[] = false
+    specialization_counter[] = 0
+    libjulia[] = C_NULL
+end
+
 end # module

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -9,6 +9,8 @@ using ExprTools: splitdef, combinedef
 
 using Libdl
 
+using Base: @invokelatest
+
 const to = TimerOutput()
 
 timings() = (TimerOutputs.print_timer(to); println())

--- a/src/bpf.jl
+++ b/src/bpf.jl
@@ -24,12 +24,9 @@ function llvm_machine(target::BPFCompilerTarget)
 end
 
 
-## job
+## compiler
 
-runtime_slug(job::CompilerJob{BPFCompilerTarget}) = "bpf"
+runtime_slug(::Compiler{BPFCompilerTarget}) = "bpf"
 
-const bpf_intrinsics = () # TODO
-isintrinsic(::CompilerJob{BPFCompilerTarget}, fn::String) = in(fn, bpf_intrinsics)
-
-valid_function_pointer(job::CompilerJob{BPFCompilerTarget}, ptr::Ptr{Cvoid}) =
-    reinterpret(UInt, ptr) in job.target.function_pointers
+valid_function_pointer(compiler::Compiler{BPFCompilerTarget}, ptr::Ptr{Cvoid}) =
+    reinterpret(UInt, ptr) in compiler.target.function_pointers

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -66,13 +66,13 @@ end
 # the compiler on the function being compiled). instead of using additional arguments,
 # just look it up from an inlined function (assuming the parent will have specialized
 # on the function and tuple type used to construct the CompilerJob).
-@inline cached_compilation(cache::AbstractDict, @nospecialize(job::CompilerJob),
+@inline cached_compilation(cache::AbstractDict, job::CompilerJob,
                            compiler::Function, linker::Function) =
     _cached_compilation(cache, job, compiler, linker, job.source.f, job.source.tt)
 
 # NOTE: questionable use of `@inline` to avoid allocations in the kernel launch path
 const cache_lock = ReentrantLock()
-@inline function _cached_compilation(cache::AbstractDict, @nospecialize(job::CompilerJob),
+@inline function _cached_compilation(cache::AbstractDict, job::CompilerJob,
                                      compiler::Function, linker::Function,
                                      f::F, tt::Type{TT}) where {F, TT}
     # XXX: CompilerJob contains a world age, so can't be respecialized.

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -8,7 +8,7 @@ using Base: _methods_by_ftype
 #
 # we also increment a global specialization counter and pass it along to index the cache.
 
-const specialization_counter = Ref{UInt}(0)
+const specialization_counter = Ref{UInt}()
 @generated function specialization_id(f::F, tt::Type{TT}) where {F, TT}
     # get a hold of the method and code info of the kernel function
     sig = Tuple{F, TT.parameters...}

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -131,7 +131,7 @@ end
     end
 end
 
-const __llvm_initialized = Ref(false)
+const __llvm_initialized = Ref{Bool}()
 
 @locked function emit_llvm(job::CompilerJob, method_instance::Core.MethodInstance;
                            libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -170,7 +170,7 @@ const __llvm_initialized = Ref(false)
         # target-specific libraries
         if libraries
             undefined_fns = LLVM.name.(decls(ir))
-            @timeit_debug to "target libraries" link_libraries!(job, ir, undefined_fns)
+            @timeit_debug to "target libraries" @invokelatest link_libraries!(job, ir, undefined_fns)
         end
 
         if optimize
@@ -311,7 +311,7 @@ end
 
 @locked function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module;
                           strip::Bool=false, validate::Bool=true, format::LLVM.API.LLVMCodeGenFileType)
-    finish_module!(job, ir)
+    @invokelatest finish_module!(job, ir)
 
     if validate
         @timeit_debug to "validation" begin

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -133,9 +133,14 @@ end
 
 const __llvm_initialized = Ref(false)
 
-@locked function emit_llvm(@nospecialize(job::CompilerJob), @nospecialize(method_instance);
-                           libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
-                           only_entry::Bool=false)
+# JuliaLang/julia#34516: keyword functions drop @nospecialize
+@locked emit_llvm(@nospecialize(job::CompilerJob), method_instance::Core.MethodInstance;
+                  libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
+                  only_entry::Bool=false) =
+    emit_llvm(job, method_instance, libraries, deferred_codegen, optimize, only_entry)
+function emit_llvm(@nospecialize(job::CompilerJob), method_instance::Core.MethodInstance,
+                   libraries::Bool, deferred_codegen::Bool, optimize::Bool,
+                   only_entry::Bool)
     if !__llvm_initialized[]
         InitializeAllTargets()
         InitializeAllTargetInfos()
@@ -309,8 +314,12 @@ const __llvm_initialized = Ref(false)
     return ir, (; entry, compiled)
 end
 
-@locked function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module;
-                          strip::Bool=false, validate::Bool=true, format::LLVM.API.LLVMCodeGenFileType)
+# JuliaLang/julia#34516: keyword functions drop @nospecialize
+@locked emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module;
+                 strip::Bool=false, validate::Bool=true, format::LLVM.API.LLVMCodeGenFileType) =
+    emit_asm(job, ir, strip, validate, format)
+function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module,
+                                strip::Bool, validate::Bool, format::LLVM.API.LLVMCodeGenFileType)
     @invokelatest finish_module!(job, ir)
 
     if validate

--- a/src/error.jl
+++ b/src/error.jl
@@ -8,7 +8,7 @@ struct KernelError <: Exception
     help::Union{Nothing,String}
     bt::StackTraces.StackTrace
 
-    KernelError(@nospecialize(job::CompilerJob), message::String, help=nothing;
+    KernelError(job::CompilerJob, message::String, help=nothing;
                 bt=StackTraces.StackTrace()) =
         new(job, message, help, bt)
 end

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -26,7 +26,7 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
     end
 
     # target-specific processing
-    process_module!(job, mod)
+    @invokelatest process_module!(job, mod)
 
     # sanitize function names
     # FIXME: Julia should do this, but apparently fails (see maleadt/LLVM.jl#201)
@@ -49,7 +49,7 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
     if job.source.kernel
         LLVM.name!(entry, mangle_call(entry, job.source.tt))
     end
-    entry = process_entry!(job, mod, entry)
+    entry = @invokelatest process_entry!(job, mod, entry)
     compiled[method_instance] =
         (; compiled[method_instance].ci, compiled[method_instance].func,
            specfunc=LLVM.name(entry))
@@ -68,9 +68,9 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
         end
         internalize!(pm, exports)
 
-        can_throw(job) || add!(pm, ModulePass("LowerThrow", lower_throw!))
+        @invokelatest(can_throw(job)) || add!(pm, ModulePass("LowerThrow", lower_throw!))
 
-        add_lowering_passes!(job, pm)
+        @invokelatest add_lowering_passes!(job, pm)
 
         run!(pm, mod)
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -317,12 +317,12 @@ function _lookup_fun(mi, min_world, max_world)
     ci_cache_lookup(_cache[], mi, min_world, max_world)
 end
 
-function compile_method_instance(@nospecialize(job::CompilerJob),
+function compile_method_instance(job::CompilerJob,
                                  method_instance::MethodInstance)
     # populate the cache
-    cache = @invokelatest ci_cache(job)
-    mt = @invokelatest method_table(job)
-    interp = @invokelatest get_interpreter(job)
+    cache = @invokelatest ci_cache(job.compiler)
+    mt = @invokelatest method_table(job.compiler)
+    interp = @invokelatest get_interpreter(job.compiler, job.source)
     if ci_cache_lookup(cache, method_instance, job.source.world, typemax(Cint)) === nothing
         ci_cache_populate(interp, cache, mt, method_instance, job.source.world, typemax(Cint))
     end
@@ -343,7 +343,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     end
 
     # set-up the compiler interface
-    debug_info_kind = @invokelatest llvm_debug_info(job)
+    debug_info_kind = @invokelatest llvm_debug_info(job.compiler)
     params = Base.CodegenParams(;
         track_allocations  = false,
         code_coverage      = false,
@@ -407,8 +407,8 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     end
 
     # configure the module
-    triple!(llvm_mod, @invokelatest(llvm_triple(job.target)))
-    dl = @invokelatest julia_datalayout(job.target)
+    triple!(llvm_mod, @invokelatest(llvm_triple(job.compiler.target)))
+    dl = @invokelatest julia_datalayout(job.compiler.target)
     if dl !== nothing
         datalayout!(llvm_mod, dl)
     end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -320,9 +320,9 @@ end
 function compile_method_instance(@nospecialize(job::CompilerJob),
                                  method_instance::MethodInstance)
     # populate the cache
-    cache = ci_cache(job)
-    mt = method_table(job)
-    interp = get_interpreter(job)
+    cache = @invokelatest ci_cache(job)
+    mt = @invokelatest method_table(job)
+    interp = @invokelatest get_interpreter(job)
     if ci_cache_lookup(cache, method_instance, job.source.world, typemax(Cint)) === nothing
         ci_cache_populate(interp, cache, mt, method_instance, job.source.world, typemax(Cint))
     end
@@ -343,7 +343,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     end
 
     # set-up the compiler interface
-    debug_info_kind = llvm_debug_info(job)
+    debug_info_kind = @invokelatest llvm_debug_info(job)
     params = Base.CodegenParams(;
         track_allocations  = false,
         code_coverage      = false,
@@ -407,9 +407,10 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     end
 
     # configure the module
-    triple!(llvm_mod, llvm_triple(job.target))
-    if julia_datalayout(job.target) !== nothing
-        datalayout!(llvm_mod, julia_datalayout(job.target))
+    triple!(llvm_mod, @invokelatest(llvm_triple(job.target)))
+    dl = @invokelatest julia_datalayout(job.target)
+    if dl !== nothing
+        datalayout!(llvm_mod, dl)
     end
 
     return llvm_mod, compiled

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -2,7 +2,7 @@
 
 # final preparations for the module to be compiled to machine code
 # these passes should not be run when e.g. compiling to write to disk.
-function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
+function prepare_execution!(job::CompilerJob, mod::LLVM.Module)
     let pm = ModulePassManager()
         global current_job
         current_job = job
@@ -68,8 +68,6 @@ function resolve_cpu_references!(mod::LLVM.Module)
 end
 
 
-function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
-    tm = @invokelatest llvm_machine(job.target)
-
-    return String(emit(tm, mod, format))
+function mcgen(job::CompilerJob, mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
+    @invokelatest emit_assembly(job.compiler, job.source, mod, format)
 end

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -69,7 +69,7 @@ end
 
 
 function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
-    tm = llvm_machine(job.target)
+    tm = @invokelatest llvm_machine(job.target)
 
     return String(emit(tm, mod, format))
 end

--- a/src/native.jl
+++ b/src/native.jl
@@ -23,14 +23,16 @@ function llvm_machine(target::NativeCompilerTarget)
     return tm
 end
 
-function process_entry!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
+function process_entry!(compiler::Compiler{NativeCompilerTarget}, source::FunctionSpec, mod::LLVM.Module, entry::LLVM.Function)
     ctx = context(mod)
-    if job.target.always_inline
+    if compiler.target.always_inline
         push!(function_attributes(entry), EnumAttribute("alwaysinline", 0; ctx))
     end
-    invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
+    invoke(process_entry!, Tuple{Compiler, FunctionSpec, LLVM.Module, LLVM.Function}, compiler, source, mod, entry)
 end
 
-## job
 
-runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))"
+## compiler
+
+runtime_slug(compiler::Compiler{NativeCompilerTarget}) =
+    "native_$(compiler.target.cpu)-$(hash(compiler.target.features))"

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -1,7 +1,7 @@
 # LLVM IR optimization
 
-function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
-    tm = @invokelatest llvm_machine(job.target)
+function optimize!(job::CompilerJob, mod::LLVM.Module)
+    tm = @invokelatest llvm_machine(job.compiler.target)
 
     function initialize!(pm)
         add_library_info!(pm, triple(mod))
@@ -45,7 +45,7 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     end
 
     # target-specific optimizations
-    @invokelatest optimize_module!(job, mod)
+    @invokelatest optimize_module!(job.compiler, job.source, mod)
 
     # we compile a module containing the entire call graph,
     # so perform some interprocedural optimizations.

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -1,7 +1,7 @@
 # LLVM IR optimization
 
 function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
-    tm = llvm_machine(job.target)
+    tm = @invokelatest llvm_machine(job.target)
 
     function initialize!(pm)
         add_library_info!(pm, triple(mod))
@@ -45,7 +45,7 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     end
 
     # target-specific optimizations
-    optimize_module!(job, mod)
+    @invokelatest optimize_module!(job, mod)
 
     # we compile a module containing the entire call graph,
     # so perform some interprocedural optimizations.

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,18 +1,15 @@
+struct PrecompilationCompilerParams <: AbstractCompilerParams end
+GPUCompiler.runtime_module(::Compiler{<:Any,PrecompilationCompilerParams}) = GPUCompiler
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    Base.precompile(Tuple{typeof(lower_throw!),LLVM.Module})   # time: 0.17275752
-    Base.precompile(Tuple{typeof(lower_byval),CompilerJob,LLVM.Module,LLVM.Function})   # time: 0.055481136
-    Base.precompile(Tuple{typeof(call!),Builder,GPUCompiler.Runtime.RuntimeMethodInstance,Vector{ConstantExpr}})   # time: 0.022024114
-    Base.precompile(Tuple{Type{GPUInterpreter},CodeCache,Core.MethodTable,UInt64})   # time: 0.014925144
-    Base.precompile(Tuple{typeof(resolve_cpu_references!),LLVM.Module})   # time: 0.014757595
-    Base.precompile(Tuple{typeof(lower_ptls!),LLVM.Module})   # time: 0.013304743
-    Base.precompile(Tuple{Core.kwftype(typeof(load_runtime)),NamedTuple{(:ctx,), Tuple{Context}},typeof(load_runtime),CompilerJob})   # time: 0.012303286
-    Base.precompile(Tuple{typeof(lower_gc_frame!),LLVM.Function})   # time: 0.008227327
-    Base.precompile(Tuple{typeof(llvm_machine),PTXCompilerTarget})   # time: 0.008051048
-    Base.precompile(Tuple{typeof(hide_trap!),LLVM.Module})   # time: 0.007331288
-    Base.precompile(Tuple{typeof(mangle_param),Type,Vector{String}})   # time: 0.003355128
-    isdefined(GPUCompiler, Symbol("#55#59")) && Base.precompile(Tuple{getfield(GPUCompiler, Symbol("#55#59")),ModulePassManager})   # time: 0.001026008
-    Base.precompile(Tuple{typeof(julia_datalayout),PTXCompilerTarget})   # time: 0.001025637
 
-    precompile(emit_llvm, (CompilerJob, Core.MethodInstance))
+    # simple compilation
+    target = NativeCompilerTarget()
+    params = PrecompilationCompilerParams()
+    compiler = Compiler(target, params)
+    source = FunctionSpec(identity, Tuple{Nothing}, true, "dummy")
+    job = CompilerJob(compiler, source)
+    compile(:asm, job; strip=true, only_entry=true)
+    empty!(GLOBAL_CI_CACHE) # JuliaLang/julia#41714
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -51,15 +51,18 @@ end
 
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    @assert precompile(Tuple{typeof(GPUCompiler.assign_args!),Expr,Vector{Any}})
-    @assert precompile(Tuple{typeof(GPUCompiler.hide_trap!),LLVM.Module})
-    @assert precompile(Tuple{typeof(GPUCompiler.hide_unreachable!),LLVM.Function})
-    @assert precompile(Tuple{typeof(GPUCompiler.lower_gc_frame!),LLVM.Function})
-    @assert precompile(Tuple{typeof(GPUCompiler.lower_throw!),LLVM.Module})
-    #@assert precompile(Tuple{typeof(GPUCompiler.split_kwargs),Tuple{},Vector{Symbol},Vararg{Vector{Symbol}, N} where N})
-    let fbody = try __lookup_kwbody__(which(GPUCompiler.compile, (Symbol,GPUCompiler.CompilerJob,))) catch missing end
+    let fbody = try __lookup_kwbody__(which(emit_llvm, (CompilerJob,Any,))) catch missing end
         if !ismissing(fbody)
-            @assert precompile(fbody, (Bool,Bool,Bool,Bool,Bool,Bool,typeof(GPUCompiler.compile),Symbol,GPUCompiler.CompilerJob,))
+            precompile(fbody, (Bool,Bool,Bool,Bool,typeof(emit_llvm),CompilerJob,Any,))
         end
     end
+    Base.precompile(Tuple{typeof(process_entry!),CompilerJob{PTXCompilerTarget},LLVM.Module,LLVM.Function})
+    Base.precompile(Tuple{Core.kwftype(typeof(load_runtime)),NamedTuple{(:ctx,), Tuple{Context}},typeof(load_runtime),CompilerJob})
+    Base.precompile(Tuple{typeof(lower_byval),CompilerJob,LLVM.Module,LLVM.Function})
+    Base.precompile(Tuple{typeof(lower_ptls!),LLVM.Module})
+    Base.precompile(Tuple{typeof(call!),Builder,GPUCompiler.Runtime.RuntimeMethodInstance,Vector{ConstantExpr}})
+    Base.precompile(Tuple{typeof(emit_function!),LLVM.Module,CompilerJob,Function,GPUCompiler.Runtime.RuntimeMethodInstance})
+    Base.precompile(Tuple{typeof(mangle_param),Type,Vector{String}})
+    Base.precompile(Tuple{typeof(process_module!),CompilerJob{PTXCompilerTarget},LLVM.Module})
+    Base.precompile(Tuple{typeof(resolve_cpu_references!),LLVM.Module})
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,13 +1,18 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    Base.precompile(Tuple{typeof(process_entry!),CompilerJob{PTXCompilerTarget},LLVM.Module,LLVM.Function})
-    Base.precompile(Tuple{Core.kwftype(typeof(load_runtime)),NamedTuple{(:ctx,), Tuple{Context}},typeof(load_runtime),CompilerJob})
-    Base.precompile(Tuple{typeof(lower_byval),CompilerJob,LLVM.Module,LLVM.Function})
-    Base.precompile(Tuple{typeof(lower_ptls!),LLVM.Module})
-    Base.precompile(Tuple{typeof(call!),Builder,GPUCompiler.Runtime.RuntimeMethodInstance,Vector{ConstantExpr}})
-    Base.precompile(Tuple{typeof(emit_function!),LLVM.Module,CompilerJob,Function,GPUCompiler.Runtime.RuntimeMethodInstance})
-    Base.precompile(Tuple{typeof(mangle_param),Type,Vector{String}})
-    Base.precompile(Tuple{typeof(process_module!),CompilerJob{PTXCompilerTarget},LLVM.Module})
-    Base.precompile(Tuple{typeof(resolve_cpu_references!),LLVM.Module})
-    precompile(emit_llvm, (CompilerJob, Core.MethodInstance, Bool, Bool, Bool, Bool))
+    Base.precompile(Tuple{typeof(lower_throw!),LLVM.Module})   # time: 0.17275752
+    Base.precompile(Tuple{typeof(lower_byval),CompilerJob,LLVM.Module,LLVM.Function})   # time: 0.055481136
+    Base.precompile(Tuple{typeof(call!),Builder,GPUCompiler.Runtime.RuntimeMethodInstance,Vector{ConstantExpr}})   # time: 0.022024114
+    Base.precompile(Tuple{Type{GPUInterpreter},CodeCache,Core.MethodTable,UInt64})   # time: 0.014925144
+    Base.precompile(Tuple{typeof(resolve_cpu_references!),LLVM.Module})   # time: 0.014757595
+    Base.precompile(Tuple{typeof(lower_ptls!),LLVM.Module})   # time: 0.013304743
+    Base.precompile(Tuple{Core.kwftype(typeof(load_runtime)),NamedTuple{(:ctx,), Tuple{Context}},typeof(load_runtime),CompilerJob})   # time: 0.012303286
+    Base.precompile(Tuple{typeof(lower_gc_frame!),LLVM.Function})   # time: 0.008227327
+    Base.precompile(Tuple{typeof(llvm_machine),PTXCompilerTarget})   # time: 0.008051048
+    Base.precompile(Tuple{typeof(hide_trap!),LLVM.Module})   # time: 0.007331288
+    Base.precompile(Tuple{typeof(mangle_param),Type,Vector{String}})   # time: 0.003355128
+    isdefined(GPUCompiler, Symbol("#55#59")) && Base.precompile(Tuple{getfield(GPUCompiler, Symbol("#55#59")),ModulePassManager})   # time: 0.001026008
+    Base.precompile(Tuple{typeof(julia_datalayout),PTXCompilerTarget})   # time: 0.001025637
+
+    precompile(emit_llvm, (CompilerJob, Core.MethodInstance))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -12,4 +12,6 @@ function _precompile_()
     job = CompilerJob(compiler, source)
     compile(:asm, job; strip=true, only_entry=true)
     empty!(GLOBAL_CI_CACHE) # JuliaLang/julia#41714
+
+    precompile(emit_llvm, (CompilerJob, MethodInstance))
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,61 +1,5 @@
-const __bodyfunction__ = Dict{Method,Any}()
-
-# Find keyword "body functions" (the function that contains the body
-# as written by the developer, called after all missing keyword-arguments
-# have been assigned values), in a manner that doesn't depend on
-# gensymmed names.
-# `mnokw` is the method that gets called when you invoke it without
-# supplying any keywords.
-function __lookup_kwbody__(mnokw::Method)
-    function getsym(arg)
-        isa(arg, Symbol) && return arg
-        @assert isa(arg, GlobalRef)
-        return arg.name
-    end
-
-    f = get(__bodyfunction__, mnokw, nothing)
-    if f === nothing
-        fmod = mnokw.module
-        # The lowered code for `mnokw` should look like
-        #   %1 = mkw(kwvalues..., #self#, args...)
-        #        return %1
-        # where `mkw` is the name of the "active" keyword body-function.
-        ast = Base.uncompressed_ast(mnokw)
-        if isa(ast, Core.CodeInfo) && length(ast.code) >= 2
-            callexpr = ast.code[end-1]
-            if isa(callexpr, Expr) && callexpr.head == :call
-                fsym = callexpr.args[1]
-                if isa(fsym, Symbol)
-                    f = getfield(fmod, fsym)
-                elseif isa(fsym, GlobalRef)
-                    if fsym.mod === Core && fsym.name === :_apply
-                        f = getfield(mnokw.module, getsym(callexpr.args[2]))
-                    elseif fsym.mod === Core && fsym.name === :_apply_iterate
-                        f = getfield(mnokw.module, getsym(callexpr.args[3]))
-                    else
-                        f = getfield(fsym.mod, fsym.name)
-                    end
-                else
-                    f = missing
-                end
-            else
-                f = missing
-            end
-        else
-            f = missing
-        end
-        __bodyfunction__[mnokw] = f
-    end
-    return f
-end
-
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    let fbody = try __lookup_kwbody__(which(emit_llvm, (CompilerJob,Any,))) catch missing end
-        if !ismissing(fbody)
-            precompile(fbody, (Bool,Bool,Bool,Bool,typeof(emit_llvm),CompilerJob,Any,))
-        end
-    end
     Base.precompile(Tuple{typeof(process_entry!),CompilerJob{PTXCompilerTarget},LLVM.Module,LLVM.Function})
     Base.precompile(Tuple{Core.kwftype(typeof(load_runtime)),NamedTuple{(:ctx,), Tuple{Context}},typeof(load_runtime),CompilerJob})
     Base.precompile(Tuple{typeof(lower_byval),CompilerJob,LLVM.Module,LLVM.Function})
@@ -65,4 +9,5 @@ function _precompile_()
     Base.precompile(Tuple{typeof(mangle_param),Type,Vector{String}})
     Base.precompile(Tuple{typeof(process_module!),CompilerJob{PTXCompilerTarget},LLVM.Module})
     Base.precompile(Tuple{typeof(resolve_cpu_references!),LLVM.Module})
+    precompile(emit_llvm, (CompilerJob, Core.MethodInstance, Bool, Bool, Bool, Bool))
 end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -54,7 +54,7 @@ function code_typed(@nospecialize(job::CompilerJob); interactive::Bool=false, kw
         descend_code_typed = getfield(mod, :descend_code_typed)
         descend_code_typed(job.source.f, job.source.tt; kwargs...)
     elseif VERSION >= v"1.7-"
-        interp = get_interpreter(job)
+        interp = @invokelatest get_interpreter(job)
         InteractiveUtils.code_typed(job.source.f, job.source.tt; interp, kwargs...)
     else
         InteractiveUtils.code_typed(job.source.f, job.source.tt; kwargs...)
@@ -71,7 +71,7 @@ function code_warntype(io::IO, @nospecialize(job::CompilerJob); interactive::Boo
         descend_code_warntype = getfield(mod, :descend_code_warntype)
         descend_code_warntype(job.source.f, job.source.tt; kwargs...)
     elseif VERSION >= v"1.7-"
-        interp = get_interpreter(job)
+        interp = @invokelatest get_interpreter(job)
         InteractiveUtils.code_warntype(io, job.source.f, job.source.tt; interp, kwargs...)
     else
         InteractiveUtils.code_warntype(io, job.source.f, job.source.tt; kwargs...)
@@ -119,7 +119,7 @@ See also: [`@device_code_native`](@ref), `InteractiveUtils.code_llvm`
 """
 function code_native(io::IO, @nospecialize(job::CompilerJob); raw::Bool=false, dump_module::Bool=false)
     asm, meta = codegen(:asm, job; strip=!raw, only_entry=!dump_module, validate=false)
-    highlight(io, asm, source_code(job.target))
+    highlight(io, asm, @invokelatest(source_code(job.target)))
 end
 code_native(@nospecialize(job::CompilerJob); kwargs...) =
     code_native(stdout, job; kwargs...)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -104,10 +104,11 @@ end
 function build_runtime(@nospecialize(job::CompilerJob); ctx)
     mod = LLVM.Module("GPUCompiler run-time library"; ctx)
 
+    srcmod = @invokelatest runtime_module(job)
     for method in values(Runtime.methods)
         def = if isa(method.def, Symbol)
-            isdefined(runtime_module(job), method.def) || continue
-            getfield(runtime_module(job), method.def)
+            isdefined(srcmod, method.def) || continue
+            getfield(srcmod, method.def)
         else
             method.def
         end

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -63,6 +63,9 @@ end
 
 ## functionality to build the runtime library
 
+# XXX: these APIs don't need a CompilerJob, just a Compiler, but that object causes
+#      specialization (without `@noinfer`) so we pass a wrapping CompilerJob instead.
+
 function emit_function!(mod, job::CompilerJob, f, method)
     tt = Base.to_tuple_type(method.types)
     new_mod, meta = codegen(:llvm, similar(job, FunctionSpec(f, tt, #=kernel=# false));

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -13,8 +13,8 @@ function check_method(@nospecialize(job::CompilerJob))
 
     # kernels can't return values
     if job.source.kernel
-        cache = ci_cache(job)
-        mt = method_table(job)
+        cache = @invokelatest ci_cache(job)
+        mt = @invokelatest method_table(job)
         interp = GPUInterpreter(cache, mt, job.source.world)
         rt = Base.return_types(job.source.f, job.source.tt, interp)[1]
         if rt != Nothing
@@ -208,7 +208,7 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
             ptr_val = convert(Int, ptr_arg)
             ptr = Ptr{Cvoid}(ptr_val)
 
-            if !valid_function_pointer(job, ptr)
+            if !@invokelatest(valid_function_pointer(job, ptr))
                 # look it up in the Julia JIT cache
                 frames = ccall(:jl_lookup_code_address, Any, (Ptr{Cvoid}, Cint,), ptr, 0)
                 if length(frames) >= 1

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -130,7 +130,7 @@ function check_ir!(job, errors::Vector{IRError}, f::LLVM.Function)
     return errors
 end
 
-const libjulia = Ref{Ptr{Cvoid}}(C_NULL)
+const libjulia = Ref{Ptr{Cvoid}}()
 
 function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
     bt = backtrace(inst)

--- a/test/definitions/bpf.jl
+++ b/test/definitions/bpf.jl
@@ -8,10 +8,11 @@ end
 # create a native test compiler, and generate reflection methods for it
 
 function bpf_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
-    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = BPFCompilerTarget()
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    compiler = Compiler(target, params)
+    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
+    CompilerJob(compiler, source), kwargs
 end
 
 function bpf_code_llvm(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/gcn.jl
+++ b/test/definitions/gcn.jl
@@ -8,10 +8,11 @@ end
 # create a GCN-based test compiler, and generate reflection methods for it
 
 function gcn_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
-    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    compiler = Compiler(target, params)
+    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
+    CompilerJob(compiler, source), kwargs
 end
 
 function gcn_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/native.jl
+++ b/test/definitions/native.jl
@@ -7,8 +7,6 @@ end
 
 # create a native test compiler, and generate reflection methods for it
 
-NativeCompilerJob = CompilerJob{NativeCompilerTarget,TestCompilerParams}
-
 # local method table for device functions
 @static if isdefined(Base.Experimental, Symbol("@overlay"))
 Base.Experimental.@MethodTable(method_table)
@@ -16,13 +14,14 @@ else
 const method_table = nothing
 end
 
-GPUCompiler.method_table(@nospecialize(job::NativeCompilerJob)) = method_table
+GPUCompiler.method_table(job::Compiler{NativeCompilerTarget}) = method_table
 
 function native_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
-    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = NativeCompilerTarget(always_inline=true)
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    compiler = Compiler(target, params)
+    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
+    CompilerJob(compiler, source), kwargs
 end
 
 function native_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -10,12 +10,13 @@ end
 function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                  minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
                  maxregs=nothing, kwargs...)
-    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = PTXCompilerTarget(cap=v"7.0",
                                minthreads=minthreads, maxthreads=maxthreads,
                                blocks_per_sm=blocks_per_sm, maxregs=maxregs)
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    compiler = Compiler(target, params)
+    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
+    CompilerJob(compiler, source), kwargs
 end
 
 function ptx_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/spirv.jl
+++ b/test/definitions/spirv.jl
@@ -8,10 +8,11 @@ end
 # create a SPIRV-based test compiler, and generate reflection methods for it
 
 function spirv_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
-    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = SPIRVCompilerTarget()
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    compiler = Compiler(target, params)
+    source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
+    CompilerJob(compiler, source), kwargs
 end
 
 function spirv_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/util.jl
+++ b/test/util.jl
@@ -46,4 +46,4 @@ module TestRuntime
 end
 
 struct TestCompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,TestCompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::Compiler{<:Any,TestCompilerParams}) = TestRuntime


### PR DESCRIPTION
I'm trying to make it possible to precompile most of the compiler, but it's proving to be hard. First, I removed the function from the CompilerJob, since it's otherwise too easy to invalidate the precompilation results. I think that we also have to use `@invokelatest` with all of the GPUCompiler interfaces, because even with type assertions and `@noinline` the generic implementations of the interface are referred to literally in the compiled code.

However, I'm still seeing `emit_llvm` getting re-compiled when using CUDA.jl, even though I don't immediately spot invalidations that would explain this (is it possible to go backwards -- start from a method that got invalidated to find the definition that invalidated it?).
Strangely, the method instance also lists the specific compiler target, even though `job` is passed as `@nospecialize` in `emit_llvm`...

```
MethodInstance for GPUCompiler.emit_llvm(::GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}, ::Core.MethodInstance, ::Bool, ::Bool, ::Bool, ::Bool)
```