### PR TITLE
Use byval with type on LLVM 12.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -176,7 +176,12 @@ function process_entry!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
         args = classify_arguments(job, entry)
         for arg in args
             if arg.cc == BITS_REF
-                push!(parameter_attributes(entry, arg.codegen.i), EnumAttribute("byval", 0; ctx))
+                attr = if LLVM.version() >= v"12"
+                    TypeAttribute("byval", eltype(arg.codegen.typ); ctx)
+                else
+                    EnumAttribute("byval", 0; ctx)
+                end
+                push!(parameter_attributes(entry, arg.codegen.i), attr)
             end
         end
     end

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -185,7 +185,11 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry_f::
             param = parameters(wrapper_f)[arg.codegen.i]
             attrs = parameter_attributes(wrapper_f, arg.codegen.i)
             if arg.cc == BITS_REF
-                push!(attrs, EnumAttribute("byval", 0; ctx))
+                if LLVM.version() >= v"12"
+                    push!(attrs, TypeAttribute("byval", eltype(arg.codegen.typ); ctx))
+                else
+                    push!(attrs, EnumAttribute("byval", 0; ctx))
+                end
                 ptr = struct_gep!(builder, param, 0)
                 push!(wrapper_args, ptr)
             else


### PR DESCRIPTION
The BitcodeWriter on LLVM 12 assumes that `byval` has its type set, e.g., https://github.com/llvm/llvm-project/blob/77ebfba68b9aa89e9ccbcdf8e285afa0661c8ca4/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp#L1068-L1069 otherwise results in a nullpointer assertion / segfault:

```
julia: /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/Support/Casting.h:104: static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::StructType; From = llvm::Type]: Assertion `Val && "isa<> used on a null pointer"' failed.

signal (6): Aborted
in expression starting at /home/tim/Julia/pkg/GPUCompiler/wip.jl:19
gsignal at /usr/lib/libc.so.6 (unknown line)
abort at /usr/lib/libc.so.6 (unknown line)
__assert_fail_base.cold at /usr/lib/libc.so.6 (unknown line)
__assert_fail at /usr/lib/libc.so.6 (unknown line)
doit at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/Support/Casting.h:104
doit at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/ADT/DenseMap.h:653 [inlined]
doit at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/Support/Casting.h:131 [inlined]
doit at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/Support/Casting.h:122 [inlined]
isa<llvm::StructType, llvm::Type*> at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/Support/Casting.h:143 [inlined]
dyn_cast<llvm::StructType, llvm::Type> at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/include/llvm/Support/Casting.h:345 [inlined]
EnumerateType at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/ValueEnumerator.cpp:910
incorporateFunction at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/ValueEnumerator.cpp:1004
writeFunction at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/BitcodeWriter.cpp:3266 [inlined]
write at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/BitcodeWriter.cpp:4398 [inlined]
writeModule at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/BitcodeWriter.cpp:4575
WriteBitcodeToFile at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/BitcodeWriter.cpp:4601
LLVMWriteBitcodeToFD at /home/tim/Julia/src/julia/deps/srccache/llvm-12.0.0/lib/Bitcode/Writer/BitWriter.cpp:35
```

That's probably an LLVM bug, but specifying the `byval` type works around it.