### PR TITLE
More fixes for the SPIRV compiler

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -189,9 +189,6 @@ function process_entry!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
     return entry
 end
 
-# post-Julia optimization processing of the module
-optimize_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
-
 # final processing of the IR module, right before validation and machine-code generation
 finish_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
 
@@ -219,3 +216,7 @@ function llvm_debug_info(@nospecialize(job::CompilerJob))
         LLVM.API.LLVMDebugEmissionKindFullDebug
     end
 end
+
+# optimization
+optimization_params(@nospecialize(job::CompilerJob)) = GPUOptimizationParams()
+optimize_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -189,6 +189,9 @@ function process_entry!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
     return entry
 end
 
+# post-Julia optimization processing of the module
+optimize_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
+
 # final processing of the IR module, right before validation and machine-code generation
 finish_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
 
@@ -216,7 +219,3 @@ function llvm_debug_info(@nospecialize(job::CompilerJob))
         LLVM.API.LLVMDebugEmissionKindFullDebug
     end
 end
-
-# optimization
-optimization_params(@nospecialize(job::CompilerJob)) = GPUOptimizationParams()
-optimize_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -62,14 +62,6 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module)
     end
 end
 
-# the LLVM to SPIRV translator does not support optimized LLVM IR
-# (KhronosGroup/SPIRV-LLVM-Translator#203). however, not optimizing at all
-# doesn't work either, as we then don't even run the alloc optimizer (resulting
-# in many calls to gpu_alloc that spirv-opt cannot remove) or even 'invalid IR'
-# like casts to addrspace-less pointers (which aren't allowed in SPIR-V).
-optimization_params(@nospecialize(job::CompilerJob{SPIRVCompilerTarget})) =
-    GPUOptimizationParams(; optlevel=1)
-
 @unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
                          format=LLVM.API.LLVMAssemblyFile)
     # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -62,6 +62,14 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module)
     end
 end
 
+# the LLVM to SPIRV translator does not support optimized LLVM IR
+# (KhronosGroup/SPIRV-LLVM-Translator#203). however, not optimizing at all
+# doesn't work either, as we then don't even run the alloc optimizer (resulting
+# in many calls to gpu_alloc that spirv-opt cannot remove) or even 'invalid IR'
+# like casts to addrspace-less pointers (which aren't allowed in SPIR-V).
+optimization_params(@nospecialize(job::CompilerJob{SPIRVCompilerTarget})) =
+    GPUOptimizationParams(; optlevel=1)
+
 @unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
                          format=LLVM.API.LLVMAssemblyFile)
     # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -64,6 +64,9 @@ end
 
 @unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
                          format=LLVM.API.LLVMAssemblyFile)
+    # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...
+    strip_debuginfo!(mod)
+
     # write the bitcode to a temporary file (the SPIRV Translator library doesn't have a C API)
     mktemp() do input, input_io
         write(input_io, mod)
@@ -92,14 +95,6 @@ end
 
 # reimplementation that uses `spirv-dis`, giving much more pleasant output
 function code_native(io::IO, job::CompilerJob{SPIRVCompilerTarget}; raw::Bool=false, dump_module::Bool=false)
-    if raw
-        # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...
-        # so just return what LLVM gives us in that case (which is also more faithful).
-        asm, _ = codegen(:asm, job; strip=false, only_entry=!dump_module, validate=false)
-        print(io, asm)
-        return
-    end
-
     obj, _ = codegen(:obj, job; strip=!raw, only_entry=!dump_module, validate=false)
     mktemp() do input_path, input_io
         write(input_io, obj)


### PR DESCRIPTION
This PR contains 1.7-related fixes for the SPIR-V backend, which includes maintaining our own optimization pipeline so that we can disable the SLP vectorizer (which generates code that the SPIR-V toolchain doesn't support, but generally also isn't very useful for scalar GPU code). The pipeline is copied over from Enzyme.jl, but with some changes to get us back at performance parity (cc @vchuravy, the VolumeRHS integration test from CUDA.jl showed significant additional register pressure).