### PR TITLE
1.8 compatibility.

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -196,7 +196,8 @@ struct GPUInterpreter <: AbstractInterpreter
 
             # parameters for inference and optimization
             InferenceParams(unoptimize_throw_blocks=false),
-            OptimizationParams(unoptimize_throw_blocks=false),
+            VERSION >= v"1.8.0-DEV.486" ? OptimizationParams() :
+                                          OptimizationParams(unoptimize_throw_blocks=false),
         )
     end
 end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/42149 has deleted an `OptimizationParam` we were using.