### PR TITLE
Add Enzyme.jl to the reverse testing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,6 +67,27 @@ steps:
     soft_fail:
       - exit_status: 1
 
+  - label: "Enzyme.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: 1.6
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+      julia -e 'using Pkg;
+
+                println("--- :julia: Instantiating project");
+                Pkg.develop(PackageSpec(path=pwd()));
+                Pkg.add(PackageSpec(name="Enzyme", rev="master"));
+                Pkg.build();
+
+                println("+++ :julia: Running tests");
+                Pkg.test("Enzyme"; coverage=true);'
+    agents:
+      queue: "juliagpu"
+    if: build.message !~ /\[skip tests\]/
+    timeout_in_minutes: 60
+
 env:
   JULIA_PKG_SERVER: "" # it often struggles with our large artifacts
   SECRET_CODECOV_TOKEN: "ya+qhtTvHdnO/U1KSoTcdCRB4WCCFU7Or2wt7YlzSZJWqITbLxidDfvqxTMG0mPo6M9I2XW6GULCleA9okq06reF5//14WSmxiF8qPwBONj6m+ImdkLpju2FfLCAtISFJYRM5OJRdDuQ5hKz+FyNoDG/jWBm/vrHoXzrVOHpcHGOPvrEtSwkdo8ew0prFq5RTi6c0Pe+Vj+xRMH7o8QhIPisYUd4RWsA/BL3ukxqSSzpU1+ZJ4F5v6eZILSaKSPb04FzpotkbH+UUCvJSn28Cif+JQANJ9HDLgaa1BbSlOAcu7syktS2fJOyOTfE67er9Lu8utqz6973Evnqjfbclw==;U2FsdGVkX19sIzsESyU7ZuRndlTrQy67iOsrPzevxn+W/dWZBd3ds5Soh1ig5ivoUi4tLZrqUv/ZyPIHohVy0A=="


### PR DESCRIPTION
Enzyme.jl makes heavy use of the GPUCompiler infrastructure
and it would be helpful for us to make sure that changes in
GPUCompiler don't break Enzyme.jl unexpectedly.

Both I and @wsmoses are happy to help maintenance.
