### PR TITLE
Perform late optimization, after deferred codegen and byval lowering.

### DIFF
--- a/test/util.jl
+++ b/test/util.jl
@@ -35,7 +35,9 @@ end
 module TestRuntime
     # dummy methods
     signal_exception() = return
-    malloc(sz) = C_NULL
+    # HACK: if malloc returns 0 or traps, all calling functions (like jl_box_*)
+    #       get reduced to a trap, which really messes with our test suite.
+    malloc(sz) = Ptr{Cvoid}(Int(0xDEADBEEF))
     report_oom(sz) = return
     report_exception(ex) = return
     report_exception_name(ex) = return


### PR DESCRIPTION
Without it, the manual byval lowering generates really slow code, so this PR fixes a huge regression in CUDA.jl after https://github.com/JuliaGPU/GPUCompiler.jl/pull/236.

There's something wrong with the native LazyCodegen tests though. The deferred kernel isn't in the module anymore:

```julia
julia> using Test, GPUCompiler

julia> include("test/definitions/native.jl")

julia> import .LazyCodegen: call_delayed

julia> global flag = Ref(false) # otherwise f is a closure and we can't
Base.RefValue{Bool}(false)

julia> # pass it to `Val`...
       f() = (flag[]=true; nothing)
f (generic function with 1 method)

julia> function caller()
           call_delayed(f)
       end
caller (generic function with 1 method)

julia> @test caller() === nothing
Test Passed
  Expression: caller() === nothing
   Evaluated: nothing === nothing

julia> @test flag[]
Test Passed
  Expression: flag[]

julia> native_code_llvm(caller, Tuple{}, dump_module=true)
```
```llvm
; ModuleID = 'text'
source_filename = "text"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu"

;  @ REPL[5]:1 within `caller`
; Function Attrs: alwaysinline
define void @julia_caller_1294() local_unnamed_addr #0 {
top:
  %0 = alloca {}*, i32 2, align 8
;  @ REPL[5]:2 within `caller`
; ┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:309 within `call_delayed`
; │┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:243 within `abi_call`
; ││┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:300 within `macro expansion`
; │││┌ @ REPL[4]:2 within `f`
      %1 = load atomic {}*, {}** inttoptr (i64 140565617453160 to {}**) unordered, align 8
      %2 = getelementptr inbounds {}*, {}** %0, i32 0
      store {}* %1, {}** %2, align 8
      %3 = getelementptr inbounds {}*, {}** %0, i32 1
      store {}* inttoptr (i64 140565428594192 to {}*), {}** %3, align 8
      %4 = call nonnull {}* @jl_apply_generic({}* inttoptr (i64 140565481952384 to {}*), {}** %0, i32 2)
; └└└└
  ret void
}

declare nonnull {}* @jl_apply_generic({}*, {}**, i32) local_unnamed_addr #1

attributes #0 = { alwaysinline "probe-stack"="inline-asm" }
attributes #1 = { "thunk" }

!llvm.module.flags = !{!0, !1}

!0 = !{i32 2, !"Dwarf Version", i32 4}
!1 = !{i32 2, !"Debug Info Version", i32 3}
```

LLVM is right to remove this function though (that is, we instruct it to, but `julia_f` is really unused). This is the IR before this change:

```llvm
; ModuleID = 'text'
source_filename = "text"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu"

;  @ REPL[41]:1 within `caller`
; Function Attrs: alwaysinline
define void @julia_caller_1811() local_unnamed_addr #0 {
top:
  %0 = alloca [2 x {}*], align 8
  %1 = bitcast [2 x {}*]* %0 to i8*
  call void @llvm.lifetime.start.p0i8(i64 16, i8* %1)
  %.sub.i = getelementptr inbounds [2 x {}*], [2 x {}*]* %0, i64 0, i64 0
;  @ REPL[41]:2 within `caller`
; ┌ @ REPL[37]:247 within `call_delayed`
; │┌ @ REPL[37]:181 within `abi_call`
; ││┌ @ REPL[37]:238 within `macro expansion`
; │││┌ @ REPL[40]:2 within `f`
      %2 = load atomic {}*, {}** inttoptr (i64 140066947351080 to {}**) unordered, align 8
      store {}* %2, {}** %.sub.i, align 8
      %3 = getelementptr inbounds [2 x {}*], [2 x {}*]* %0, i64 0, i64 1
      store {}* inttoptr (i64 140068397913616 to {}*), {}** %3, align 8
      %4 = call nonnull {}* @jl_apply_generic({}* nonnull inttoptr (i64 140068451271808 to {}*), {}** nonnull %.sub.i, i32 2)
      call void @llvm.lifetime.end.p0i8(i64 16, i8* %1)
; └└└└
  ret void
}

; Function Attrs: nofree nosync nounwind willreturn
declare void @llvm.assume(i1 noundef) #1

;  @ REPL[40]:2 within `f`
; Function Attrs: alwaysinline
define void @julia_f_2026() local_unnamed_addr #0 {
top:
  %0 = alloca [2 x {}*], align 8
  %.sub = getelementptr inbounds [2 x {}*], [2 x {}*]* %0, i64 0, i64 0
  %1 = load atomic {}*, {}** inttoptr (i64 140066947351080 to {}**) unordered, align 8
  store {}* %1, {}** %.sub, align 8
  %2 = getelementptr inbounds [2 x {}*], [2 x {}*]* %0, i64 0, i64 1
  store {}* inttoptr (i64 140068397913616 to {}*), {}** %2, align 8
  %3 = call nonnull {}* @jl_apply_generic({}* nonnull inttoptr (i64 140068451271808 to {}*), {}** nonnull %.sub, i32 2)
  ret void
}

declare nonnull {}* @jl_apply_generic({}*, {}**, i32) local_unnamed_addr #2

; Function Attrs: argmemonly nofree nosync nounwind willreturn
declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #3

; Function Attrs: argmemonly nofree nosync nounwind willreturn
declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #3

attributes #0 = { alwaysinline "probe-stack"="inline-asm" }
attributes #1 = { nofree nosync nounwind willreturn }
attributes #2 = { "thunk" }
attributes #3 = { argmemonly nofree nosync nounwind willreturn }

!llvm.module.flags = !{!0, !1}

!0 = !{i32 2, !"Dwarf Version", i32 4}
!1 = !{i32 2, !"Debug Info Version", i32 3}
```

i.e. `julia_caller` has `f` inlined into it. How does that even happen? I'm not sure what you meant to test here, @vchuravy, but if the deferred kernel is inlined it shouldn't be part of the module anymore, right? Could you fix this test?