### PR TITLE
Fixes for late optimization of kernel state arguments

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -194,6 +194,10 @@ const __llvm_initialized = Ref(false)
         run!(pm, ir)
     end
 
+    # finalize the current module. this needs to happen before linking deferred modules,
+    # since those modules have been finalized themselves, and we don't want to re-finalize.
+    entry = finish_module!(job, ir, entry)
+
     # deferred code generation
     do_deferred_codegen = !only_entry && deferred_codegen &&
                           haskey(functions(ir), "deferred_codegen")
@@ -257,8 +261,6 @@ const __llvm_initialized = Ref(false)
     end
 
     @timeit_debug to "IR post-processing" begin
-        entry = finish_module!(job, ir, entry)
-
         # some early clean-up to reduce the amount of code to optimize
         @timeit_debug to "clean-up" begin
             ModulePassManager() do pm

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -307,17 +307,6 @@ const __llvm_initialized = Ref(false)
             end
         end
 
-        # remove the kernel state dummy use
-        if haskey(functions(ir), "julia.gpu.state_user")
-            dummy_user = functions(ir)["julia.gpu.state_user"]
-            for use in uses(dummy_user)
-                call = user(use)
-                unsafe_delete!(LLVM.parent(call), call)
-            end
-            @assert isempty(uses(dummy_user))
-            unsafe_delete!(ir, dummy_user)
-        end
-
         if ccall(:jl_is_debugbuild, Cint, ()) == 1
             @timeit_debug to "verification" verify(ir)
         end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -205,20 +205,8 @@ function finish_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry
     entry_fn = LLVM.name(entry)
 
     # add the kernel state, and lower calls to the `julia.gpu.state_getter` intrinsic.
-    # we do this _after_ optimization, because the runtime is linked after optimization too.
     if job.source.kernel
-        state = kernel_state_type(job)
-        if state !== Nothing
-            T_state = convert(LLVMType, state; ctx)
-            add_kernel_state!(job, mod, entry, T_state)
-        end
-
-        # don't pass the state when unnecessary
-        # XXX: only apply in add_kernel_state! when needed?
-        ModulePassManager() do pm
-            dead_arg_elimination!(pm)
-            run!(pm, mod)
-        end
+        add_kernel_state!(job, mod, entry)
     end
 
     return functions(mod)[entry_fn]

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -606,9 +606,9 @@ function add_kernel_state!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
         # use a value materializer for replacing uses of the function in constants
         function materializer(val)
             if val isa LLVM.ConstantExpr && opcode(val) == LLVM.API.LLVMPtrToInt
-                val = operands(val)[1]
-                if haskey(workmap, val)
-                    return LLVM.const_ptrtoint(workmap[val], llvmtype(val))
+                src = operands(val)[1]
+                if haskey(workmap, src)
+                    return LLVM.const_ptrtoint(workmap[src], llvmtype(val))
                 end
             end
             return val

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -726,11 +726,6 @@ function lower_kernel_state!(fun::LLVM.Function)
     changed = false
 
     # check if we even need a kernel state argument
-    if !job.source.kernel
-        # only kernels have had a kernel state argument added
-        # XXX: for consistency, also add the state to non-kernel compilation jobs?
-        return false
-    end
     state = kernel_state_type(job)
     if state === Nothing
         return false

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -572,7 +572,7 @@ function add_kernel_state!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
     state_intr = if haskey(functions(mod), "julia.gpu.state_getter")
         functions(mod)["julia.gpu.state_getter"]
     else
-        LLVM.Function(mod, "julia.gpu.state_getter", LLVM.FunctionType(T_int8))
+        LLVM.Function(mod, "julia.gpu.state_getter", LLVM.FunctionType(T_pint8))
     end
     push!(function_attributes(state_intr), EnumAttribute("readnone", 0; ctx))
 
@@ -709,7 +709,7 @@ function add_kernel_state!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
             f = LLVM.parent(bb)
 
             state = parameters(f)[1]
-            state = bitcast!(builder, state, T_int8)
+            state = bitcast!(builder, state, T_pint8)
             replace_uses!(inst, state)
 
             @assert isempty(uses(inst))

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -185,6 +185,7 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
         # GC lowering is the last pass that may introduce calls to the runtime library,
         # and thus additional uses of the kernel state.
         add!(pm, FunctionPass("LowerKernelState", lower_kernel_state!))
+        add!(pm, ModulePass("CleanupKernelState", cleanup_kernel_state!))
 
         # remove dead uses of ptls
         aggressive_dce!(pm)

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -182,10 +182,12 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
 
         add!(pm, FunctionPass("LowerGCFrame", lower_gc_frame!))
 
-        # GC lowering is the last pass that may introduce calls to the runtime library,
-        # and thus additional uses of the kernel state.
-        add!(pm, FunctionPass("LowerKernelState", lower_kernel_state!))
-        add!(pm, ModulePass("CleanupKernelState", cleanup_kernel_state!))
+        if job.source.kernel
+            # GC lowering is the last pass that may introduce calls to the runtime library,
+            # and thus additional uses of the kernel state intrinsic.
+            add!(pm, FunctionPass("LowerKernelState", lower_kernel_state!))
+            add!(pm, ModulePass("CleanupKernelState", cleanup_kernel_state!))
+        end
 
         # remove dead uses of ptls
         aggressive_dce!(pm)
@@ -222,7 +224,9 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     ModulePassManager() do pm
         addTargetPasses!(pm, tm, triple)
 
-        dead_arg_elimination!(pm)   # parent doesn't use return value --> ret void
+        # - remove unused kernel state arguments
+        # - simplify function calls that don't use the returned value
+        dead_arg_elimination!(pm)
 
         run!(pm, mod)
     end

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -182,6 +182,10 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
 
         add!(pm, FunctionPass("LowerGCFrame", lower_gc_frame!))
 
+        # GC lowering is the last pass that may introduce calls to the runtime library,
+        # and thus additional uses of the kernel state.
+        add!(pm, FunctionPass("LowerKernelState", lower_kernel_state!))
+
         # remove dead uses of ptls
         aggressive_dce!(pm)
         add!(pm, ModulePass("LowerPTLS", lower_ptls!))

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -118,6 +118,11 @@ end
 function build_runtime(@nospecialize(job::CompilerJob); ctx)
     mod = LLVM.Module("GPUCompiler run-time library"; ctx)
 
+    # the compiler job passed into here is identifies the job that requires the runtime.
+    # derive a job that represents the runtime itself (notably with kernel=false).
+    source = FunctionSpec(identity, Tuple{Nothing}, false, nothing, job.source.world_age)
+    job = CompilerJob(job.target, source, job.params)
+
     for method in values(Runtime.methods)
         def = if isa(method.def, Symbol)
             isdefined(runtime_module(job), method.def) || continue

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -33,11 +33,19 @@ struct RuntimeMethodInstance
     llvm_name::String
 end
 
-function Base.convert(::Type{LLVM.FunctionType}, rt::RuntimeMethodInstance; ctx::LLVM.Context)
+function Base.convert(::Type{LLVM.FunctionType}, rt::RuntimeMethodInstance;
+                      ctx::LLVM.Context, state::Type=Nothing)
     types = if rt.llvm_types === nothing
         LLVMType[convert(LLVMType, typ; ctx, allow_boxed=true) for typ in rt.types]
     else
         rt.llvm_types(ctx)
+    end
+
+    # if we're running post-optimization, prepend the kernel state to the argument list
+    if state !== Nothing
+        T_state = convert(LLVMType, state; ctx)
+        T_ptr_state = LLVM.PointerType(T_state)
+        pushfirst!(types, T_ptr_state)
     end
 
     return_type = if rt.llvm_return_type === nothing

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -92,7 +92,11 @@ end
     # state should only passed to device functions that use it
 
     @eval @noinline kernel_state_child1(ptr) = unsafe_load(ptr)
-    @eval @noinline kernel_state_child2() = ptx_kernel_state().data
+    @eval @noinline function kernel_state_child2()
+        data = ptx_kernel_state().data
+        ptr = reinterpret(Ptr{Int}, data)
+        unsafe_load(ptr)
+    end
 
     function kernel(ptr)
         unsafe_store!(ptr, kernel_state_child1(ptr) + kernel_state_child2())


### PR DESCRIPTION
Turns out there were a bunch of issues with a couple of my recent PRs.

---

When we `ccall` a function that we may later link (i.e. it's a real definition, not just a declaration) we might end up with IR that relies on a bitcast:

```llvm
  call void bitcast (void (double, double*, double*)* @__nv_sincos.stateless to void (double, i64, i64)*)(double %78, i64 %74, i64 %77) [ "jl_roots"({} addrspace(10)* %70, {} addrspace(10)* %65, double addrspace(11)* %8) ]
```

These weren't rewritten properly.

---

With late optimization, we're lowering calls to `julia.gc_pool_alloc` after the kernel state argument has been added. We need to take that into account, and manually add the kernel state argument. It's not easy to access that argument though, since the `julia.gpu.kernel_state_getter` intrinsic has already been lowered. We also can't just look at the first argument, because (even though dead arg elimination hasn't run yet), the pointer argument may have been eagerly lowered to a byval argument. To hack around this, we add a dummy use of the state argument (before byval lowering) so that we're sure to have the kernel state in a stack slot. This only occurs in the kernel function, called functions do have a pointer to the kernel state as first argument.

---

We were also mixing opaque and typed versions of the kernel state intrinsic. I guess we should enable IR verification on CI to catch these.