### PR TITLE
More kernel state optimizations

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,15 +39,17 @@ version = "1.3.0"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "756cd7ea042f82962d8d46e378c0f1863bb4dc0f"
+git-tree-sha1 = "46092047ca4edc10720ecab437c42283cd7c44f3"
+repo-rev = "master"
+repo-url = "https://github.com/maleadt/LLVM.jl.git"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.5.3"
+version = "4.6.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9c360e5ce980b88bb31a7b086dbb19469008154b"
+git-tree-sha1 = "6a2af408fe809c4f1a54d2b3f188fdd3698549d6"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.10+0"
+version = "0.0.11+0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -122,7 +122,8 @@ function lower_throw_extra!(mod::LLVM.Module)
                     end
 
                     # remove the call
-                    call_args = operands(call)[1:end-1] # last arg is function itself
+                    nargs = length(parameters(f))
+                    call_args = arguments(call)
                     unsafe_delete!(LLVM.parent(call), call)
 
                     # HACK: kill the exceptions' unused arguments

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -195,7 +195,7 @@ function lower_throw!(mod::LLVM.Module)
                 end
 
                 # remove the call
-                call_args = operands(call)[1:end-1] # last arg is function itself
+                call_args = arguments(call)
                 unsafe_delete!(LLVM.parent(call), call)
 
                 # HACK: kill the exceptions' unused arguments
@@ -659,7 +659,7 @@ function add_kernel_state!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
                     untyped_state = call!(builder, state_intr, Value[], "state")
                     typed_state = bitcast!(builder, untyped_state, T_ptr_state)
                     new_val = if val isa LLVM.CallInst
-                        call!(builder, new_f, [typed_state, operands(val)[1:end-1]...])
+                        call!(builder, new_f, [typed_state, arguments(val)...], operand_bundles(val))
                     else
                         # TODO: invoke and callbr
                         error("Rewrite of $(typeof(val))-based calls is not implemented: $val")

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -262,7 +262,7 @@ function lower_gc_frame!(fun::LLVM.Function)
             call = user(use)::LLVM.CallInst
 
             # decode the call
-            ops = operands(call)
+            ops = arguments(call)
             sz = ops[2]
 
             # replace with PTX alloc_obj

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -49,12 +49,10 @@ function LLVM.call!(builder, rt::Runtime.RuntimeMethodInstance, args=LLVM.Value[
     args = Value[args...]
     if state !== Nothing
         T_state = convert(LLVMType, state; ctx)
-        T_ptr_state = LLVM.PointerType(T_state)
 
-        state_intr = kernel_state_intr(mod)
-        untyped_state = call!(builder, state_intr, Value[], "state")
-        typed_state = bitcast!(builder, untyped_state, T_ptr_state)
-        pushfirst!(args, typed_state)
+        state_intr = kernel_state_intr(mod, T_state)
+        state_val = call!(builder, state_intr, Value[], "state")
+        pushfirst!(args, state_val)
     end
 
     # runtime functions are written in Julia, while we're calling from LLVM,

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -44,8 +44,7 @@ function Base.convert(::Type{LLVM.FunctionType}, rt::RuntimeMethodInstance;
     # if we're running post-optimization, prepend the kernel state to the argument list
     if state !== Nothing
         T_state = convert(LLVMType, state; ctx)
-        T_ptr_state = LLVM.PointerType(T_state)
-        pushfirst!(types, T_ptr_state)
+        pushfirst!(types, T_state)
     end
 
     return_type = if rt.llvm_return_type === nothing

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -141,7 +141,7 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
         fn = LLVM.name(dest)
 
         # some special handling for runtime functions that we don't implement
-        if fn == "jl_get_binding_or_error"
+        if fn == "jl_get_binding_or_error" || fn == "ijl_get_binding_or_error"
             try
                 m, sym = arguments(inst)
                 sym = first(operands(sym::ConstantExpr))::ConstantInt
@@ -153,7 +153,7 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
                 @debug "Decoding arguments to jl_get_binding_or_error failed" inst bb=LLVM.parent(inst)
                 push!(errors, (DELAYED_BINDING, bt, nothing))
             end
-        elseif fn == "jl_invoke"
+        elseif fn == "jl_invoke" || fn == "ijl_invoke"
             try
                 f, args, nargs, meth = arguments(inst)
                 meth = first(operands(meth::ConstantExpr))::ConstantInt
@@ -165,7 +165,7 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
                 @debug "Decoding arguments to jl_invoke failed" inst bb=LLVM.parent(inst)
                 push!(errors, (DYNAMIC_CALL, bt, nothing))
             end
-        elseif fn == "jl_apply_generic"
+        elseif fn == "jl_apply_generic" || fn == "ijl_apply_generic"
             try
                 f, args, nargs = arguments(inst)
                 f = first(operands(f))::ConstantInt # get rid of inttoptr

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -13,8 +13,7 @@ struct PTXKernelState
     data::Int64
 end
 GPUCompiler.kernel_state_type(@nospecialize(job::PTXCompilerJob)) = PTXKernelState
-ptx_kernel_state() =
-    unsafe_load(convert(Ptr{PTXKernelState}, GPUCompiler.kernel_state_pointer()))
+@inline @generated ptx_kernel_state() = GPUCompiler.kernel_state_value(PTXKernelState)
 
 # a version of the test runtime that has some side effects, loading the kernel state
 # (so that we can test if kernel state arguments are appropriately optimized away)
@@ -22,10 +21,8 @@ module PTXTestRuntime
     using ..GPUCompiler
     import ..PTXKernelState
 
-    kernel_state() = unsafe_load(convert(Ptr{PTXKernelState}, GPUCompiler.kernel_state_pointer()))
-
     function signal_exception()
-        kernel_state()
+        ptx_kernel_state()
         return
     end
 

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -113,7 +113,7 @@ end
     @test occursin(r"@.*child1.+\(i64", ir)
 
     # child2 does
-    @test occursin(r"@.*child2.+\(\[1 x i64\]\* %state", ir)
+    @test occursin(r"@.*child2.+\(\[1 x i64\] %state", ir)
 
     # can't have the unlowered intrinsic
     @test !occursin("julia.gpu.state_getter", ir)


### PR DESCRIPTION
LLVM/NVPTX doesn't like how we pass the kernel state object by reference, and marking it `readonly byval` doesn't currently help. Awaiting better fixes, let's just pass the object by value right now.