### PR TITLE
Add additional optimization passes.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,15 +39,17 @@ version = "1.3.0"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "46092047ca4edc10720ecab437c42283cd7c44f3"
+git-tree-sha1 = "7cc22e69995e2329cc047a879395b2b74647ab5f"
+repo-rev = "6998bf4"
+repo-url = "https://github.com/maleadt/LLVM.jl.git"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.6.0"
+version = "4.7.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "6a2af408fe809c4f1a54d2b3f188fdd3698549d6"
+git-tree-sha1 = "9436f02a0c9f726d914cc6539f87850701be18fc"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.11+0"
+version = "0.0.12+0"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "4.6"
+LLVM = "4.7"
 TimerOutputs = "0.5"
 julia = "1.6"
 

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -13,17 +13,6 @@ function addOptimizationPasses!(pm, opt_level=2)
     #      pm, opt_level, #=lower_intrinsics=# 0)
     #return
 
-    # compate to Clang by using the pass manager builder APIs:
-    #LLVM.clopts("-print-after-all", "-filter-print-funcs=$(LLVM.name(entry))")
-    #ModulePassManager() do pm
-    #    add_library_info!(pm, triple(mod))
-    #    add_transform_info!(pm, tm)
-    #    PassManagerBuilder() do pmb
-    #        populate!(pm, pmb)
-    #    end
-    #    run!(pm, mod)
-    #end
-
     # NOTE: LLVM 12 disabled the hoisting of common instruction
     #       before loop vectorization (https://reviews.llvm.org/D84108).
     #
@@ -106,6 +95,7 @@ function addOptimizationPasses!(pm, opt_level=2)
     loop_unswitch!(pm)
     licm!(pm)
     julia_licm!(pm)
+    inductive_range_check_elimination!(pm)
     # Subsequent passes not stripping metadata from terminator
     instruction_simplify!(pm)
     ind_var_simplify!(pm)
@@ -230,6 +220,17 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
 
         run!(pm, mod)
     end
+
+    # compare to Clang by using the pass manager builder APIs:
+    #LLVM.clopts("-print-after-all", "-filter-print-funcs=$(LLVM.name(entry))")
+    #ModulePassManager() do pm
+    #    addTargetPasses!(pm, tm, triple)
+    #    PassManagerBuilder() do pmb
+    #        optlevel!(pmb, 2)
+    #        populate!(pm, pmb)
+    #    end
+    #    run!(pm, mod)
+    #end
 
     return
 end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -148,6 +148,9 @@ function optimize_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
         add_library_info!(pm, triple(mod))
         add_transform_info!(pm, tm)
 
+        # needed by GemmKernels.jl-like code
+        speculative_execution_if_has_branch_divergence!(pm)
+
         # NVPTX's target machine info enables runtime unrolling,
         # but Julia's pass sequence only invokes the simple unroller.
         loop_unroll!(pm)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/256, and adds a pass that deals with the regression from https://github.com/JuliaGPU/GemmKernels.jl/pull/83 as noted in https://github.com/JuliaGPU/GemmKernels.jl/pull/85.
Depends on https://github.com/maleadt/LLVM.jl/pull/272.

cc @thomasfaingnaert @vchuravy 