### PR TITLE
Allow caller of classify_argument to specify that the first arg is sret

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -287,14 +287,14 @@ end
     GHOST       # not passed
 end
 
-function classify_arguments(@nospecialize(job::CompilerJob), codegen_ft::LLVM.FunctionType)
+function classify_arguments(@nospecialize(job::CompilerJob), codegen_ft::LLVM.FunctionType, has_sret=false)
     source_sig = Base.signature_type(job.source.f, job.source.tt)::Type
     source_types = [source_sig.parameters...]
 
     codegen_types = parameters(codegen_ft)
 
     args = []
-    codegen_i = 1
+    codegen_i = 1 + has_sret
     for (source_i, source_typ) in enumerate(source_types)
         if isghosttype(source_typ) || Core.Compiler.isconstType(source_typ)
             push!(args, (cc=GHOST, typ=source_typ))

--- a/test/native.jl
+++ b/test/native.jl
@@ -361,4 +361,22 @@ end
 
 ############################################################################################
 
+@testset "classify_arguments" begin
+    f_sret(x) = (x, x)
+    job, _ = native_job(f_sret, Tuple{Float64})
+    _, meta = GPUCompiler.compile(:llvm, job)
+    ft = LLVM.eltype(LLVM.llvmtype(meta.entry))
+
+    sret = EnumAttribute("sret"; ctx=context(ft))
+    attrs = collect(parameter_attributes(meta.entry, 1))
+    has_sret = any(attr->kind(attr)==kind(sret), attrs)
+
+    @test has_sret
+
+    classification = GPUCompiler.classify_arguments(job, ft, has_sret)
+    @test length(classification) == 2
+    @test classification[1].typ == typeof(f_sret)
+    @test classification[2].typ == Float64
+end
+
 end


### PR DESCRIPTION
`classify_arguments` uses the function type so it can't do that
determination on it's own.

cc: @wsmoses
