### PR TITLE
Add `code_typed(::InvalidIRError)` etc.

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -79,6 +79,10 @@ function code_warntype(io::IO, @nospecialize(job::CompilerJob); interactive::Boo
 end
 code_warntype(@nospecialize(job::CompilerJob); kwargs...) = code_warntype(stdout, job; kwargs...)
 
+InteractiveUtils.code_lowered(err::InvalidIRError; kwargs...) = code_lowered(err.job; kwargs...)
+InteractiveUtils.code_typed(err::InvalidIRError; kwargs...) = code_typed(err.job; kwargs...)
+InteractiveUtils.code_warntype(err::InvalidIRError; kwargs...) = code_warntype(err.job; kwargs...)
+
 """
     code_llvm([io], job; optimize=true, raw=false, dump_module=false)
 

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -101,6 +101,14 @@ function Base.showerror(io::IO, err::InvalidIRError)
         end
         Base.show_backtrace(io, bt)
     end
+    println(io)
+    printstyled(io, "HINT"; bold = true, color = :cyan)
+    printstyled(
+        io,
+        ": catch this exception as `err` and call `code_typed(err; interactive = true)` to",
+        " introspect the erronous code";
+        color = :cyan,
+    )
     return
 end
 


### PR DESCRIPTION
When a GPU kernel is behind some pre-processing code on the host, it's rather cumbersome to use introspection tools on the device code. But, since `InvalidIRError` includes a `CompilerJob`, I can simply call `GPUCompiler.code_typed(err.job)` if I catch `InvalidIRError` as `err`. I like this workflow since I can rapidly iterate over my code to make it compilable.

This PR implements thin wrappers of `GPUCompiler.code_typed(err.job)` etc. as `Interactive.code_typed(err::InvalidIRError)` etc.. I think it's nice to make it easily invokable by extending `InteractiveUtils.code_typed` since users typically don't have GPUCompiler as a direct dependency (and then importing GPUCompiler is a bit tricky; e.g., `using CUDA.GPUCompiler`). Furthermore, I think it's nice to "advertise" that the exception has this feature, by including a hint in the error message.