### PR TITLE
Generalize classify arguments function

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -182,7 +182,8 @@ function process_entry!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
     if job.source.kernel
         # pass all bitstypes by value; by default Julia passes aggregates by reference
         # (this improves performance, and is mandated by certain back-ends like SPIR-V).
-        args = classify_arguments(job, eltype(llvmtype(entry)))
+        source_sig = Base.signature_type(job.source.f, job.source.tt)::Type
+        args = classify_arguments(source_sig, eltype(llvmtype(entry)))
         for arg in args
             if arg.cc == BITS_REF
                 attr = if LLVM.version() >= v"12"

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -287,10 +287,8 @@ end
     GHOST       # not passed
 end
 
-function classify_arguments(@nospecialize(job::CompilerJob), codegen_ft::LLVM.FunctionType)
-    source_sig = Base.signature_type(job.source.f, job.source.tt)::Type
+function classify_arguments(source_sig::Type, codegen_ft::LLVM.FunctionType)
     source_types = [source_sig.parameters...]
-
     codegen_types = parameters(codegen_ft)
 
     args = []
@@ -396,7 +394,8 @@ function lower_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.
         else
             ft
         end
-        args = classify_arguments(job, orig_ft)
+        source_sig = Base.signature_type(job.source.f, job.source.tt)::Type
+        args = classify_arguments(source_sig, orig_ft)
         filter!(args) do arg
             arg.cc != GHOST
         end

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -239,7 +239,8 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.F
         else
             ft
         end
-        args = classify_arguments(job, orig_ft)
+        source_sig = Base.signature_type(job.source.f, job.source.tt)::Type
+        args = classify_arguments(source_sig, orig_ft)
         filter!(args) do arg
             arg.cc != GHOST
         end


### PR DESCRIPTION
This PR extends the classify_arguments API to take the signature type rather than the compiler job. This allows argument classification without having the runtime value of the function and enables the use of the utility in broader contexts (like Enzyme.jl)