### PR TITLE
Link the runtime when specific intrinsics occur.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -157,6 +157,7 @@ const __llvm_initialized = Ref(false)
     if libraries
         runtime = load_runtime(job; ctx)
         runtime_fns = LLVM.name.(defs(runtime))
+        runtime_intrinsics = ["julia.gc_alloc_obj"]
     end
 
     @timeit_debug to "Library linking" begin
@@ -166,7 +167,7 @@ const __llvm_initialized = Ref(false)
             @timeit_debug to "target libraries" link_libraries!(job, ir, undefined_fns)
 
             # GPU run-time library
-            if any(fn -> fn in runtime_fns, undefined_fns)
+            if any(fn -> fn in runtime_fns || fn in runtime_intrinsics, undefined_fns)
                 @timeit_debug to "runtime library" link_library!(ir, runtime)
             end
         end

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -322,7 +322,11 @@ function lower_gc_frame!(fun::LLVM.Function)
             Builder(ctx) do builder
                 # NOTE: this happens late during the pipeline, where we may have to
                 #       pass a kernel state arguments to the runtime function.
-                state = kernel_state_type(job)
+                state = if job.source.kernel
+                    kernel_state_type(job)
+                else
+                    Nothing
+                end
 
                 position!(builder, call)
                 ptr = call!(builder, Runtime.get(:gc_pool_alloc), [sz]; state)


### PR DESCRIPTION
These intrinsics probably will get lowered to a call to the runtime library.