### PR TITLE
remove `CachedMethodTable`

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -166,8 +166,8 @@ end
 
 ## interpreter
 
-using Core.Compiler: AbstractInterpreter, InferenceResult, InferenceParams, InferenceState,
-                     OptimizationParams, CachedMethodTable
+using Core.Compiler:
+    AbstractInterpreter, InferenceResult, InferenceParams, InferenceState, OptimizationParams
 
 struct GPUInterpreter <: AbstractInterpreter
     global_cache::CodeCache
@@ -220,17 +220,17 @@ end
 Core.Compiler.may_optimize(interp::GPUInterpreter) = true
 Core.Compiler.may_compress(interp::GPUInterpreter) = true
 Core.Compiler.may_discard_trees(interp::GPUInterpreter) = true
-if VERSION >= v"1.7.0-DEV.577"
+@static if VERSION >= v"1.7.0-DEV.577"
 Core.Compiler.verbose_stmt_info(interp::GPUInterpreter) = false
 end
 
-if isdefined(Base.Experimental, Symbol("@overlay"))
+@static if isdefined(Base.Experimental, Symbol("@overlay"))
 using Core.Compiler: OverlayMethodTable
 Core.Compiler.method_table(interp::GPUInterpreter, sv::InferenceState) =
-    CachedMethodTable(OverlayMethodTable(interp.world, interp.method_table))
+    OverlayMethodTable(interp.world, interp.method_table)
 else
 Core.Compiler.method_table(interp::GPUInterpreter, sv::InferenceState) =
-    CachedMethodTable(WorldOverlayMethodTable(interp.world))
+    WorldOverlayMethodTable(interp.world)
 end
 
 


### PR DESCRIPTION
Apologize for the confusion!
In <https://github.com/JuliaLang/julia/pull/44240>, we figured out that
`CachedMethodTable` doesn't give us any performance benefit (both in
time and space), and so we removed that from Julia Base.
This commit updates the (newly updated) GPUCompiler's overloads accordingly.