### PR TITLE
Don't optimize the runtime library.

### DIFF
--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -131,7 +131,10 @@ function build_runtime(@nospecialize(job::CompilerJob); ctx)
         emit_function!(mod, job, def, method)
     end
 
-    optimize!(job, mod)
+    # we cannot optimize the runtime library, because the code would then be optimized again
+    # during main compilation (and optimizing twice isn't safe). for example, optimization
+    # removes Julia address spaces, which would then lead to type mismatches when using
+    # functions from the runtime library from IR that has not been stripped of AS info.
 
     mod
 end


### PR DESCRIPTION
Now that we link the runtime early, avoid optimizing it twice (https://github.com/JuliaGPU/GPUCompiler.jl/commit/6e4cfc9270275584c62a57e2cbd385988e79a408 didn't do much to actually allow re-optimization, and it's wrong, see the comment I added to the code).