### PR TITLE
Fixes for 1.8

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -102,7 +102,7 @@ function Base.showerror(io::IO, err::InvalidIRError)
         Base.show_backtrace(io, bt)
     end
     println(io)
-    printstyled(io, "HINT"; bold = true, color = :cyan)
+    printstyled(io, "Hint"; bold = true, color = :cyan)
     printstyled(
         io,
         ": catch this exception as `err` and call `code_typed(err; interactive = true)` to",

--- a/test/native.jl
+++ b/test/native.jl
@@ -283,6 +283,10 @@ end
     end
 end
 
+end
+
+############################################################################################
+
 @testset "LazyCodegen" begin
     import .LazyCodegen: call_delayed
 
@@ -329,8 +333,6 @@ end
 
     # tests struct return
     @test call_delayed(complex, 1.0, 2.0) == 1.0+2.0im
-end
-
 end
 
 ############################################################################################

--- a/test/native.jl
+++ b/test/native.jl
@@ -228,7 +228,8 @@ end
                          native_code_execution(foobar, Tuple{Int})) do msg
         occursin("invalid LLVM IR", msg) &&
         (occursin(GPUCompiler.RUNTIME_FUNCTION, msg) ||
-         occursin(GPUCompiler.UNKNOWN_FUNCTION, msg)) &&
+         occursin(GPUCompiler.UNKNOWN_FUNCTION, msg) ||
+         occursin(GPUCompiler.DYNAMIC_CALL, msg)) &&
         occursin("[1] println", msg) &&
         occursin(r"\[2\] .*foobar", msg)
     end

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,5 +1,7 @@
 ## test helpers
 
+using Test
+
 # @test_throw, with additional testing for the exception message
 macro test_throws_message(f, typ, ex...)
     quote


### PR DESCRIPTION
@vchuravy a LazyCodegen tests fails, where you test for 'ABI removal'. I'm not sure what's up there, could you have a look?

The generated code is:

```
julia> native_code_llvm(call_real, Tuple{ComplexF64})
;  @ REPL[20]:1 within `call_real`
; Function Attrs: alwaysinline
define double @julia_call_real_3776([2 x double]* nocapture nonnull readonly align 8 dereferenceable(16) %0) local_unnamed_addr #0 {
top:
  %1 = alloca [2 x double], align 16
  %.sub = bitcast [2 x double]* %1 to i8*
  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %.sub)
;  @ REPL[20]:2 within `call_real`
; ┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:309 within `call_delayed`
; │┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:243 within `abi_call`
; ││┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:300 within `macro expansion`
; │││┌ @ refpointer.jl:134 within `Ref`
; ││││┌ @ refvalue.jl:10 within `RefValue` @ refvalue.jl:8
       %.elt = getelementptr inbounds [2 x double], [2 x double]* %0, i64 0, i64 0
       %.unpack = load double, double* %.elt, align 8
       %.elt2 = getelementptr inbounds [2 x double], [2 x double]* %0, i64 0, i64 1
       %.unpack3 = load double, double* %.elt2, align 8
       %.repack = getelementptr inbounds [2 x double], [2 x double]* %1, i64 0, i64 0
       store double %.unpack, double* %.repack, align 16
       %.repack5 = getelementptr inbounds [2 x double], [2 x double]* %1, i64 0, i64 1
       store double %.unpack3, double* %.repack5, align 8
; │││└└
; │││┌ @ refvalue.jl:39 within `unsafe_convert`
; ││││┌ @ array.jl:157 within `allocatedinline`
       %2 = call i32 inttoptr (i64 139951111453456 to i32 ({}*)*)({}* nonnull inttoptr (i64 139950744134384 to {}*))
; │││││┌ @ operators.jl:282 within `!=`
; ││││││┌ @ promotion.jl:473 within `==`
         %.not = icmp eq i32 %2, 0
; ││││└└└
      %3 = ptrtoint [2 x double]* %1 to i64
      %4 = bitcast double %.unpack to i64
      %value_phi = select i1 %.not, i64 %4, i64 %3
; │││└
     %5 = inttoptr i64 %value_phi to [2 x double]*
; │││┌ @ complex.jl:72 within `real`
; ││││┌ @ Base.jl:38 within `getproperty`
       %6 = getelementptr inbounds [2 x double], [2 x double]* %5, i64 0, i64 0
; ││││└
      %7 = load double, double* %6, align 8
; └└└└
  ret double %7
}
```

i.e. containing an `alloca`.

Interestingly, but probably not relevant: when using the upstream Julia pass pipeline, we get slightly different IR:

```
julia> native_code_llvm(call_real, Tuple{ComplexF64})
;  @ REPL[20]:1 within `call_real`
; Function Attrs: alwaysinline
define double @julia_call_real_3665([2 x double]* nocapture nonnull readonly align 8 dereferenceable(16) %0) local_unnamed_addr #0 {
top:
  %1 = alloca <2 x double>, align 16
  %.sub = bitcast <2 x double>* %1 to i8*
  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %.sub)
;  @ REPL[20]:2 within `call_real`
; ┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:309 within `call_delayed`
; │┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:243 within `abi_call`
; ││┌ @ /home/tim/Julia/pkg/GPUCompiler/test/definitions/native.jl:300 within `macro expansion`
; │││┌ @ refpointer.jl:134 within `Ref`
; ││││┌ @ refvalue.jl:10 within `RefValue` @ refvalue.jl:8
       %2 = bitcast [2 x double]* %0 to <2 x double>*
       %3 = load <2 x double>, <2 x double>* %2, align 8
       store <2 x double> %3, <2 x double>* %1, align 16
; │││└└
; │││┌ @ refvalue.jl:39 within `unsafe_convert`
; ││││┌ @ array.jl:157 within `allocatedinline`
       %4 = call i32 inttoptr (i64 139951111453456 to i32 ({}*)*)({}* nonnull inttoptr (i64 139950744134384 to {}*))
; │││││┌ @ operators.jl:282 within `!=`
; ││││││┌ @ promotion.jl:473 within `==`
         %.not = icmp eq i32 %4, 0
; ││││└└└
      %5 = ptrtoint <2 x double>* %1 to i64
      %bc = bitcast <2 x double> %3 to <2 x i64>
      %6 = extractelement <2 x i64> %bc, i32 0
      %value_phi = select i1 %.not, i64 %6, i64 %5
; │││└
     %7 = inttoptr i64 %value_phi to [2 x double]*
; │││┌ @ complex.jl:72 within `real`
; ││││┌ @ Base.jl:38 within `getproperty`
       %8 = getelementptr inbounds [2 x double], [2 x double]* %7, i64 0, i64 0
; ││││└
      %9 = load double, double* %8, align 8
; └└└└
  ret double %9
}
```

Not sure if this matters? It doesn't look like we're missing a pass.