### PR TITLE
NativeCompilerTarget should support throwing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "4.7"
+LLVM = "4.8"
 TimerOutputs = "0.5"
 julia = "1.6"

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -209,7 +209,7 @@ const __llvm_initialized = Ref(false)
 
     # always preload the runtime, and do so early; it cannot be part of any timing block
     # because it recurses into the compiler
-    if libraries
+    if !uses_julia_runtime(job) && libraries
         runtime = load_runtime(job; ctx)
         runtime_fns = LLVM.name.(defs(runtime))
         runtime_intrinsics = ["julia.gc_alloc_obj"]
@@ -222,7 +222,7 @@ const __llvm_initialized = Ref(false)
             @timeit_debug to "target libraries" link_libraries!(job, ir, undefined_fns)
 
             # GPU run-time library
-            if any(fn -> fn in runtime_fns || fn in runtime_intrinsics, undefined_fns)
+            if !uses_julia_runtime(job) && any(fn -> fn in runtime_fns || fn in runtime_intrinsics, undefined_fns)
                 @timeit_debug to "runtime library" link_library!(ir, runtime)
             end
         end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -146,6 +146,9 @@ end
 # Has the runtime available and does not require special handling
 uses_julia_runtime(@nospecialize(job::CompilerJob)) = false
 
+# Should emit PTLS lookup that can be relocated
+dump_native(@nospecialize(job::CompilerJob)) = false
+
 # the Julia module to look up target-specific runtime functions in (this includes both
 # target-specific functions from the GPU runtime library, like `malloc`, but also
 # replacements functions for operations like `Base.sin`)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -143,6 +143,9 @@ end
 
 ## interfaces and fallback definitions
 
+# Has the runtime available and does not require special handling
+uses_julia_runtime(@nospecialize(job::CompilerJob)) = false
+
 # the Julia module to look up target-specific runtime functions in (this includes both
 # target-specific functions from the GPU runtime library, like `malloc`, but also
 # replacements functions for operations like `Base.sin`)
@@ -157,7 +160,7 @@ get_interpreter(@nospecialize(job::CompilerJob)) =
 
 # does this target support throwing Julia exceptions with jl_throw?
 # if not, calls to throw will be replaced with calls to the GPU runtime
-can_throw(@nospecialize(job::CompilerJob)) = false
+can_throw(@nospecialize(job::CompilerJob)) = uses_julia_runtime(job)
 
 # generate a string that represents the type of compilation, for selecting a compiled
 # instance of the runtime library. this slug should encode everything that affects

--- a/src/native.jl
+++ b/src/native.jl
@@ -35,4 +35,4 @@ end
 ## job
 
 runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))$(job.target.jlruntime ? "-jlrt" : "")"
-can_throw(job::CompilerJob{NativeCompilerTarget}) = job.target.jlruntime
+uses_julia_runtime(job::CompilerJob{NativeCompilerTarget}) = job.target.jlruntime

--- a/src/native.jl
+++ b/src/native.jl
@@ -8,6 +8,7 @@ Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
     cpu::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
     features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
     always_inline::Bool=false # will mark the job function as always inline
+    jlruntime::Bool=true # Use Julia runtime for throwing errors, instead of the GPUCompiler support
 end
 
 llvm_triple(::NativeCompilerTarget) = Sys.MACHINE
@@ -33,5 +34,5 @@ end
 
 ## job
 
-runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))"
-can_throw(job::CompilerJob{NativeCompilerTarget}) = true
+runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))$(job.target.jlruntime ? "-jlrt" : "")"
+can_throw(job::CompilerJob{NativeCompilerTarget}) = job.target.jlruntime

--- a/src/native.jl
+++ b/src/native.jl
@@ -34,3 +34,4 @@ end
 ## job
 
 runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))"
+can_throw(job::CompilerJob{NativeCompilerTarget}) = true

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -222,7 +222,7 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
             sccp!(pm)
             # Remove dead use of ptls
             dce!(pm)
-            LLVM.lower_ptls!(pm, dump_native(job))
+            LLVM.Interop.lower_ptls!(pm, dump_native(job))
             instruction_combining!(pm)
             # Clean up write barrier and ptls lowering
             cfgsimplification!(pm)

--- a/test/native.jl
+++ b/test/native.jl
@@ -335,6 +335,10 @@ end
 
     # tests struct return
     @test call_delayed(complex, 1.0, 2.0) == 1.0+2.0im
+
+    throws(arr, i) = arr[i]
+    @test call_delayed(throws, [1], 1) == 1
+    @test_throws BoundsError call_delayed(throws, [1], 0)
 end
 
 ############################################################################################


### PR DESCRIPTION
As noted in https://github.com/EnzymeAD/Enzyme.jl/pull/243

The issue is that for nested Codegen Enzyme uses the NativeCompilerTarget or PTXCompilerTarget 
and so it picks up the default for each.
