### PR TITLE
Adapt to upstream changes to return_types

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -226,7 +226,7 @@ end
 
 if isdefined(Base.Experimental, Symbol("@overlay"))
 using Core.Compiler: OverlayMethodTable
-if VERSION >= v"1.9.0-DEV.120"
+if v"1.8-beta2" <= VERSION < v"1.9-" || VERSION >= v"1.9.0-DEV.120"
 Core.Compiler.method_table(interp::GPUInterpreter) =
     OverlayMethodTable(interp.world, interp.method_table)
 else

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -16,7 +16,12 @@ function check_method(@nospecialize(job::CompilerJob))
         cache = ci_cache(job)
         mt = method_table(job)
         interp = GPUInterpreter(cache, mt, job.source.world)
-        rt = Base.return_types(job.source.f, job.source.tt, interp)[1]
+        @static if v"1.8-beta2" <= VERSION < v"1.9-" || VERSION ≥ v"1.9.0-DEV.190"
+            # https://github.com/JuliaLang/julia/pull/44515
+            rt = Base.return_types(job.source.f, job.source.tt; interp)[1]
+        else
+            rt = Base.return_types(job.source.f, job.source.tt, interp)[1]
+        end
         if rt != Nothing
             throw(KernelError(job, "kernel returns a value of type `$rt`",
                 """Make sure your kernel function ends in `return`, `return nothing` or `nothing`.

--- a/test/native.jl
+++ b/test/native.jl
@@ -330,7 +330,7 @@ end
 
     # Test ABI removal
     ir = sprint(io->native_code_llvm(io, call_real, Tuple{ComplexF64}))
-    if VERSION < v"1.8-"
+    if VERSION < v"1.8-" || v"1.8-beta2" <= VERSION < v"1.9-" || VERSION ≥ v"1.9.0-DEV.190"
         @test !occursin("alloca", ir)
     else
         @test_broken !occursin("alloca", ir)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/309

Still we want to wait for the release of [next beta version](https://github.com/JuliaLang/julia/pull/44324) and change the version compat accordingly.