### PR TITLE
Kernel state rewriting: support more IR

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -224,8 +224,8 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
             if !valid_function_pointer(job, ptr)
                 # look it up in the Julia JIT cache
                 frames = ccall(:jl_lookup_code_address, Any, (Ptr{Cvoid}, Cint,), ptr, 0)
-                if length(frames) >= 1
-                    @compiler_assert length(frames) == 1 job frames=frames
+                # XXX: what if multiple frames are returned? rare, but happens
+                if length(frames) == 1
                     fn, file, line, linfo, fromC, inlined = last(frames)
                     push!(errors, (POINTER_FUNCTION, bt, fn))
                 else


### PR DESCRIPTION
In https://github.com/JuliaGPU/CUDA.jl/issues/1482, where GPUCompiler is invoked with a bunch of CuArray code (i.e., a very invalid and GPU-incompatible compilation job), the kernel state rewriting pass failed. Turns out we weren't properly supporting several IR constructs Julia likes to emit, most notably constant expressions that contain references to a function (e.g., bitcasting them, or doing a ptrtoint before passing the function as a pointer).

This PR fixes that, supporting the above use case (which still fails, but at least doesn't crash the compiler now). There's two remaining issues:
- `jlcall`, which pass an array of arguments: we don't rewrite those, which would require allocating a new array of arguments (with the kernel state prepended). shouldn't matter for now, as only the CUDA back-end uses kernel state objects, and that back-end doesn't really support `jlcall`
- `ptrtoint`/`inttoptr` pairs, where casting a function to an integer and back breaks our tracking and may result in uses of the old 'stateless' function type (without the kernel state having been added). we should detect and abort in such cases.