### PR TITLE
Perform all kernel-state transformations late

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,15 +39,15 @@ version = "1.4.1"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "c9b86064be5ae0f63e50816a5a90b08c474507ae"
+git-tree-sha1 = "d7f3db3b5f564016b5dfcc71a20506f8796f403a"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.9.1"
+version = "4.10.0"
 
 [[LLVMExtra_jll]]
-deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "5558ad3c8972d602451efe9d81c78ec14ef4f5ef"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
+git-tree-sha1 = "00d23b26d194507028b9a1c2728a691ab9914262"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.14+2"
+version = "0.0.15+0"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,15 +39,15 @@ version = "1.4.1"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "d7f3db3b5f564016b5dfcc71a20506f8796f403a"
+git-tree-sha1 = "dd58421009014ff1ffacaa0db2a9a392114d75ee"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.10.0"
+version = "4.11.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
-git-tree-sha1 = "00d23b26d194507028b9a1c2728a691ab9914262"
+git-tree-sha1 = "771bfe376249626d3ca12bcd58ba243d3f961576"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.15+0"
+version = "0.0.16+0"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "4.8"
+LLVM = "4.10"
 TimerOutputs = "0.5"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "4.10"
+LLVM = "4.11"
 TimerOutputs = "0.5"
 julia = "1.6"

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -318,13 +318,9 @@ const __llvm_initialized = Ref(false)
     @timeit_debug to "IR post-processing" begin
         # mark the kernel entry-point functions (optimization may need it)
         if job.source.kernel
-            # XXX: we want to save the actual function here, but due to our passes rewriting
-            #      functions, and the inability to RAUW values with a different type, that
-            #      metadata gets lost. So instead we save the function name. See also:
-            #      https://discourse.llvm.org/t/replacing-module-metadata-uses-of-function/62431
-            push!(metadata(ir)["julia.kernel"], MDNode([MDString(LLVM.name(entry); ctx)]; ctx))
+            push!(metadata(ir)["julia.kernel"], MDNode([entry]; ctx))
 
-            # IDEA: save all jobs, not only top-level kernels, and save other attributes
+            # IDEA: save all jobs, not only kernels, and save other attributes
             #       so that we can reconstruct the CompileJob instead of setting it globally
         end
 

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -317,6 +317,13 @@ const __llvm_initialized = Ref(false)
     end
 
     @timeit_debug to "IR post-processing" begin
+        # mark the entry-point function (optimization may need it)
+        if deferred_codegen
+            # IDEA: save other parts of the CompileJob (so that we can reconstruct it
+            #       instead of setting it globally, which is incompatible with threading)?
+            push!(metadata(ir)["julia.entry"], MDNode([entry]; ctx))
+        end
+
         if optimize
             @timeit_debug to "optimization" begin
                 optimize!(job, ir)

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -257,10 +257,9 @@ const __llvm_initialized = Ref(false)
     # deferred code generation
     do_deferred_codegen = !only_entry && deferred_codegen &&
                           haskey(functions(ir), "deferred_codegen")
+    deferred_jobs = Dict{CompilerJob, String}(job => entry_fn)
     if do_deferred_codegen
         dyn_marker = functions(ir)["deferred_codegen"]
-
-        cache = Dict{CompilerJob, String}(job => entry_fn)
 
         # iterative compilation (non-recursive)
         changed = true
@@ -286,7 +285,7 @@ const __llvm_initialized = Ref(false)
             # compile and link
             for dyn_job in keys(worklist)
                 # cached compilation
-                dyn_entry_fn = get!(cache, dyn_job) do
+                dyn_entry_fn = get!(deferred_jobs, dyn_job) do
                     dyn_ir, dyn_meta = codegen(:llvm, dyn_job; optimize=false,
                                                deferred_codegen=false, parent_job=job, ctx)
                     dyn_entry_fn = LLVM.name(dyn_meta.entry)
@@ -372,7 +371,18 @@ const __llvm_initialized = Ref(false)
             end
         end
 
-        entry = finish_ir!(job, ir, entry)
+        # finish the module
+        #
+        # we want to finish the module after optimization, so we cannot do so during
+        # deferred code generation. instead, process the deferred jobs here.
+        if deferred_codegen
+            entry = finish_ir!(job, ir, entry)
+
+            for (deferred_job, deferred_fn) in deferred_jobs
+                deferred_job == job && continue
+                finish_ir!(deferred_job, ir, functions(ir)[deferred_fn])
+            end
+        end
 
         # replace non-entry function definitions with a declaration
         # NOTE: we can't do this before optimization, because the definitions of called

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -321,7 +321,11 @@ const __llvm_initialized = Ref(false)
         if deferred_codegen
             # IDEA: save other parts of the CompileJob (so that we can reconstruct it
             #       instead of setting it globally, which is incompatible with threading)?
-            push!(metadata(ir)["julia.entry"], MDNode([entry]; ctx))
+            # XXX: we want to save the actual function here, but due to our passes rewriting
+            #      functions, and the inability to RAUW values with a different type, that
+            #      metadata gets lost. So instead we save the function name. See also:
+            #      https://discourse.llvm.org/t/replacing-module-metadata-uses-of-function/62431
+            push!(metadata(ir)["julia.entry"], MDNode([MDString(LLVM.name(entry); ctx)]; ctx))
         end
 
         if optimize

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -316,15 +316,16 @@ const __llvm_initialized = Ref(false)
     end
 
     @timeit_debug to "IR post-processing" begin
-        # mark the entry-point function (optimization may need it)
-        if deferred_codegen
-            # IDEA: save other parts of the CompileJob (so that we can reconstruct it
-            #       instead of setting it globally, which is incompatible with threading)?
+        # mark the kernel entry-point functions (optimization may need it)
+        if job.source.kernel
             # XXX: we want to save the actual function here, but due to our passes rewriting
             #      functions, and the inability to RAUW values with a different type, that
             #      metadata gets lost. So instead we save the function name. See also:
             #      https://discourse.llvm.org/t/replacing-module-metadata-uses-of-function/62431
-            push!(metadata(ir)["julia.entry"], MDNode([MDString(LLVM.name(entry); ctx)]; ctx))
+            push!(metadata(ir)["julia.kernel"], MDNode([MDString(LLVM.name(entry); ctx)]; ctx))
+
+            # IDEA: save all jobs, not only top-level kernels, and save other attributes
+            #       so that we can reconstruct the CompileJob instead of setting it globally
         end
 
         if optimize

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -233,15 +233,7 @@ optimize_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
 
 # finalization of the module, before deferred codegen and optimization
 function finish_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry::LLVM.Function)
-    ctx = context(mod)
-    entry_fn = LLVM.name(entry)
-
-    # add the kernel state, and lower calls to the `julia.gpu.state_getter` intrinsic.
-    if job.source.kernel
-        add_kernel_state!(job, mod, entry)
-    end
-
-    return functions(mod)[entry_fn]
+    return entry
 end
 
 # final processing of the IR, right before validation and machine-code generation

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -552,9 +552,8 @@ function add_kernel_state!(mod::LLVM.Module)
     state_intr = kernel_state_intr(mod, T_state)
 
     entry_md = operands(metadata(mod)["julia.entry"])[1]
-    entry = Value(operands(entry_md)[1]; ctx)
-    # XXX: this metadata will be invalid after the replacement here (it'll be null).
-    #      how do we replace Metadata uses? Normally RAUW, but it asserts type equality
+    entry_fn = string(operands(entry_md)[1])
+    entry = functions(mod)[entry_fn]
 
     # determine which functions need a kernel state argument
     #

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -713,10 +713,12 @@ function add_kernel_state!(mod::LLVM.Module)
                 elseif val isa LLVM.CallBase
                     # the function is being passed as an argument, which we'll just permit,
                     # because we expect to have rewritten the call down the line separately.
+                elseif val isa LLVM.StoreInst
+                    # the function is being stored, which again we'll permit like before.
                 elseif val isa ConstantExpr
                     rewrite_uses!(val)
                 else
-                    error("Cannot rewrite unknown use of function: $val")
+                    error("Cannot rewrite $(typeof(val)) use of function: $val")
                 end
             end
         end

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -404,21 +404,14 @@ function lower_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.
         # XXX: byval is not round-trippable on LLVM < 12 (see maleadt/LLVM.jl#186)
         #      so we need to re-classify the Julia arguments.
         #      remove this once we only support 1.7.
-        has_kernel_state = kernel_state_type(job) !== Nothing
-        orig_ft = if has_kernel_state
-            # the kernel state has been added here already, so strip the first parameter
-            LLVM.FunctionType(LLVM.return_type(ft), parameters(ft)[2:end]; vararg=isvararg(ft))
-        else
-            ft
-        end
-        args = classify_arguments(job, orig_ft)
+        args = classify_arguments(job, ft)
         filter!(args) do arg
             arg.cc != GHOST
         end
         for arg in args
             if arg.cc == BITS_REF
                 # NOTE: +1 since this pass runs after introducing the kernel state
-                byval[arg.codegen.i+has_kernel_state] = true
+                byval[arg.codegen.i] = true
             end
         end
     end

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -192,6 +192,8 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
         if job.source.kernel
             # GC lowering is the last pass that may introduce calls to the runtime library,
             # and thus additional uses of the kernel state intrinsic.
+            # TODO: now that all kernel state-related passes are being run here, merge some?
+            add!(pm, ModulePass("AddKernelState", add_kernel_state!))
             add!(pm, FunctionPass("LowerKernelState", lower_kernel_state!))
             add!(pm, ModulePass("CleanupKernelState", cleanup_kernel_state!))
         end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -198,10 +198,6 @@ function finish_ir!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
     if job.source.kernel
         # add metadata annotations for the assembler to the module
 
-        # NOTE: we do this here, rather than in finish_module!, because otherwise
-        #       the metadata is lost when functions are cloned. See also:
-        #       https://discourse.llvm.org/t/replacing-module-metadata-uses-of-function/62431
-
         # property annotations
         annotations = Metadata[entry]
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -199,8 +199,8 @@ function finish_ir!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
         # add metadata annotations for the assembler to the module
 
         # NOTE: we do this here, rather than in finish_module!, because otherwise
-        #       the metadata is lost when functions are cloned.
-        # XXX: why does this happen? shouldn't cloning preserve metadata?
+        #       the metadata is lost when functions are cloned. See also:
+        #       https://discourse.llvm.org/t/replacing-module-metadata-uses-of-function/62431
 
         # property annotations
         annotations = Metadata[entry]

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -34,17 +34,11 @@ struct RuntimeMethodInstance
 end
 
 function Base.convert(::Type{LLVM.FunctionType}, rt::RuntimeMethodInstance;
-                      ctx::LLVM.Context, state::Type=Nothing)
+                      ctx::LLVM.Context)
     types = if rt.llvm_types === nothing
         LLVMType[convert(LLVMType, typ; ctx, allow_boxed=true) for typ in rt.types]
     else
         rt.llvm_types(ctx)
-    end
-
-    # if we're running post-optimization, prepend the kernel state to the argument list
-    if state !== Nothing
-        T_state = convert(LLVMType, state; ctx)
-        pushfirst!(types, T_state)
     end
 
     return_type = if rt.llvm_return_type === nothing

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -232,25 +232,14 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.F
         end
     else
         # XXX: byval is not round-trippable on LLVM < 12 (see maleadt/LLVM.jl#186)
-        has_kernel_state = kernel_state_type(job) !== Nothing
-        orig_ft = if has_kernel_state
-            # the kernel state has been added here already, so strip the first parameter
-            LLVM.FunctionType(LLVM.return_type(ft), parameters(ft)[2:end]; vararg=isvararg(ft))
-        else
-            ft
-        end
-        args = classify_arguments(job, orig_ft)
+        args = classify_arguments(job, ft)
         filter!(args) do arg
             arg.cc != GHOST
         end
         for arg in args
             if arg.cc == BITS_REF
-                # NOTE: +1 since this pass runs after introducing the kernel state
-                byval[arg.codegen.i+has_kernel_state] = true
+                byval[arg.codegen.i] = true
             end
-        end
-        if has_kernel_state
-            byval[1] = true
         end
     end
 

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -317,6 +317,7 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.F
     # NOTE: if we ever have legitimate uses of the old function, create a shim instead
     fn = LLVM.name(f)
     @assert isempty(uses(f))
+    replace_metadata_uses!(f, new_f)
     unsafe_delete!(mod, f)
     LLVM.name!(new_f, fn)
 


### PR DESCRIPTION
cc @vchuravy 

TODO:

- [x] make it so that the `julia.entry` metadata keeps being valid after function cloning (worst case we'll need it to be a MDString referring to the entry by-name)
- [x] verify correctness by running the CUDA.jl test suite
- [x] check performance, now that the transformation happens late (maybe we can move it before optimization? or isn't that legal in the case optimization introduces uses of the state argument)