### PR TITLE
Changes in preparation of adding Metal support

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -204,12 +204,15 @@ process_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
 # state (possibly indirectly) via the `kernel_state_pointer` function.
 kernel_state_type(@nospecialize(job::CompilerJob)) = Nothing
 
+# Does the target need to pass kernel arguments by value?
+needs_byval(@nospecialize(job::CompilerJob)) = true
+
 # early processing of the newly identified LLVM kernel function
 function process_entry!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
                         entry::LLVM.Function)
     ctx = context(mod)
 
-    if job.source.kernel
+    if job.source.kernel && needs_byval(job)
         # pass all bitstypes by value; by default Julia passes aggregates by reference
         # (this improves performance, and is mandated by certain back-ends like SPIR-V).
         args = classify_arguments(job, eltype(llvmtype(entry)))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -139,14 +139,20 @@ struct CompilerJob{T,P,F}
     params::P
     entry_abi::Symbol
 
-    function CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec, params::AbstractCompilerParams, entry_abi::Symbol)
+    # metadata gathered during compilation
+    meta::Dict{Symbol,Any}
+
+    function CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec,
+                         params::AbstractCompilerParams, entry_abi::Symbol)
         if entry_abi ∉ (:specfunc, :func)
             error("Unknown entry_abi=$entry_abi")
         end
-        new{typeof(target), typeof(params), typeof(source)}(target, source, params, entry_abi)
+        new{typeof(target), typeof(params), typeof(source)}(
+            target, source, params, entry_abi, Dict{Symbol,Any}())
     end
 end
-CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec, params::AbstractCompilerParams; entry_abi=:specfunc) =
+CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec,
+            params::AbstractCompilerParams; entry_abi=:specfunc) =
     CompilerJob(target, source, params, entry_abi)
 
 Base.similar(@nospecialize(job::CompilerJob), @nospecialize(source::FunctionSpec)) =
@@ -156,12 +162,19 @@ function Base.show(io::IO, @nospecialize(job::CompilerJob{T})) where {T}
     print(io, "CompilerJob of ", job.source, " for ", T)
 end
 
+# make it possible to key on CompilerJobs, while ignoring the metadata
 function Base.hash(job::CompilerJob, h::UInt)
     h = hash(job.target, h)
     h = hash(job.source, h)
     h = hash(job.params, h)
     h = hash(job.entry_abi, h)
     h
+end
+function Base.isequal(a::CompilerJob, b::CompilerJob)
+    a.target == b.target &&
+    a.source == b.source &&
+    a.params == b.params &&
+    a.entry_abi == b.entry_abi
 end
 
 

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -308,31 +308,42 @@ end
     GHOST       # not passed
 end
 
+function method_argnames(m::Method)
+    argnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), m.slot_syms)
+    isempty(argnames) && return argnames
+    return argnames[1:m.nargs]
+end
+
 function classify_arguments(@nospecialize(job::CompilerJob), codegen_ft::LLVM.FunctionType)
     source_sig = typed_signature(job)
 
     source_types = [source_sig.parameters...]
+    source_method = only(method_matches(typed_signature(job); job.source.world)).method
+    source_arguments = method_argnames(source_method)
 
     codegen_types = parameters(codegen_ft)
 
     args = []
     codegen_i = 1
     for (source_i, source_typ) in enumerate(source_types)
+        source_name = source_arguments[min(source_i, length(source_arguments))]
+        # NOTE: in case of varargs, we have fewer arguments than parameters
+
         if isghosttype(source_typ) || Core.Compiler.isconstType(source_typ)
-            push!(args, (cc=GHOST, typ=source_typ))
+            push!(args, (cc=GHOST, typ=source_typ, name=source_name))
             continue
         end
 
         codegen_typ = codegen_types[codegen_i]
         if codegen_typ isa LLVM.PointerType && !issized(eltype(codegen_typ))
-            push!(args, (cc=MUT_REF, typ=source_typ,
+            push!(args, (cc=MUT_REF, typ=source_typ, name=source_name,
                          codegen=(typ=codegen_typ, i=codegen_i)))
         elseif codegen_typ isa LLVM.PointerType && issized(eltype(codegen_typ)) &&
                !(source_typ <: Ptr) && !(source_typ <: Core.LLVMPtr)
-            push!(args, (cc=BITS_REF, typ=source_typ,
+            push!(args, (cc=BITS_REF, typ=source_typ, name=source_name,
                          codegen=(typ=codegen_typ, i=codegen_i)))
         else
-            push!(args, (cc=BITS_VALUE, typ=source_typ,
+            push!(args, (cc=BITS_VALUE, typ=source_typ, name=source_name,
                          codegen=(typ=codegen_typ, i=codegen_i)))
         end
         codegen_i += 1


### PR DESCRIPTION
Small pieces of functionality that will be needed.

@vchuravy thoughts on the `meta` field in CompilerJob? Returning all kinds of metadata from functions like `emit_llvm` is cumbersome (I specifically have to escape some info from `finish_module!` which currently doesn't return a value). Maybe we should then also encode the metadata returned from `emit_llvm` in this dictionary?