### PR TITLE
Use at-dispose from LLVM.jl.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,9 +39,9 @@ version = "1.4.1"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "c8d47589611803a0f3b4813d9e267cd4e3dbcefb"
+git-tree-sha1 = "10a20c556107dc5833d3bb7c5e45c4a6e191bd28"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.11.1"
+version = "4.13.0"
 
 [[LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "4.11"
+LLVM = "4.13"
 TimerOutputs = "0.5"
 julia = "1.6"

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -3,7 +3,7 @@
 # final preparations for the module to be compiled to machine code
 # these passes should not be run when e.g. compiling to write to disk.
 function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
-    let pm = ModulePassManager()
+    @dispose pm=ModulePassManager() begin
         global current_job
         current_job = job
 
@@ -15,7 +15,6 @@ function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
         strip_dead_prototypes!(pm)
 
         run!(pm, mod)
-        dispose(pm)
     end
 
     return

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -41,7 +41,7 @@ end
 
 #
 # Compat shims
-# 
+#
 
 include("reflection_compat.jl")
 

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -74,10 +74,10 @@ function emit_function!(mod, @nospecialize(job::CompilerJob), f, method; ctx::Co
     end
 
     # recent Julia versions include prototypes for all runtime functions, even if unused
-    pm = ModulePassManager()
-    strip_dead_prototypes!(pm)
-    run!(pm, new_mod)
-    dispose(pm)
+    @dispose pm=ModulePassManager() begin
+        strip_dead_prototypes!(pm)
+        run!(pm, new_mod)
+    end
 
     temp_name = LLVM.name(meta.entry)
     link!(mod, new_mod)

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -140,7 +140,7 @@ const gc_bits = 0x3 # FIXME
 
 # get the type tag of a type at run-time
 @generated function type_tag(::Val{type_name}) where type_name
-    Context() do ctx
+    @dispose ctx=Context() begin
         T_tag = convert(LLVMType, tag_type; ctx)
         T_ptag = LLVM.PointerType(T_tag)
 
@@ -155,7 +155,7 @@ const gc_bits = 0x3 # FIXME
                             LLVM.FunctionType(T_pjlvalue))
 
         # generate IR
-        Builder(ctx) do builder
+        @dispose builder=Builder(ctx) begin
             entry = BasicBlock(llvm_f, "entry"; ctx)
             position!(builder, entry)
 

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -78,7 +78,7 @@ end
     # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...
     strip_debuginfo!(mod)
 
-    ModulePassManager() do pm
+    @dispose pm=ModulePassManager() begin
         # SPIR-V does not support trap, and has no mechanism to abort compute kernels
         # (OpKill is only available in fragment execution mode)
         add!(pm, ModulePass("RemoveTrap", rm_trap!))
@@ -263,7 +263,7 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.F
 
     # emit IR performing the "conversions"
     new_args = Vector{LLVM.Value}()
-    Builder(ctx) do builder
+    @dispose builder=Builder(ctx) begin
         entry = BasicBlock(new_f, "entry"; ctx)
         position!(builder, entry)
 
@@ -312,7 +312,7 @@ function wrap_byval(@nospecialize(job::CompilerJob), mod::LLVM.Module, f::LLVM.F
 
     # clean-up
     # NOTE: byval wrapping happens very late, after optimization
-    ModulePassManager() do pm
+    @dispose pm=ModulePassManager() begin
         # merge GEPs
         instruction_combining!(pm)
 


### PR DESCRIPTION
Greatly improves performance by avoiding closures. See https://github.com/maleadt/LLVM.jl/pull/309 for details.