### PR TITLE
Add `always_inline` target property to ptx backend

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -265,7 +265,14 @@ link_libraries!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
 valid_function_pointer(@nospecialize(job::CompilerJob), ptr::Ptr{Cvoid}) = false
 
 # the codeinfo cache to use
-ci_cache(@nospecialize(job::CompilerJob)) = GLOBAL_CI_CACHE
+function ci_cache(@nospecialize(job::CompilerJob))
+    lock(GLOBAL_CI_CACHES_LOCK) do
+        cache = get!(GLOBAL_CI_CACHES, (typeof(job.target), inference_params(job), optimization_params(job))) do
+            CodeCache()
+        end
+        return cache
+    end
+end
 
 # the method table to use
 method_table(@nospecialize(job::CompilerJob)) = GLOBAL_METHOD_TABLE

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -192,7 +192,7 @@ isintrinsic(@nospecialize(job::CompilerJob), fn::String) = false
 
 # provide a specific interpreter to use.
 get_interpreter(@nospecialize(job::CompilerJob)) =
-    GPUInterpreter(ci_cache(job), method_table(job), job.source.world)
+    GPUInterpreter(ci_cache(job), method_table(job), job.source.world, inference_params(job), optimization_params(job))
 
 # does this target support throwing Julia exceptions with jl_throw?
 # if not, calls to throw will be replaced with calls to the GPU runtime
@@ -269,6 +269,22 @@ ci_cache(@nospecialize(job::CompilerJob)) = GLOBAL_CI_CACHE
 
 # the method table to use
 method_table(@nospecialize(job::CompilerJob)) = GLOBAL_METHOD_TABLE
+
+# the inference parameters to use when constructing the GPUInterpreter
+function inference_params(@nospecialize(job::CompilerJob))
+    return InferenceParams(;unoptimize_throw_blocks=false)
+end
+
+# the optimization parameters to use when constructing the GPUInterpreter
+function optimization_params(@nospecialize(job::CompilerJob))
+    kwargs = NamedTuple()
+
+    if VERSION < v"1.8.0-DEV.486"
+        kwargs = (kwargs..., unoptimize_throw_blocks=false)
+    end
+
+    return OptimizationParams(;kwargs...)
+end
 
 # how much debuginfo to emit
 function llvm_debug_info(@nospecialize(job::CompilerJob))

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -182,7 +182,8 @@ struct GPUInterpreter <: AbstractInterpreter
     inf_params::InferenceParams
     opt_params::OptimizationParams
 
-    function GPUInterpreter(cache::CodeCache, mt::Union{Nothing,Core.MethodTable}, world::UInt)
+
+    function GPUInterpreter(cache::CodeCache, mt::Union{Nothing,Core.MethodTable}, world::UInt, ip::InferenceParams, op::OptimizationParams)
         @assert world <= Base.get_world_counter()
 
         return new(
@@ -196,9 +197,8 @@ struct GPUInterpreter <: AbstractInterpreter
             world,
 
             # parameters for inference and optimization
-            InferenceParams(unoptimize_throw_blocks=false),
-            VERSION >= v"1.8.0-DEV.486" ? OptimizationParams() :
-                                          OptimizationParams(unoptimize_throw_blocks=false),
+            ip,
+            op
         )
     end
 end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -2,7 +2,7 @@
 
 ## cache
 
-using Core.Compiler: CodeInstance, MethodInstance
+using Core.Compiler: CodeInstance, MethodInstance, InferenceParams, OptimizationParams
 
 struct CodeCache
     dict::Dict{MethodInstance,Vector{CodeInstance}}
@@ -39,7 +39,8 @@ end
 
 Base.empty!(cc::CodeCache) = empty!(cc.dict)
 
-const GLOBAL_CI_CACHE = CodeCache()
+const GLOBAL_CI_CACHES = Dict{Tuple{DataType, InferenceParams, OptimizationParams}, CodeCache}()
+const GLOBAL_CI_CACHES_LOCK = ReentrantLock()
 
 
 ## method invalidations

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -32,7 +32,9 @@ function check_method(@nospecialize(job::CompilerJob))
     if job.source.kernel
         cache = ci_cache(job)
         mt = method_table(job)
-        interp = GPUInterpreter(cache, mt, world)
+        ip = inference_params(job)
+        op = optimization_params(job)
+        interp = GPUInterpreter(cache, mt, world, ip, op)
         rt = return_type(only(ms); interp)
 
         if rt != Nothing

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -39,11 +39,12 @@ GPUCompiler.runtime_module(::PTXCompilerJob) = PTXTestRuntime
 
 function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                  minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
-                 maxregs=nothing, kwargs...)
+                 maxregs=nothing, always_inline=false, kwargs...)
     source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = PTXCompilerTarget(cap=v"7.0",
                                minthreads=minthreads, maxthreads=maxthreads,
-                               blocks_per_sm=blocks_per_sm, maxregs=maxregs)
+                               blocks_per_sm=blocks_per_sm, maxregs=maxregs,
+                               always_inline=always_inline)
     params = TestCompilerParams()
     CompilerJob(target, source, params), kwargs
 end


### PR DESCRIPTION
Add the ability for backends to define their own inference and optimization parameters.  This is used to add the `always_inline` target property the to ptx backend enabling the forced inlining of functions.  These changes build on the code and suggestions given in https://github.com/JuliaGPU/GPUCompiler.jl/pull/186.