### PR TITLE
Metal: Change approach to adding ptr arg ASs.

### DIFF
--- a/test/metal.jl
+++ b/test/metal.jl
@@ -31,26 +31,6 @@ end
     @test occursin(r"@.*julia.*kernel.*\(({ i64 }|\[1 x i64\]) addrspace\(1\)\*", ir)
 end
 
-@testset "byref aggregates with memcpy" begin
-    ir = """
-        declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1 immarg)
-
-        define void @kernel(i8* %0, i8* %1) {
-        entry:
-            call void @llvm.memcpy.p0i8.p0i8.i64(i8* %0, i8* %1, i64 0, i1 false)
-            ret void
-        }
-    """
-    Context() do ctx
-        mod = parse(LLVM.Module, ir; ctx)
-        f = functions(mod)["kernel"]
-        GPUCompiler.add_address_spaces!(mod, f)
-        LLVM.verify(mod)
-    end
-    return
-
-end
-
 @testset "byref primitives" begin
     kernel(x) = return
 


### PR DESCRIPTION
Turns out that using module cloning isn't working here. If we change
the address space of the arguments, and just remap those arguments
using a value mapper, those changes will get lost after, e.g., a
bitcast from the argument pointer to a different type (that destination
type won't have an address space, resulting in invalid operations).

We were working around this limitation by using a type remapper,
rewriting all pointer types to contain an address space, but that's
obviously invalid: Stack space (i.e. `alloca`s) should still reside
in address space 0.

So instead we're taking the approach we're using with byval lowering,
storing the arguments to a temporary slot. We're still changing the
function's pointer arguments to include an address space, but after
loading the argument and storing it in a stack slot we can dereference
it and get a valid pointer without an address space. We can then
re-use the existing IR with that pointer, without having to rewrite it.

This simplifies the pass a lot, because we don't have to worry about
rewriting intrinsics like memcpy.