### PR TITLE
Metal simplifications

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,29 @@ steps:
     if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
     timeout_in_minutes: 60
 
+  - label: "Metal.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: 1.8
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+      julia -e 'using Pkg;
+
+                println("--- :julia: Instantiating project");
+                Pkg.develop(PackageSpec(path=pwd()));
+                Pkg.add(PackageSpec(name="Metal", rev="main",
+                                    url="https://github.com/JuliaGPU/Metal.jl.git"));
+                Pkg.build();
+
+                println("+++ :julia: Running tests");
+                Pkg.test("Metal"; coverage=true);'
+    agents:
+      queue: "juliagpu"
+      metal: "*"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 120
+
 #  - label: "AMDGPU.jl"
 #    plugins:
 #      - JuliaCI/julia#v1:

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -139,20 +139,14 @@ struct CompilerJob{T,P,F}
     params::P
     entry_abi::Symbol
 
-    # metadata gathered during compilation
-    meta::Dict{Symbol,Any}
-
-    function CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec,
-                         params::AbstractCompilerParams, entry_abi::Symbol)
+    function CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec, params::AbstractCompilerParams, entry_abi::Symbol)
         if entry_abi ∉ (:specfunc, :func)
             error("Unknown entry_abi=$entry_abi")
         end
-        new{typeof(target), typeof(params), typeof(source)}(
-            target, source, params, entry_abi, Dict{Symbol,Any}())
+        new{typeof(target), typeof(params), typeof(source)}(target, source, params, entry_abi)
     end
 end
-CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec,
-            params::AbstractCompilerParams; entry_abi=:specfunc) =
+CompilerJob(target::AbstractCompilerTarget, source::FunctionSpec, params::AbstractCompilerParams; entry_abi=:specfunc) =
     CompilerJob(target, source, params, entry_abi)
 
 Base.similar(@nospecialize(job::CompilerJob), @nospecialize(source::FunctionSpec)) =
@@ -162,19 +156,12 @@ function Base.show(io::IO, @nospecialize(job::CompilerJob{T})) where {T}
     print(io, "CompilerJob of ", job.source, " for ", T)
 end
 
-# make it possible to key on CompilerJobs, while ignoring the metadata
 function Base.hash(job::CompilerJob, h::UInt)
     h = hash(job.target, h)
     h = hash(job.source, h)
     h = hash(job.params, h)
     h = hash(job.entry_abi, h)
     h
-end
-function Base.isequal(a::CompilerJob, b::CompilerJob)
-    a.target == b.target &&
-    a.source == b.source &&
-    a.params == b.params &&
-    a.entry_abi == b.entry_abi
 end
 
 

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -356,37 +356,6 @@ function classify_arguments(@nospecialize(job::CompilerJob), codegen_ft::LLVM.Fu
     return args
 end
 
-function classify_fields(julia::DataType, llvm::LLVMType)
-    nfields = fieldcount(julia)
-    fieldoffsets = [fieldoffset(julia, i) for i in 1:nfields]
-    fieldsizes = similar(fieldoffsets)
-    for i in 1:nfields
-        field_start = fieldoffsets[i]
-        field_end = i == nfields ? sizeof(julia) : fieldoffsets[i+1]
-        fieldsizes[i] = field_end - field_start
-    end
-    fieldsizes
-
-    args = []
-    codegen_i = 1
-    for source_i in 1:nfields
-        source_name = fieldname(julia, source_i)
-        source_typ = fieldtype(julia, source_i)
-        if fieldsizes[source_i] == 0
-            push!(args, (; typ=source_typ, name=source_name))
-            continue
-        end
-
-        # NOTE: a cc doesn't make sense here, so the lack of codegen field should be checked
-
-        codegen_typ = elements(llvm)[codegen_i]
-        push!(args, (typ=source_typ, name=source_name, codegen=(typ=codegen_typ, i=codegen_i)))
-        codegen_i += 1
-    end
-
-    return args
-end
-
 if VERSION >= v"1.7.0-DEV.204"
     function is_immutable_datatype(T::Type)
         isa(T,DataType) && !Base.ismutabletype(T)

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -43,23 +43,6 @@ isintrinsic(@nospecialize(job::CompilerJob{MetalCompilerTarget}), fn::String) =
 const LLVMMETALFUNCCallConv   = LLVM.API.LLVMCallConv(102)
 const LLVMMETALKERNELCallConv = LLVM.API.LLVMCallConv(103)
 
-const metal_struct_names = [:MtlDeviceArray, :MtlDeviceMatrix, :MtlDeviceVector]
-
-# Initial mapping of types - There has to be a better way
-const jl_type_to_c = Dict(
-                    Float32 => "float",
-                    Float16 => "half",
-                    Int64   => "long",
-                    UInt64  => "ulong",
-                    Int32   => "int",
-                    UInt32  => "uint",
-                    Int16   => "short",
-                    UInt16  => "ushort",
-                    Int8    => "char",
-                    UInt8   => "uchar",
-                    Bool    => "char" # xxx: ?
-                )
-
 function process_module!(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module)
     # calling convention
     for f in functions(mod)
@@ -552,80 +535,61 @@ end
 #
 # module metadata is used to identify buffers that are passed as kernel arguments.
 
-# TODO: MDString(::Symbol)?
-
-# XXX: we translate Julia types to C typenames. that's not required, but reduces the diff
-#      while working on this code. after that, just report the full type name (no `nameof`)
-type_mapping = Dict(
-    "Int32" => "int",
-    "Int64" => "long",
-)
-function humanize_typename(typ)
-    name = string(nameof(typ))
-    get(type_mapping, name, name)
-end
-
-# return the Julia element type of a type represented by an LLVM ArrayType
-# (i.e., not only tuples, but every homogeneous structure)
-function generalized_eltype(typ)
-    if typ <: Tuple
-        eltype(typ)
-    else # homogeneous struct
-        typs = unique(fieldtypes(typ))
-        @assert length(typs) == 1 "LLVM array type used with non-homogeneous struct $typ"
-        typs[]
-    end
-end
-
-# TODO: express different argument types using Julia types
-@enum ArgumentKind begin
-    GhostArgument
-    BufferArgument
-    ArrayArgument
-    ConstantArgument
-    StructArgument
-    IndirectStructArgument
-end
-struct ArgumentInfo
-    name::String
-    kind::ArgumentKind
-    id::Union{Nothing,Int}
-    fields::Union{Nothing,Vector{ArgumentInfo}}
-
-    ArgumentInfo(name, kind, id=nothing, fields=nothing) = new(string(name), kind, id, fields)
-end
-
-# TODO: split metadata encoding in two separate passes:
-# - first build the ArgumentInfo tree
-# - then use it to generate metadata and pass the same tree to the front-end
+# TODO: remove metadata emission infrastructure from GPUCompiler
 
 function add_argument_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
                                 entry::LLVM.Function, used_intrinsics::Vector)
     ctx = context(mod)
 
     ## argument info
-    arg_infos = Metadata[]      # information for Metal
-    arg_metas = ArgumentInfo[]  # metadata for Metal.jl
+    arg_infos = Metadata[]
 
     # Iterate through arguments and create metadata for them
     args = classify_arguments(job, eltype(llvmtype(entry)))
-    for (i, arg) in enumerate(args)
-        if !haskey(arg, :codegen)
-            push!(arg_metas, ArgumentInfo(arg.name, GhostArgument))
-            continue
-        end
+    i = 1
+    for arg in args
+        haskey(arg, :codegen) || continue
         @assert arg.codegen.typ isa LLVM.PointerType
 
-        # if an argument is a structure containing resources (buffers, textures, samplers,
-        # constants), as opposed to passing a resource directly, it will be encoded using a
-        # argument encoder targeting an argument buffer. this requires the fields of the
-        # structure to have a (monotonically increasing) resource identifier. see also:
-        # https://developer.apple.com/documentation/metal/buffers/indexing_argument_buffers
+        # NOTE: we emit the bare minimum of argument metadata to support
+        #       bindless argument encoding. Actually using the argument encoder
+        #       APIs (deprecated in Metal 3) turned out too difficult, given the
+        #       undocumented nature of the argument metadata, and the complex
+        #       arguments we encounter with typical Julia kernels.
 
-        arg_info, arg_meta, _ = encode_argument(arg; ctx)
-        push!(arg_infos, MDNode(arg_info; ctx))
+        md = Metadata[]
 
-        push!(arg_metas, arg_meta)
+        # argument index
+        push!(md, Metadata(ConstantInt(Int32(arg.codegen.i-1); ctx)))
+
+        push!(md, MDString("air.buffer"; ctx))
+
+        push!(md, MDString("air.location_index"; ctx))
+        push!(md, Metadata(ConstantInt(Int32(arg.codegen.i-1); ctx)))
+
+        # XXX: unknown
+        push!(md, Metadata(ConstantInt(Int32(1); ctx)))
+
+        push!(md, MDString("air.read_write"; ctx)) # TODO: Check for const array
+
+        push!(md, MDString("air.address_space"; ctx))
+        push!(md, Metadata(ConstantInt(Int32(addrspace(arg.codegen.typ)); ctx)))
+
+        arg_type = if arg.typ <: Core.LLVMPtr
+            arg.typ.parameters[1]
+        else
+            arg.typ
+        end
+
+        push!(md, MDString("air.arg_type_size"; ctx))
+        push!(md, Metadata(ConstantInt(Int32(sizeof(arg_type)); ctx)))
+
+        push!(md, MDString("air.arg_type_align_size"; ctx))
+        push!(md, Metadata(ConstantInt(Int32(Base.datatype_alignment(arg_type)); ctx)))
+
+        push!(arg_infos, MDNode(md; ctx))
+
+        i += 1
     end
 
     # Create metadata for argument intrinsics last
@@ -645,6 +609,8 @@ function add_argument_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Modul
         push!(arg_infos, arg_info)
     end
     arg_infos = MDNode(arg_infos; ctx)
+
+
     ## stage info
     stage_infos = Metadata[]
     stage_infos = MDNode(stage_infos; ctx)
@@ -652,220 +618,7 @@ function add_argument_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Modul
     kernel_md = MDNode([entry, stage_infos, arg_infos]; ctx)
     push!(metadata(mod)["air.kernel"], kernel_md)
 
-    job.meta[:arguments] = arg_metas
     return
-end
-
-function encode_argument(arg, id=0; ctx)
-    md = Metadata[]
-
-    # argument index
-    push!(md, Metadata(ConstantInt(Int32(arg.codegen.i-1); ctx)))
-
-    if arg.codegen.typ isa LLVM.PointerType
-        eltyp = eltype(arg.codegen.typ)
-
-        push!(md, MDString("air.buffer"; ctx))
-
-        push!(md, MDString("air.location_index"; ctx))
-        if id == 0
-            # for top-level arguments (which start at id=0), this value seems to represent
-            # the index of the argument, whereas for nested arguments it's just the id...
-            push!(md, Metadata(ConstantInt(Int32(arg.codegen.i-1); ctx)))
-        else
-            push!(md, Metadata(ConstantInt(Int32(id); ctx)))
-        end
-
-        push!(md, Metadata(ConstantInt(Int32(1); ctx))) # XXX: unknown
-
-        push!(md, MDString("air.read_write"; ctx)) # TODO: Check for const array
-
-        if eltyp isa LLVM.StructType
-            push!(md, MDString("air.struct_type_info"; ctx))
-            nested_info, nested_meta, ids, indirect = encode_struct(arg, id, eltyp; ctx)
-            if indirect
-                md[2] = MDString("air.indirect_buffer"; ctx)
-            end
-            push!(md, MDNode(nested_info; ctx))
-            info = ArgumentInfo(arg.name,
-                                indirect ? IndirectStructArgument : StructArgument,
-                                nothing, nested_meta)
-        elseif eltyp isa LLVM.ArrayType
-            # XXX: duplication with encode_struct
-            ids = length(eltyp)
-            let eltyp=eltyp
-                eltyp = eltype(eltyp)
-                while eltyp isa LLVM.ArrayType
-                    ids *= length(eltyp)
-                    eltyp = eltype(eltyp)
-                end
-            end
-            info = ArgumentInfo(arg.name, ArrayArgument, id)
-        else
-            ids = 1
-            info = ArgumentInfo(arg.name, BufferArgument, id)
-        end
-
-        # buffers require to report the alignment of the element type
-        # TODO: deduplicate with the same logic below
-        # TODO: what to do with array types?
-        arg_type = if arg.typ <: Core.LLVMPtr
-            arg.typ.parameters[1]
-        else
-            arg.typ
-        end
-
-        push!(md, MDString("air.arg_type_size"; ctx))
-        push!(md, Metadata(ConstantInt(Int32(sizeof(arg_type)); ctx)))
-
-        push!(md, MDString("air.arg_type_align_size"; ctx))
-        push!(md, Metadata(ConstantInt(Int32(Base.datatype_alignment(arg_type)); ctx)))
-    else
-        # this can only happen with indirect argument, i.e., as part of a struct
-
-        ids = 1
-
-        push!(md, MDString("air.indirect_constant"; ctx))
-
-        push!(md, MDString("air.location_index"; ctx))
-        push!(md, Metadata(ConstantInt(Int32(id); ctx)))
-        push!(md, Metadata(ConstantInt(Int32(1); ctx))) # XXX: unknown
-
-        info = ArgumentInfo(arg.name, ConstantArgument, id)
-    end
-
-    push!(md, MDString("air.arg_type_name"; ctx))
-    if arg.typ <: Core.LLVMPtr
-        # in the case of buffers, the element type is encoded
-        push!(md, MDString(humanize_typename(arg.typ.parameters[1]); ctx))
-    else
-        push!(md, MDString(humanize_typename(arg.typ); ctx))
-    end
-    # TODO: duplication with encode_struct
-
-    # NOTE: this is optional
-    push!(md, MDString("air.arg_name"; ctx))
-    push!(md, MDString(string(arg.name); ctx))
-
-    return md, info, ids
-end
-
-function encode_struct(arg, offset, typ=arg.codegen.typ; indirect=false, ctx)
-    md = Metadata[]
-    infos = ArgumentInfo[]
-
-    # the `indirect` keyword argument controls whether we should emit `!indirect_argument`
-    # metadata for all fields of this structure. this flag is set when encountering a
-    # (nested) buffer, in which case earlier fields also need an `!indirect_argument` entry.
-    # we implement this by restarting the process and calling `encode_struct` again.
-
-    # the `typ` argument allows overriding the type of this structure. this is needed to
-    # overcome the difference between struct arguments (passed by reference, i.e., pointer)
-    # and nested structs which are a value contained in another object.
-
-    fields = classify_fields(arg.typ, typ)
-    ids = 0
-    id = offset
-    for (i, field) in enumerate(fields)
-        # skip ghost fields
-        if !haskey(field, :codegen)
-            push!(infos, ArgumentInfo(field.name, GhostArgument))
-            continue
-        end
-
-        if field.codegen.typ isa LLVM.StructType
-            push!(md, MDString("air.struct_type_info"; ctx))
-            nested_md, nested_info, field_ids, nested_indirect =
-                encode_struct(field, id; ctx, indirect)
-            if nested_indirect && !indirect
-                # backtrack and restart the process with indirect=true
-                return encode_struct(arg, offset, typ; ctx, indirect=true)
-            end
-            push!(md, MDNode(nested_md; ctx))
-            field_info = ArgumentInfo(field.name,
-                                      indirect ? IndirectStructArgument : StructArgument,
-                                      nothing, nested_info)
-        elseif field.codegen.typ isa LLVM.ArrayType
-            field_ids = length(field.codegen.typ)
-            element_typ = eltype(field.codegen.typ)
-            while element_typ isa LLVM.ArrayType
-                field_ids *= length(element_typ)
-                element_typ = eltype(element_typ)
-            end
-            field_info = ArgumentInfo(field.name, ArrayArgument, id)
-        elseif field.codegen.typ isa LLVM.VectorType
-            error("Vector types are not supported")
-        elseif field.codegen.typ isa LLVM.PointerType
-            if !indirect
-                # NOTE: we detect actual LLVM pointers here, meaning we only support buffer
-                #       fields encoded by Core.LLVMPtr, not Base.Ptr (encoded as an integer)
-                # TODO: can we support regular Julia pointers? if so, we wouldn't have to
-                #       look for Ptr/LLVMPtr anymore, but could just use the LLVM type
-                #       representation. on the other hand, to support textures etc, we'll
-                #       have to look at the Julia type representation anyway.
-                return encode_struct(arg, offset, typ; ctx, indirect=true)
-            end
-            field_ids = 1
-            field_info = ArgumentInfo(field.name, BufferArgument, id)
-        else
-            field_ids = 1
-            field_info = ArgumentInfo(field.name, ConstantArgument, indirect ? id : nothing)
-        end
-
-        # Offset in bytes from start of struct
-        push!(md, Metadata(ConstantInt(Int32(fieldoffset(arg.typ, i)); ctx)))
-
-        # Size of element in bytes, always 8 for buffers (pointer size)
-        if field.codegen.typ isa LLVM.ArrayType
-            push!(md, Metadata(ConstantInt(Int32(sizeof(generalized_eltype(field.typ))); ctx)))
-        else
-            push!(md, Metadata(ConstantInt(Int32(sizeof(field.typ)); ctx)))
-        end
-
-        # Length of element, always 0 for buffers
-        if field.codegen.typ isa LLVM.ArrayType
-            push!(md, Metadata(ConstantInt(Int32(length(field.codegen.typ)); ctx)))
-        else
-            push!(md, Metadata(ConstantInt(Int32(0); ctx)))
-        end
-
-        # Field type
-        if field.typ <: Core.LLVMPtr
-            # in the case of buffers, the element type is encoded
-            push!(md, MDString(humanize_typename(field.typ.parameters[1]); ctx))
-        else
-            push!(md, MDString(humanize_typename(field.typ); ctx))
-        end
-        # TODO: in the case of LLVM.ArrayType (coming from a tuple, or homogeneous struct)
-        #       the element type should be reported as well
-
-        # Field name
-        push!(md, MDString(string(field.name); ctx))
-
-        if indirect
-            push!(md, MDString("air.indirect_argument"; ctx))
-            # numbering of the fields of an indirect arguments begins at id 0 again
-            # TODO: does that mean we should reuse code at a higher level?
-            indirect_id = id - offset
-            if field.codegen.typ isa LLVM.StructType
-                push!(md, Metadata(ConstantInt(Int32(indirect_id); ctx)))
-            else
-                indirect_md, indirect_info, indirect_ids =
-                    encode_argument(field, indirect_id; ctx)
-                #@assert indirect_ids == field_ids
-                # XXX: for non-ptr arguments, encode_argument always assumes a constant.
-                #      that isn't true; it could also be an array, with multiple IDs.
-                #      enable the assertion above to identify such cases.
-                push!(md, MDNode(indirect_md; ctx))
-            end
-        end
-
-        id += field_ids
-        ids += field_ids
-        push!(infos, field_info)
-    end
-
-    return md, infos, ids, indirect
 end
 
 


### PR DESCRIPTION
Latest version of the Metal API greatly simplifies argument passing -- no complicated metadata required anymore -- so let's get rid of most of the code supporting that.