### PR TITLE
Slightly improve validation error message

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -113,12 +113,12 @@ const DYNAMIC_CALL     = "dynamic function invocation"
 function Base.showerror(io::IO, err::InvalidIRError)
     print(io, "InvalidIRError: compiling ", err.job.source, " resulted in invalid LLVM IR")
     for (kind, bt, meta) in err.errors
-        print(io, "\nReason: unsupported $kind")
+        printstyled(io, "\nReason: unsupported $kind"; color=:red)
         if meta !== nothing
             if kind == RUNTIME_FUNCTION || kind == UNKNOWN_FUNCTION || kind == POINTER_FUNCTION || kind == DYNAMIC_CALL
-                print(io, " (call to ", meta, ")")
+                printstyled(io, " (call to ", meta, ")"; color=:red)
             elseif kind == DELAYED_BINDING
-                print(io, " (use of '", meta, "')")
+                printstyled(io, " (use of '", meta, "')"; color=:red)
             end
         end
         Base.show_backtrace(io, bt)

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -128,7 +128,7 @@ function Base.showerror(io::IO, err::InvalidIRError)
     printstyled(
         io,
         ": catch this exception as `err` and call `code_typed(err; interactive = true)` to",
-        " introspect the erronous code";
+        " introspect the erronous code with Cthulhu.jl";
         color = :cyan,
     )
     return


### PR DESCRIPTION
@claforte indicated that the `Reason` text is easy to miss in the noise, and also that it's not immediately clear that Cthulhu.jl is necessary for interactive reflection. Of course, trying to do `code_typed(err; interactive=true)` will throw an appropriate error if Cthulhu is not available, but it seems that it might be helpful to point that out earlier rather than later.