### PR TITLE
Disable checksum verification during Julia build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           path: 'julia'
       - name: Compile Julia
         run: |
+          sed -i.bak 's/exit 2/exit 0/g' julia/deps/tools/jlchecksum
           make -C julia -j $(nproc) FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1 JULIA_PRECOMPILE=0
           echo $PWD/julia/usr/bin >> $GITHUB_PATH
       - uses: actions/cache@v1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,11 +59,19 @@ end
 macro locked(ex)
     def = splitdef(ex)
     def[:body] = quote
-        ccall(:jl_typeinf_begin, Cvoid, ())
+        if VERSION >= v"1.9.0-DEV.1308"
+            ccall(:jl_typeinf_lock_begin, Cvoid, ())
+        else
+            ccall(:jl_typeinf_begin, Cvoid, ())
+        end
         try
             $(def[:body])
         finally
-            ccall(:jl_typeinf_end, Cvoid, ())
+            if VERSION >= v"1.9.0-DEV.1308"
+                ccall(:jl_typeinf_lock_end, Cvoid, ())
+            else
+                ccall(:jl_typeinf_end, Cvoid, ())
+            end
         end
     end
     esc(combinedef(def))
@@ -73,11 +81,19 @@ end
 macro unlocked(ex)
     def = splitdef(ex)
     def[:body] = quote
-        ccall(:jl_typeinf_end, Cvoid, ())
+        if VERSION >= v"1.9.0-DEV.1308"
+            ccall(:jl_typeinf_lock_end, Cvoid, ())
+        else
+            ccall(:jl_typeinf_end, Cvoid, ())
+        end
         try
             $(def[:body])
         finally
-            ccall(:jl_typeinf_begin, Cvoid, ())
+            if VERSION >= v"1.9.0-DEV.1308"
+                ccall(:jl_typeinf_lock_begin, Cvoid, ())
+            else
+                ccall(:jl_typeinf_begin, Cvoid, ())
+            end
         end
     end
     esc(combinedef(def))


### PR DESCRIPTION
This is broken on 1.7.