### PR TITLE
Annotate exit/trap with noreturn & inaccessiblememonly

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -265,11 +265,14 @@ function emit_exception!(builder, name, inst)
     # report the exception
     if Base.JLOptions().debug_level >= 1
         name = globalstring_ptr!(builder, name, "exception")
-        if Base.JLOptions().debug_level == 1
+        c = if Base.JLOptions().debug_level == 1
             call!(builder, Runtime.get(:report_exception), [name])
         else
             call!(builder, Runtime.get(:report_exception_name), [name])
         end
+        callsite_attribute!(c, (
+            LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
+            LLVM.EnumAttribute("writeonly", 0; ctx)))
     end
 
     # report each frame
@@ -287,7 +290,10 @@ function emit_exception!(builder, name, inst)
     end
 
     # signal the exception
-    call!(builder, Runtime.get(:signal_exception))
+    c = call!(builder, Runtime.get(:signal_exception))
+    callsite_attribute!(c, (
+        LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
+        LLVM.EnumAttribute("writeonly", 0; ctx)))
 
     emit_trap!(job, builder, mod, inst)
 end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -409,7 +409,6 @@ function hide_trap!(mod::LLVM.Module)
                         LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
                         LLVM.EnumAttribute("writeonly", 0; ctx), # can we do readnone?
                         LLVM.EnumAttribute("noreturn", 0; ctx)))
-                 end
                 end
                 unsafe_delete!(LLVM.parent(val), val)
                 changed = true

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -404,7 +404,11 @@ function hide_trap!(mod::LLVM.Module)
             if isa(val, LLVM.CallInst)
                 @dispose builder=Builder(ctx) begin
                     position!(builder, val)
-                    call!(builder, exit)
+                    c = call!(builder, exit)
+                    # TODO: Make a nice API for this in LLVM.jl
+                    LLVM.API.LLVMAddCallSiteAttribute(c, LLVM.API.LLVMAttributeFunctionIndex, LLVM.EnumAttribute("inaccessiblememonly", 0; ctx))
+                    LLVM.API.LLVMAddCallSiteAttribute(c, LLVM.API.LLVMAttributeFunctionIndex, LLVM.EnumAttribute("writeonly", 0; ctx)) # can we readnone?
+                    LLVM.API.LLVMAddCallSiteAttribute(c, LLVM.API.LLVMAttributeFunctionIndex, LLVM.EnumAttribute("noreturn", 0; ctx))
                 end
                 unsafe_delete!(LLVM.parent(val), val)
                 changed = true

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -405,10 +405,11 @@ function hide_trap!(mod::LLVM.Module)
                 @dispose builder=Builder(ctx) begin
                     position!(builder, val)
                     c = call!(builder, exit)
-                    # TODO: Make a nice API for this in LLVM.jl
-                    LLVM.API.LLVMAddCallSiteAttribute(c, LLVM.API.LLVMAttributeFunctionIndex, LLVM.EnumAttribute("inaccessiblememonly", 0; ctx))
-                    LLVM.API.LLVMAddCallSiteAttribute(c, LLVM.API.LLVMAttributeFunctionIndex, LLVM.EnumAttribute("writeonly", 0; ctx)) # can we readnone?
-                    LLVM.API.LLVMAddCallSiteAttribute(c, LLVM.API.LLVMAttributeFunctionIndex, LLVM.EnumAttribute("noreturn", 0; ctx))
+                    callsite_attribute!(c, (
+                        LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
+                        LLVM.EnumAttribute("writeonly", 0; ctx), # can we do readnone?
+                        LLVM.EnumAttribute("noreturn", 0; ctx)))
+                 end
                 end
                 unsafe_delete!(LLVM.parent(val), val)
                 changed = true

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -98,3 +98,10 @@ macro unlocked(ex)
     end
     esc(combinedef(def))
 end
+
+function callsite_attribute!(call, attributes)
+    # TODO: Make a nice API for this in LLVM.jl
+    for attribute in attributes
+        LLVM.API.LLVMAddCallSiteAttribute(call, LLVM.API.LLVMAttributeFunctionIndex, attribute)
+    end
+end


### PR DESCRIPTION
This should help Enzyme to not assume that this assembly has
any effects it needs to handle.
