### PR TITLE
MethodInstances are unique so we can use an IdDict here.

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -5,7 +5,7 @@
 using Core.Compiler: CodeInstance, MethodInstance, InferenceParams, OptimizationParams
 
 struct CodeCache
-    dict::Dict{MethodInstance,Vector{CodeInstance}}
+    dict::IdDict{MethodInstance,Vector{CodeInstance}}
 
     CodeCache() = new(Dict{MethodInstance,Vector{CodeInstance}}())
 end


### PR DESCRIPTION
MIs are considered unique by pointer-identity. So use an IdDict here since that will allow for serialization and de-serialization.

cc: @collinwarner