### PR TITLE
Implement always_inline as a CompilerJob property

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -11,7 +11,7 @@ Base.@kwdef struct MetalCompilerTarget <: AbstractCompilerTarget
 end
 
 function Base.hash(target::MetalCompilerTarget, h::UInt)
-    hash(target.macos, h)
+    h = hash(target.macos, h)
 end
 
 source_code(target::MetalCompilerTarget) = "text"

--- a/src/native.jl
+++ b/src/native.jl
@@ -7,10 +7,9 @@ export NativeCompilerTarget
 Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
     cpu::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
     features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
-    always_inline::Bool=false # will mark the job function as always inline
+    llvm_always_inline::Bool=false # will mark the job function as always inline
     jlruntime::Bool=true # Use Julia runtime for throwing errors, instead of the GPUCompiler support
 end
-
 llvm_triple(::NativeCompilerTarget) = Sys.MACHINE
 
 function llvm_machine(target::NativeCompilerTarget)
@@ -26,7 +25,7 @@ end
 
 function process_entry!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     ctx = context(mod)
-    if job.target.always_inline
+    if job.target.llvm_always_inline
         push!(function_attributes(entry), EnumAttribute("alwaysinline", 0; ctx))
     end
     invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -21,7 +21,6 @@ Base.@kwdef struct PTXCompilerTarget <: AbstractCompilerTarget
     maxthreads::Union{Nothing,Int,NTuple{<:Any,Int}} = nothing
     blocks_per_sm::Union{Nothing,Int} = nothing
     maxregs::Union{Nothing,Int} = nothing
-    always_inline::Bool = false
 end
 
 function Base.hash(target::PTXCompilerTarget, h::UInt)
@@ -36,7 +35,6 @@ function Base.hash(target::PTXCompilerTarget, h::UInt)
     h = hash(target.maxthreads, h)
     h = hash(target.blocks_per_sm, h)
     h = hash(target.maxregs, h)
-    h = hash(target.always_inline, h)
 
     h
 end
@@ -76,7 +74,6 @@ function Base.show(io::IO, @nospecialize(job::CompilerJob{PTXCompilerTarget}))
     job.target.maxthreads !== nothing && print(io, ", maxthreads=$(job.target.maxthreads)")
     job.target.blocks_per_sm !== nothing && print(io, ", blocks_per_sm=$(job.target.blocks_per_sm)")
     job.target.maxregs !== nothing && print(io, ", maxregs=$(job.target.maxregs)")
-    job.target.always_inline !== nothing && print(io, ", always_inline=$(job.target.always_inline)")
 end
 
 const ptx_intrinsics = ("vprintf", "__assertfail", "malloc", "free")
@@ -88,20 +85,6 @@ runtime_slug(@nospecialize(job::CompilerJob{PTXCompilerTarget})) =
     "ptx-sm_$(job.target.cap.major)$(job.target.cap.minor)" *
        "-debuginfo=$(Int(llvm_debug_info(job)))" *
        "-exitable=$(job.target.exitable)"
-
-function optimization_params(@nospecialize(job::CompilerJob{PTXCompilerTarget}))
-    kwargs = NamedTuple()
-
-    if VERSION < v"1.8.0-DEV.486"
-        kwargs = (kwargs..., unoptimize_throw_blocks=false)
-    end
-
-    if job.target.always_inline
-        kwargs = (kwargs..., inline_cost_threshold=typemax(Int))
-    end
-
-    return OptimizationParams(;kwargs...)
-end
 
 function process_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}), mod::LLVM.Module)
     ctx = context(mod)

--- a/test/definitions/bpf.jl
+++ b/test/definitions/bpf.jl
@@ -7,11 +7,12 @@ end
 
 # create a native test compiler, and generate reflection methods for it
 
-function bpf_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
+function bpf_job(@nospecialize(func), @nospecialize(types);
+                 kernel::Bool=false, always_inline=false, kwargs...)
     source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = BPFCompilerTarget()
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    CompilerJob(target, source, params; always_inline), kwargs
 end
 
 function bpf_code_llvm(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/gcn.jl
+++ b/test/definitions/gcn.jl
@@ -7,11 +7,12 @@ end
 
 # create a GCN-based test compiler, and generate reflection methods for it
 
-function gcn_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
+function gcn_job(@nospecialize(func), @nospecialize(types); 
+                 kernel::Bool=false, always_inline=false, kwargs...)
     source = FunctionSpec(typeof(func), Base.to_tuple_type(types), kernel)
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    CompilerJob(target, source, params; always_inline), kwargs
 end
 
 function gcn_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/metal.jl
+++ b/test/definitions/metal.jl
@@ -7,11 +7,12 @@ end
 
 # create a Metal test compiler, and generate reflection methods for it
 
-function metal_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
+function metal_job(@nospecialize(func), @nospecialize(types);
+                   kernel::Bool=false, always_inline=false, kwargs...)
     source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = MetalCompilerTarget(; macos=v"12.2")
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    CompilerJob(target, source, params; always_inline), kwargs
 end
 
 function metal_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/native.jl
+++ b/test/definitions/native.jl
@@ -19,11 +19,13 @@ end
 GPUCompiler.method_table(@nospecialize(job::NativeCompilerJob)) = method_table
 GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.params.entry_safepoint
 
-function native_job(@nospecialize(f_type), @nospecialize(types); kernel::Bool=false, entry_abi=:specfunc, entry_safepoint::Bool=false, kwargs...)
+function native_job(@nospecialize(f_type), @nospecialize(types);
+                    kernel::Bool=false, entry_abi=:specfunc, entry_safepoint::Bool=false,
+                    always_inline=false, llvm_always_inline=true, kwargs...)
     source = FunctionSpec(f_type, Base.to_tuple_type(types), kernel)
-    target = NativeCompilerTarget(always_inline=true)
+    target = NativeCompilerTarget(;llvm_always_inline)
     params = TestCompilerParams(entry_safepoint)
-    CompilerJob(target, source, params, entry_abi), kwargs
+    CompilerJob(target, source, params, entry_abi, always_inline), kwargs
 end
 
 function native_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -41,12 +41,11 @@ function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                  minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
                  maxregs=nothing, always_inline=false, kwargs...)
     source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
-    target = PTXCompilerTarget(cap=v"7.0",
-                               minthreads=minthreads, maxthreads=maxthreads,
-                               blocks_per_sm=blocks_per_sm, maxregs=maxregs,
-                               always_inline=always_inline)
+    target = PTXCompilerTarget(;cap=v"7.0",
+                               minthreads, maxthreads,
+                               blocks_per_sm, maxregs)
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    CompilerJob(target, source, params; always_inline), kwargs
 end
 
 function ptx_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/spirv.jl
+++ b/test/definitions/spirv.jl
@@ -7,11 +7,12 @@ end
 
 # create a SPIRV-based test compiler, and generate reflection methods for it
 
-function spirv_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false, kwargs...)
+function spirv_job(@nospecialize(func), @nospecialize(types);
+                   kernel::Bool=false, always_inline=false, kwargs...)
     source = FunctionSpec(func, Base.to_tuple_type(types), kernel)
     target = SPIRVCompilerTarget()
     params = TestCompilerParams()
-    CompilerJob(target, source, params), kwargs
+    CompilerJob(target, source, params; always_inline), kwargs
 end
 
 function spirv_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -38,34 +38,6 @@ if VERSION < v"1.9.0-DEV.1018"
 end
 end
 
-@testset "always_inline" begin
-    @eval f_expensive(x) = $(foldl((e, _) -> :(sink($e) + sink(x)), 1:100; init=:x))
-    function g(x)
-        f_expensive(x)
-        return
-    end
-    function h(x)
-        f_expensive(x)
-        return
-    end
-
-    ir = sprint(io->gcn_code_llvm(io, g, Tuple{Int64}; dump_module=true,
-                                  kernel=true))
-    @test occursin(r"^define.*julia_f_expensive"m, ir)
-
-    ir = sprint(io->gcn_code_llvm(io, g, Tuple{Int64}; dump_module=true,
-                                  kernel=true, always_inline=true))
-    @test !occursin(r"^define.*julia_f_expensive"m, ir)
-
-    ir = sprint(io->gcn_code_llvm(io, h, Tuple{Int64}; dump_module=true,
-                                  kernel=true, always_inline=true))
-    @test !occursin(r"^define.*julia_f_expensive"m, ir)
-
-    ir = sprint(io->gcn_code_llvm(io, h, Tuple{Int64}; dump_module=true,
-                                  kernel=true))
-    @test occursin(r"^define.*julia_f_expensive"m, ir)
-end
-
 end
 
 ############################################################################################

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -38,6 +38,34 @@ if VERSION < v"1.9.0-DEV.1018"
 end
 end
 
+@testset "always_inline" begin
+    @eval f_expensive(x) = $(foldl((e, _) -> :(sink($e) + sink(x)), 1:100; init=:x))
+    function g(x)
+        f_expensive(x)
+        return
+    end
+    function h(x)
+        f_expensive(x)
+        return
+    end
+
+    ir = sprint(io->gcn_code_llvm(io, g, Tuple{Int64}; dump_module=true,
+                                  kernel=true))
+    @test occursin(r"^define.*julia_f_expensive"m, ir)
+
+    ir = sprint(io->gcn_code_llvm(io, g, Tuple{Int64}; dump_module=true,
+                                  kernel=true, always_inline=true))
+    @test !occursin(r"^define.*julia_f_expensive"m, ir)
+
+    ir = sprint(io->gcn_code_llvm(io, h, Tuple{Int64}; dump_module=true,
+                                  kernel=true, always_inline=true))
+    @test !occursin(r"^define.*julia_f_expensive"m, ir)
+
+    ir = sprint(io->gcn_code_llvm(io, h, Tuple{Int64}; dump_module=true,
+                                  kernel=true))
+    @test occursin(r"^define.*julia_f_expensive"m, ir)
+end
+
 end
 
 ############################################################################################

--- a/test/native.jl
+++ b/test/native.jl
@@ -202,6 +202,32 @@ end
     end
 end
 
+@testset "always_inline" begin
+    @eval f_expensive(x) = $(foldl((e, _) -> :(sink($e) + sink(x)), 1:100; init=:x))
+    function g(x)
+        f_expensive(x)
+        return
+    end
+    function h(x)
+        f_expensive(x)
+        return
+    end
+
+    ir = sprint(io->native_code_llvm(io, g, Tuple{Int64}; dump_module=true, kernel=true))
+    @test occursin(r"^define.*julia_f_expensive"m, ir)
+
+    ir = sprint(io->native_code_llvm(io, g, Tuple{Int64}; dump_module=true, kernel=true,
+                                     always_inline=true))
+    @test !occursin(r"^define.*julia_f_expensive"m, ir)
+
+    ir = sprint(io->native_code_llvm(io, h, Tuple{Int64}; dump_module=true, kernel=true,
+                                     always_inline=true))
+    @test !occursin(r"^define.*julia_f_expensive"m, ir)
+
+    ir = sprint(io->native_code_llvm(io, h, Tuple{Int64}; dump_module=true, kernel=true))
+    @test occursin(r"^define.*julia_f_expensive"m, ir)
+end
+
 end
 
 ############################################################################################

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -174,32 +174,6 @@ end
 end
 end
 
-@testset "always_inline" begin
-    @eval f_expensive(x) = $(foldl((e, _) -> :(sink($e) + sink(x)), 1:100; init=:x))
-    function g(x)
-        f_expensive(x)
-        return
-    end
-    function h(x)
-        f_expensive(x)
-        return
-    end
-
-    asm = sprint(io->ptx_code_native(io, g, Tuple{Int64}; kernel=true))
-    @test occursin(r"\.func .*julia_f_expensive", asm)
-
-    asm = sprint(io->ptx_code_native(io, g, Tuple{Int64};
-                                     kernel=true, always_inline=true))
-    @test !occursin(r"\.func .*julia_f_expensive", asm)
-
-    asm = sprint(io->ptx_code_native(io, h, Tuple{Int64};
-                                     kernel=true, always_inline=true))
-    @test !occursin(r"\.func .*julia_f_expensive", asm)
-
-    asm = sprint(io->ptx_code_native(io, h, Tuple{Int64}; kernel=true))
-    @test occursin(r"\.func .*julia_f_expensive", asm)
-end
-
 @testset "child function reuse" begin
     # bug: depending on a child function from multiple parents resulted in
     #      the child only being present once


### PR DESCRIPTION
@maleadt remind me should we put `always_inline` into `runtime_slug`?

I also noticed that `PTXCompilerTarget` implements `hash`, but `GCNCompilerTarget` doesn't.
