### PR TITLE
Make verify on CI by default

### DIFF
--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -9,12 +9,6 @@ using ExprTools: splitdef, combinedef
 
 using Libdl
 
-const to = TimerOutput()
-
-timings() = (TimerOutputs.print_timer(to); println())
-
-enable_timings() = (TimerOutputs.enable_debug_timings(GPUCompiler); return)
-
 include("utils.jl")
 
 # compiler interface and implementations

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -402,7 +402,7 @@ const __llvm_initialized = Ref(false)
             end
         end
 
-        if ccall(:jl_is_debugbuild, Cint, ()) == 1
+        if should_verify()
             @timeit_debug to "verification" verify(ir)
         end
     end

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -653,7 +653,7 @@ function add_kernel_state!(mod::LLVM.Module)
                 end
             end
         end
-        return nothing
+        return nothing # do not claim responsibility
     end
     for (f, new_f) in workmap
         # use a value mapper for rewriting function arguments

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,6 +2,21 @@ defs(mod::LLVM.Module)  = filter(f -> !isdeclaration(f), collect(functions(mod))
 decls(mod::LLVM.Module) = filter(f ->  isdeclaration(f) && !LLVM.isintrinsic(f),
                                  collect(functions(mod)))
 
+## timings
+
+const to = TimerOutput()
+
+timings() = (TimerOutputs.print_timer(to); println())
+
+enable_timings() = (TimerOutputs.enable_debug_timings(GPUCompiler); return)
+
+
+## debug verification
+
+should_verify() = ccall(:jl_is_debugbuild, Cint, ()) == 1 ||
+                  Base.JLOptions().debug_level >= 2 ||
+                  parse(Bool, get(ENV, "CI", "false"))
+
 
 ## lazy module loading
 

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -85,7 +85,7 @@ end
 
 ############################################################################################
 
-@testset "asm" begin
+Sys.isapple() && @testset "asm" begin
 
 @testset "smoke test" begin
     kernel() = return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,9 +19,9 @@ GPUCompiler.enable_timings()
 include("native.jl")
 include("ptx.jl")
 include("spirv.jl")
-include("gcn.jl")
 include("bpf.jl")
-if Sys.isapple() && Base.thisminor(VERSION) == v"1.8"
+if VERSION >= v"1.8-"
+    include("gcn.jl")
     include("metal.jl")
 end
 include("examples.jl")


### PR DESCRIPTION
While looking at #374 I was curious if I could reproduce the issue in the GPUCompiler testsuite.

The answer is yes, with the change here and `CI=true julia -g2` 

```
kernel argument attributes: Error During Test at /home/vchuravy/src/GPUCompiler/test/ptx.jl:20
  Got exception outside of a @test
  LLVM error: mismatched subprogram between llvm.dbg.declare variable and !dbg attachment
    call void @llvm.dbg.declare(metadata [1 x i64]* undef, metadata !18, metadata !DIExpression(DW_OP_deref)), !dbg !22
  label %conversion
  void ([1 x i64], [1 x i64])* @_Z17julia_kernel_62489Aggregate
  !18 = !DILocalVariable(name: "x", arg: 2, scope: !19, file: !3, line: 21, type: !12)
  !19 = distinct !DISubprogram(name: "kernel", linkageName: "julia_kernel_6248", scope: null, file: !3, line: 21, type: !8, scopeLine: 21, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !20)
  !22 = !DILocation(line: 21, scope: !7)
  !7 = distinct !DISubprogram(name: "kernel", linkageName: "julia_kernel_6248", scope: null, file: !3, line: 21, type: !8, scopeLine: 21, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !2, retainedNodes: !15)
  
  Stacktrace:
    [1] verify(mod::LLVM.Module)
      @ LLVM ~/.julia/packages/LLVM/WjSQG/src/analysis.jl:10
    ```
