### PR TITLE
Have the default target default to not using the Julia runtime.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -321,7 +321,7 @@ const __llvm_initialized = Ref(false)
         @compiler_assert isempty(uses(dyn_marker)) job
         unsafe_delete!(ir, dyn_marker)
     end
-    
+
     @timeit_debug to "IR post-processing" begin
         # mark the kernel entry-point functions (optimization may need it)
         if job.source.kernel
@@ -334,7 +334,7 @@ const __llvm_initialized = Ref(false)
         if optimize
             @timeit_debug to "optimization" begin
                 optimize!(job, ir)
-        
+
                 # deferred codegen has some special optimization requirements,
                 # which also need to happen _after_ regular optimization.
                 # XXX: make these part of the optimizer pipeline?
@@ -376,7 +376,7 @@ const __llvm_initialized = Ref(false)
                 end
             end
         end
-        
+
         # finish the module
         #
         # we want to finish the module after optimization, so we cannot do so during

--- a/src/native.jl
+++ b/src/native.jl
@@ -8,7 +8,7 @@ Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
     cpu::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
     features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
     llvm_always_inline::Bool=false # will mark the job function as always inline
-    jlruntime::Bool=true # Use Julia runtime for throwing errors, instead of the GPUCompiler support
+    jlruntime::Bool=false # Use Julia runtime for throwing errors, instead of the GPUCompiler support
 end
 llvm_triple(::NativeCompilerTarget) = Sys.MACHINE
 

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -155,9 +155,8 @@ end
     gcn_code_native(devnull, kernel, Tuple{Float64})
 end
 
-@test_broken "exception arguments"
-#= FIXME: _ZNK4llvm14TargetLowering20scalarizeVectorStoreEPNS_11StoreSDNodeERNS_12SelectionDAGE
-@testset "exception arguments" begin
+# FIXME: _ZNK4llvm14TargetLowering20scalarizeVectorStoreEPNS_11StoreSDNodeERNS_12SelectionDAGE
+false && @testset "exception arguments" begin
     function kernel(a)
         unsafe_store!(a, trunc(Int, unsafe_load(a)))
         return
@@ -165,11 +164,9 @@ end
 
     gcn_code_native(devnull, kernel, Tuple{Ptr{Float64}})
 end
-=#
 
-@test_broken "GC and TLS lowering"
-#= FIXME: in function julia_inner_18528 void (%jl_value_t addrspace(10)*): invalid addrspacecast
-@testset "GC and TLS lowering" begin
+# FIXME: in function julia_inner_18528 void (%jl_value_t addrspace(10)*): invalid addrspacecast
+false && @testset "GC and TLS lowering" begin
     @eval mutable struct PleaseAllocate
         y::Csize_t
     end
@@ -206,7 +203,6 @@ end
 
     @test !occursin("gpu_gc_pool_alloc", asm)
 end
-=#
 
 @testset "float boxes" begin
     function kernel(a,b)


### PR DESCRIPTION
Otherwise the `kernel` example fails on macOS running Julia 1.9:

```
Reason: unsupported call through a literal pointer (call to pthread_getspecific)
```

This is because the TLS getter is lowered differently:

```llvm
define void @_Z17julia_kernel_2628() #0 !dbg !4 {
top:
  %0 = call {}*** @julia.get_pgcstack()
  %1 = bitcast {}*** %0 to {}**
  %current_task = getelementptr inbounds {}*, {}** %1, i64 -13
  %2 = bitcast {}** %current_task to i64*
  %world_age = getelementptr inbounds i64, i64* %2, i64 14
  %3 = bitcast {}*** %0 to {}**
  %current_task1 = getelementptr inbounds {}*, {}** %3, i64 -13
  %ptls_field = getelementptr inbounds {}*, {}** %current_task1, i64 15
  %ptls_load = load {}*, {}** %ptls_field, align 8, !tbaa !7
  %ptls = bitcast {}* %ptls_load to {}**
  fence syncscope("singlethread") seq_cst
  %4 = bitcast {}** %ptls to i64**
  %5 = getelementptr inbounds i64*, i64** %4, i64 2
  %safepoint = load i64*, i64** %5, align 8, !tbaa !11, !invariant.load !6
  %6 = load volatile i64, i64* %safepoint, align 8
  fence syncscope("singlethread") seq_cst
  ret void, !dbg !13
}
```

optimizes to

```llvm
define void @_Z17julia_kernel_2997() local_unnamed_addr #0 !dbg !5 {
top:
  %0 = call {}*** inttoptr (i64 7114247836 to {}*** (i64)*)(i64 261) #1
  %ptls_field3 = getelementptr inbounds {}**, {}*** %0, i64 2
  %1 = bitcast {}*** %ptls_field3 to i64***
  %ptls_load45 = load i64**, i64*** %1, align 8, !tbaa !8
  fence syncscope("singlethread") seq_cst
  %2 = getelementptr inbounds i64*, i64** %ptls_load45, i64 2
  %safepoint = load i64*, i64** %2, align 8, !tbaa !12
  %3 = load volatile i64, i64* %safepoint, align 8
  fence syncscope("singlethread") seq_cst
  ret void, !dbg !14
}
```

while on other platforms:

```llvm
define void @_Z17julia_kernel_2198() #0 !dbg !4 {
top:
  %0 = call {}*** @julia.get_pgcstack()
  %1 = bitcast {}*** %0 to {}**
  %current_task = getelementptr inbounds {}*, {}** %1, i64 -13
  %2 = bitcast {}** %current_task to i64*
  %world_age = getelementptr inbounds i64, i64* %2, i64 14
  %3 = bitcast {}*** %0 to {}**
  %current_task1 = getelementptr inbounds {}*, {}** %3, i64 -13
  %ptls_field = getelementptr inbounds {}*, {}** %current_task1, i64 15
  %ptls_load = load {}*, {}** %ptls_field, align 8, !tbaa !7
  %ptls = bitcast {}* %ptls_load to {}**
  fence syncscope("singlethread") seq_cst
  %4 = bitcast {}** %ptls to i64**
  %5 = getelementptr inbounds i64*, i64** %4, i64 2
  %safepoint = load i64*, i64** %5, align 8, !tbaa !11, !invariant.load !6
  %6 = load volatile i64, i64* %safepoint, align 8
  fence syncscope("singlethread") seq_cst
  ret void, !dbg !13
}
```

... optimizes to

```llvm
define void @_Z17julia_kernel_2936() local_unnamed_addr #0 !dbg !5 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #1
  %ppgcstack_i8 = getelementptr i8, i8* %thread_ptr, i64 -8
  %ppgcstack = bitcast i8* %ppgcstack_i8 to {}****
  %pgcstack = load {}***, {}**** %ppgcstack, align 8
  %ptls_field3 = getelementptr inbounds {}**, {}*** %pgcstack, i64 2
  %0 = bitcast {}*** %ptls_field3 to i64***
  %ptls_load45 = load i64**, i64*** %0, align 8, !tbaa !8
  fence syncscope("singlethread") seq_cst
  %1 = getelementptr inbounds i64*, i64** %ptls_load45, i64 2
  %safepoint = load i64*, i64** %1, align 8, !tbaa !12
  %2 = load volatile i64, i64* %safepoint, align 8
  fence syncscope("singlethread") seq_cst
  ret void, !dbg !14
}
```

which doesn't trigger the validator (inline asm vs call-to-pointer)

---

on 1.8, where we didn't emit a safepoint at the start, we used to get:

```llvm
define void @_Z17julia_kernel_2728() #0 !dbg !5 {
top:
  %0 = call {}*** @julia.get_pgcstack()
  %1 = bitcast {}*** %0 to {}**
  %current_task = getelementptr inbounds {}*, {}** %1, i64 -12
  %2 = bitcast {}** %current_task to i64*
  %world_age = getelementptr inbounds i64, i64* %2, i64 13
  ret void, !dbg !7
}
```