### PR TITLE
Don't use safepoint_on_entry cgparam on 1.9-beta1 and up.

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -379,7 +379,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
         gnu_pubnames       = false,
         debug_info_kind    = Cint(debug_info_kind),
         lookup             = Base.unsafe_convert(Ptr{Nothing}, lookup_cb))
-    @static if VERSION >= v"1.9.0-DEV.1660"
+    @static if v"1.9.0-DEV.1660" <= VERSION < v"1.9.0-beta1" || VERSION >= v"1.10-"
         cgparams = merge(cgparams, (;safepoint_on_entry = can_safepoint(job)))
     end
     params = Base.CodegenParams(;cgparams...)

--- a/test/native.jl
+++ b/test/native.jl
@@ -196,7 +196,7 @@ end
     ir = sprint(io->native_code_llvm(io, identity, Tuple{Nothing}; entry_safepoint=false, optimize=false, dump_module=true))
     @test !occursin("%safepoint", ir)
 
-    @static if VERSION >= v"1.9.0-DEV.1660"
+    if v"1.9.0-DEV.1660" <= VERSION < v"1.9.0-alpha1.57" || VERSION >= v"1.10-"
         ir = sprint(io->native_code_llvm(io, identity, Tuple{Nothing}; entry_safepoint=true, optimize=false, dump_module=true))
         @test occursin("%safepoint", ir)
     end


### PR DESCRIPTION
This was reverted in https://github.com/JuliaLang/julia/pull/47602, but is still live on master. cc @vchuravy 