### PR TITLE
Emit 'Dwarf Version' metadata as Int32.

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -395,7 +395,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
                 datalayout!(mod, julia_datalayout(job.target))
             end
             flags(mod)["Dwarf Version", LLVM.API.LLVMModuleFlagBehaviorWarning] =
-                Metadata(ConstantInt(4; ctx=unwrap_context(ctx)))
+                Metadata(ConstantInt(Int32(4); ctx=unwrap_context(ctx)))
             flags(mod)["Debug Info Version", LLVM.API.LLVMModuleFlagBehaviorWarning] =
                 Metadata(ConstantInt(DEBUG_METADATA_VERSION(); ctx=unwrap_context(ctx)))
 


### PR DESCRIPTION
Avoids the following warning:

```
warning: linking module flags 'Dwarf Version': IDs have conflicting values ('i32 4' from globals with 'i64 4' from start)
```

... although I'm not sure where the linking happens, as we're now responsible for configuring the module. Maybe this comes from `libdevice`. Either way, doesn't hurt to fix.