### PR TITLE
Revert "Annotate exception handling with call site effects (#359)"

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -265,14 +265,11 @@ function emit_exception!(builder, name, inst)
     # report the exception
     if Base.JLOptions().debug_level >= 1
         name = globalstring_ptr!(builder, name, "exception")
-        c = if Base.JLOptions().debug_level == 1
+        if Base.JLOptions().debug_level == 1
             call!(builder, Runtime.get(:report_exception), [name])
         else
             call!(builder, Runtime.get(:report_exception_name), [name])
         end
-        callsite_attribute!(c, (
-            LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
-            LLVM.EnumAttribute("writeonly", 0; ctx)))
     end
 
     # report each frame
@@ -290,10 +287,7 @@ function emit_exception!(builder, name, inst)
     end
 
     # signal the exception
-    c = call!(builder, Runtime.get(:signal_exception))
-    callsite_attribute!(c, (
-        LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
-        LLVM.EnumAttribute("writeonly", 0; ctx)))
+    call!(builder, Runtime.get(:signal_exception))
 
     emit_trap!(job, builder, mod, inst)
 end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -387,11 +387,7 @@ function hide_trap!(mod::LLVM.Module)
             if isa(val, LLVM.CallInst)
                 @dispose builder=Builder(ctx) begin
                     position!(builder, val)
-                    c = call!(builder, exit)
-                    callsite_attribute!(c, (
-                        LLVM.EnumAttribute("inaccessiblememonly", 0; ctx),
-                        LLVM.EnumAttribute("writeonly", 0; ctx), # can we do readnone?
-                        LLVM.EnumAttribute("noreturn", 0; ctx)))
+                    call!(builder, exit)
                 end
                 unsafe_delete!(LLVM.parent(val), val)
                 changed = true

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -113,10 +113,3 @@ macro unlocked(ex)
     end
     esc(combinedef(def))
 end
-
-function callsite_attribute!(call, attributes)
-    # TODO: Make a nice API for this in LLVM.jl
-    for attribute in attributes
-        LLVM.API.LLVMAddCallSiteAttribute(call, LLVM.API.LLVMAttributeFunctionIndex, attribute)
-    end
-end


### PR DESCRIPTION
This reverts commit 01d44c368d4db8fea81e31234a9085e7ea837e69.

Seems to be causing miss-compilations in Oceananigans.jl on Pascal generation GPUs.
Waiting for https://github.com/CliMA/Oceananigans.jl/pull/2906 to fully confirm, but the tests are already further...


cc: @wsmoses 