### PR TITLE
Validate inputs and outputs earlier.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -297,7 +297,7 @@ const __llvm_initialized = Ref(false)
             for dyn_job in keys(worklist)
                 # cached compilation
                 dyn_entry_fn = get!(deferred_jobs, dyn_job) do
-                    dyn_ir, dyn_meta = codegen(:llvm, dyn_job; validate,
+                    dyn_ir, dyn_meta = codegen(:llvm, dyn_job; validate=false,
                                                optimize=false,
                                                deferred_codegen=false,
                                                parent_job=job, ctx)

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -25,7 +25,7 @@ The following keyword arguments are supported:
 - `optimize`: optimize the code (default: true)
 - `cleanup`: run cleanup passes on the code (default: true)
 - `strip`: strip non-functional metadata and debug information (default: false)
-- `validate`: validate the generated IR before emitting machine code (default: true)
+- `validate`: enable optional validation of input and outputs (default: true)
 - `only_entry`: only keep the entry function, remove all others (default: false).
   This option is only for internal use, to implement reflection's `dump_module`.
 
@@ -90,7 +90,7 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                  ctx::Union{JuliaContextType,Nothing}=nothing)
     ## Julia IR
 
-    mi, mi_meta = emit_julia(job)
+    mi, mi_meta = emit_julia(job; validate)
 
     if output == :julia
         return mi, mi_meta
@@ -112,7 +112,7 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                      Use a JuliaContext instead.""")
         end
 
-        ir, ir_meta = emit_llvm(job, mi; libraries, deferred_codegen, optimize, cleanup, only_entry, ctx)
+        ir, ir_meta = emit_llvm(job, mi; libraries, deferred_codegen, optimize, cleanup, only_entry, validate, ctx)
 
         if output == :llvm
             if strip
@@ -148,8 +148,11 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     end
 end
 
-@locked function emit_julia(@nospecialize(job::CompilerJob))
-    @timeit_debug to "validation" check_method(job)
+@locked function emit_julia(@nospecialize(job::CompilerJob); validate::Bool=true)
+    @timeit_debug to "Validation" begin
+        check_method(job)   # not optional
+        validate && check_invocation(job)
+    end
 
     @timeit_debug to "Julia front-end" begin
 
@@ -201,7 +204,8 @@ const __llvm_initialized = Ref(false)
 
 @locked function emit_llvm(@nospecialize(job::CompilerJob), @nospecialize(method_instance);
                            libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
-                           cleanup::Bool=true, only_entry::Bool=false, ctx::JuliaContextType)
+                           cleanup::Bool=true, only_entry::Bool=false, validate::Bool=true,
+                           ctx::JuliaContextType)
     if !__llvm_initialized[]
         InitializeAllTargets()
         InitializeAllTargetInfos()
@@ -293,8 +297,10 @@ const __llvm_initialized = Ref(false)
             for dyn_job in keys(worklist)
                 # cached compilation
                 dyn_entry_fn = get!(deferred_jobs, dyn_job) do
-                    dyn_ir, dyn_meta = codegen(:llvm, dyn_job; optimize=false,
-                                               deferred_codegen=false, parent_job=job, ctx)
+                    dyn_ir, dyn_meta = codegen(:llvm, dyn_job; validate,
+                                               optimize=false,
+                                               deferred_codegen=false,
+                                               parent_job=job, ctx)
                     dyn_entry_fn = LLVM.name(dyn_meta.entry)
                     merge!(compiled, dyn_meta.compiled)
                     @assert context(dyn_ir) == unwrap_context(ctx)
@@ -407,18 +413,17 @@ const __llvm_initialized = Ref(false)
         end
     end
 
+    if validate
+        @timeit_debug to "Validation" begin
+            check_ir(job, ir)
+        end
+    end
+
     return ir, (; entry, compiled)
 end
 
 @locked function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module;
                           strip::Bool=false, validate::Bool=true, format::LLVM.API.LLVMCodeGenFileType)
-    if validate
-        @timeit_debug to "Validation" begin
-            check_invocation(job)
-            check_ir(job, ir)
-        end
-    end
-
     # NOTE: strip after validation to get better errors
     if strip
         @timeit_debug to "Debug info removal" strip_debuginfo!(ir)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -66,7 +66,7 @@ end
 function emit_function!(mod, @nospecialize(job::CompilerJob), f, method; ctx::JuliaContextType)
     tt = Base.to_tuple_type(method.types)
     new_mod, meta = codegen(:llvm, similar(job, FunctionSpec(f, tt, #=kernel=# false));
-                            optimize=false, libraries=false, ctx)
+                            optimize=false, libraries=false, validate=false, ctx)
     ft = eltype(llvmtype(meta.entry))
     expected_ft = convert(LLVM.FunctionType, method; ctx=context(new_mod))
     if LLVM.return_type(ft) != LLVM.return_type(expected_ft)

--- a/test/native.jl
+++ b/test/native.jl
@@ -88,7 +88,7 @@ end
         job, _ = native_job(foo, (Float64,))
         JuliaContext() do ctx
             # shouldn't segfault
-            ir, meta = GPUCompiler.compile(:llvm, job; ctx)
+            ir, meta = GPUCompiler.compile(:llvm, job; ctx, validate=false)
 
             meth = only(methods(foo, (Float64,)))
 


### PR DESCRIPTION
Metal's LLVM post-processing inspects arguments (as does CUDA.jl's), so we need to make sure there's no invalid stuff in there. Currently, we were only running the code instance validation during `emit_asm`, instead make it happen as early as possible, during `emit_julia`.

```
  Got exception outside of a @test
  LoadError: Type Array does not have a definite size.
  Stacktrace:
    [1] sizeof(x::Type)
      @ Base ./essentials.jl:473
    [2] add_argument_metadata!(job::GPUCompiler.CompilerJob, mod::LLVM.Module, entry::LLVM.Function)
      @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/metal.jl:612
    [3] finish_ir!(job::GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
      @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/metal.jl:108
    [4] macro expansion
      @ ~/Julia/pkg/GPUCompiler/src/driver.jl:400 [inlined]
    [5] macro expansion
      @ ~/Julia/depot/packages/TimerOutputs/LHjFw/src/TimerOutput.jl:253 [inlined]
    [6] macro expansion
      @ ~/Julia/pkg/GPUCompiler/src/driver.jl:340 [inlined]
    [7] emit_llvm(job::GPUCompiler.CompilerJob, method_instance::Any; libraries::Bool, deferred_codegen::Bool, optimize::Bool, cleanup::Bool, only_entry::Bool, ctx::LLVM.Context)
      @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/utils.jl:83
    [8] mtlfunction_compile(job::GPUCompiler.CompilerJob, ctx::LLVM.Context)
      @ Metal ~/Julia/pkg/Metal/src/compiler/execution.jl:166
```