### PR TITLE
Split CompilerJob in dynamic and static part.

### DIFF
--- a/examples/kernel.jl
+++ b/examples/kernel.jl
@@ -19,7 +19,8 @@ function main()
     source = FunctionSpec(typeof(kernel), Tuple{})
     target = NativeCompilerTarget()
     params = TestCompilerParams()
-    job = CompilerJob(source, target, params)
+    config = CompilerConfig(target, params)
+    job = CompilerJob(config, source)
 
     println(GPUCompiler.compile(:asm, job)[1])
 end

--- a/src/bpf.jl
+++ b/src/bpf.jl
@@ -32,4 +32,4 @@ const bpf_intrinsics = () # TODO
 isintrinsic(::CompilerJob{BPFCompilerTarget}, fn::String) = in(fn, bpf_intrinsics)
 
 valid_function_pointer(job::CompilerJob{BPFCompilerTarget}, ptr::Ptr{Cvoid}) =
-    reinterpret(UInt, ptr) in job.target.function_pointers
+    reinterpret(UInt, ptr) in job.cfg.target.function_pointers

--- a/src/bpf.jl
+++ b/src/bpf.jl
@@ -32,4 +32,4 @@ const bpf_intrinsics = () # TODO
 isintrinsic(::CompilerJob{BPFCompilerTarget}, fn::String) = in(fn, bpf_intrinsics)
 
 valid_function_pointer(job::CompilerJob{BPFCompilerTarget}, ptr::Ptr{Cvoid}) =
-    reinterpret(UInt, ptr) in job.cfg.target.function_pointers
+    reinterpret(UInt, ptr) in job.config.target.function_pointers

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -130,7 +130,7 @@ end
 const cache_lock = ReentrantLock()
 
 """
-    cached_compilation(cache::Dict, job::CompilerJob, compiler, linker)
+    cached_compilation(cache::Dict{UInt}, job::CompilerJob, compiler, linker)
 
 Compile `job` using `compiler` and `linker`, and store the result in `cache`.
 
@@ -140,50 +140,55 @@ and return data that can be cached across sessions (e.g., LLVM IR). This data is
 forwarded, along with the `CompilerJob`, to the `linker` function which is allowed to create
 session-dependent objects (e.g., a `CuModule`).
 """
-function cached_compilation(cache::AbstractDict,
+function cached_compilation(cache::AbstractDict{UInt,V},
                             @nospecialize(cfg::CompilerConfig),
-                            ft::Type, tt::Type, compiler::Function, linker::Function)
-    # NOTE: it is OK to index the compilation cache directly with the compilation job, i.e.,
-    #       using a world age instead of intersecting world age ranges, because we expect
-    #       that the world age is aquired through calling `get_world` and thus will only
-    #       ever change when the kernel function is redefined.
-    #
-    #       if we ever want to be able to index the cache using a compilation job that
-    #       contains a more recent world age, yet still return an older cached object that
-    #       would still be valid, we'd need the cache to store world ranges instead and
-    #       use an invalidation callback to add upper bounds to entries.
+                            ft::Type, tt::Type,
+                            compiler::Function, linker::Function) where {V}
+    # NOTE: it is OK to index the compilation cache directly with the world age, instead of
+    #       intersecting world age ranges, because we the world age is aquired by calling
+    #       `get_world` and thus will only change when the kernel function is redefined.
     world = get_world(ft, tt)
     key = hash((ft, tt, world, cfg))
 
-    force_compilation = compile_hook[] !== nothing
-
     # NOTE: no use of lock(::Function)/@lock/get! to keep stack traces clean
     lock(cache_lock)
-    try
-        obj = get(cache, key, nothing)
-        if obj === nothing || force_compilation
-            asm = nothing
+    obj = get(cache, key, nothing)
+    unlock(cache_lock)
 
-            src = FunctionSpec(ft, tt, world)
-            job = CompilerJob(cfg, src)
+    if obj === nothing || compile_hook[] !== nothing
+        obj = actual_compilation(cache, key, cfg, ft, tt, world, compiler, linker)::V
+    end
+    return obj
+end
 
-            # compile
-            if asm === nothing
-                if compile_hook[] !== nothing
-                    compile_hook[](job)
-                end
+@noinline function actual_compilation(cache::AbstractDict, key::UInt,
+                                      @nospecialize(cfg::CompilerConfig),
+                                      ft::Type, tt::Type, world,
+                                      compiler::Function, linker::Function)
+    @nospecialize
 
-                asm = compiler(job)
-            end
+    src = FunctionSpec(ft, tt, world)
+    job = CompilerJob(cfg, src)
 
-            # link (but not if we got here because of forced compilation)
-            if obj === nothing
-                obj = linker(job, asm)
-                cache[key] = obj
-            end
+    asm = nothing
+    # TODO: consider loading the assembly from an on-disk cache here
+
+    # compile
+    if asm === nothing
+        if compile_hook[] !== nothing
+            compile_hook[](job)
         end
+
+        asm = compiler(job)
+    end
+
+    # link (but not if we got here because of forced compilation,
+    # in which case the cache will already be populated)
+    lock(cache_lock) do
+        haskey(cache, key) && return cache[key]
+
+        obj = linker(job, asm)
+        cache[key] = obj
         obj
-    finally
-        unlock(cache_lock)
     end
 end

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -159,11 +159,11 @@ end
         # get the method instance
         sig = typed_signature(job)
         meth = if VERSION >= v"1.10.0-DEV.65"
-            Base._which(sig; world=job.src.world).method
+            Base._which(sig; world=job.source.world).method
         elseif VERSION >= v"1.7.0-DEV.435"
-            Base._which(sig, job.src.world).method
+            Base._which(sig, job.source.world).method
         else
-            ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), sig, job.src.world)
+            ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), sig, job.source.world)
         end
 
         (ti, env) = ccall(:jl_type_intersection_with_env, Any,
@@ -172,7 +172,7 @@ end
         meth = Base.func_for_method_checked(meth, ti, env)
 
         method_instance = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance},
-                      (Any, Any, Any, UInt), meth, ti, env, job.src.world)
+                      (Any, Any, Any, UInt), meth, ti, env, job.source.world)
 
         for var in env
             if var isa TypeVar
@@ -183,7 +183,7 @@ end
 
     # ensure that the returned method instance is valid in the compilation world.
     # otherwise, `jl_create_native` won't actually emit any code.
-    @assert method_instance.def.primary_world <= job.src.world <= method_instance.def.deleted_world
+    @assert method_instance.def.primary_world <= job.source.world <= method_instance.def.deleted_world
 
     return method_instance, ()
 end
@@ -227,7 +227,7 @@ const __llvm_initialized = Ref(false)
 
     @timeit_debug to "IR generation" begin
         ir, compiled = irgen(job, method_instance; ctx)
-        if job.cfg.entry_abi === :specfunc
+        if job.config.entry_abi === :specfunc
             entry_fn = compiled[method_instance].specfunc
         else
             entry_fn = compiled[method_instance].func
@@ -300,11 +300,11 @@ const __llvm_initialized = Ref(false)
 
                 # get a job in the appopriate world
                 dyn_job = if dyn_val isa CompilerJob
-                    dyn_src = FunctionSpec(dyn_val.src; world=job.src.world)
-                    CompilerJob(dyn_val.cfg, dyn_src)
+                    dyn_src = FunctionSpec(dyn_val.source; world=job.source.world)
+                    CompilerJob(dyn_val.config, dyn_src)
                 elseif dyn_val isa FunctionSpec
-                    dyn_src = FunctionSpec(dyn_val; world=job.src.world)
-                    CompilerJob(job.cfg, dyn_src)
+                    dyn_src = FunctionSpec(dyn_val; world=job.source.world)
+                    CompilerJob(job.config, dyn_src)
                 else
                     error("invalid deferred job type $(typeof(dyn_val))")
                 end
@@ -349,7 +349,7 @@ const __llvm_initialized = Ref(false)
 
     @timeit_debug to "IR post-processing" begin
         # mark the kernel entry-point functions (optimization may need it)
-        if job.cfg.kernel
+        if job.config.kernel
             push!(metadata(ir)["julia.kernel"], MDNode([entry]; ctx=unwrap_context(ctx)))
 
             # IDEA: save all jobs, not only kernels, and save other attributes

--- a/src/error.jl
+++ b/src/error.jl
@@ -14,7 +14,7 @@ struct KernelError <: Exception
 end
 
 function Base.showerror(io::IO, err::KernelError)
-    println(io, "GPU compilation of ", err.job.source, " failed")
+    println(io, "GPU compilation of ", err.job.src, " failed")
     println(io, "KernelError: $(err.message)")
     println(io)
     println(io, something(err.help, "Try inspecting the generated code with any of the @device_code_... macros."))

--- a/src/error.jl
+++ b/src/error.jl
@@ -14,7 +14,7 @@ struct KernelError <: Exception
 end
 
 function Base.showerror(io::IO, err::KernelError)
-    println(io, "GPU compilation of ", err.job.src, " failed")
+    println(io, "GPU compilation of ", err.job.source, " failed")
     println(io, "KernelError: $(err.message)")
     println(io)
     println(io, something(err.help, "Try inspecting the generated code with any of the @device_code_... macros."))

--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -30,7 +30,7 @@ end
 
 # TODO: encode debug build or not in the compiler job
 #       https://github.com/JuliaGPU/CUDAnative.jl/issues/368
-runtime_slug(job::CompilerJob{GCNCompilerTarget}) = "gcn-$(job.cfg.target.dev_isa)$(job.cfg.target.features)"
+runtime_slug(job::CompilerJob{GCNCompilerTarget}) = "gcn-$(job.config.target.dev_isa)$(job.config.target.features)"
 
 const gcn_intrinsics = () # TODO: ("vprintf", "__assertfail", "malloc", "free")
 isintrinsic(::CompilerJob{GCNCompilerTarget}, fn::String) = in(fn, gcn_intrinsics)
@@ -38,7 +38,7 @@ isintrinsic(::CompilerJob{GCNCompilerTarget}, fn::String) = in(fn, gcn_intrinsic
 function process_entry!(job::CompilerJob{GCNCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # calling convention
         callconv!(entry, LLVM.API.LLVMAMDGPUKERNELCallConv)
     end
@@ -54,7 +54,7 @@ function finish_module!(@nospecialize(job::CompilerJob{GCNCompilerTarget}),
                         mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(finish_module!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # work around bad byval codegen (JuliaGPU/GPUCompiler.jl#92)
         entry = lower_byval(job, mod, entry)
     end
@@ -84,10 +84,10 @@ end
 function optimize_module!(job::CompilerJob{GCNCompilerTarget}, mod::LLVM.Module)
     @static if VERSION < v"1.9.0-DEV.1018"
         # revert back to the AMDGPU target
-        triple!(mod, llvm_triple(job.cfg.target))
-        datalayout!(mod, julia_datalayout(job.cfg.target))
+        triple!(mod, llvm_triple(job.config.target))
+        datalayout!(mod, julia_datalayout(job.config.target))
 
-        tm = llvm_machine(job.cfg.target)
+        tm = llvm_machine(job.config.target)
         @dispose pm=ModulePassManager() begin
             add_library_info!(pm, triple(mod))
             add_transform_info!(pm, tm)

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -3,7 +3,7 @@
 function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInstance;
                ctx::JuliaContextType)
     mod, compiled = @timeit_debug to "emission" compile_method_instance(job, method_instance; ctx)
-    if job.cfg.entry_abi === :specfunc
+    if job.config.entry_abi === :specfunc
         entry_fn = compiled[method_instance].specfunc
     else
         entry_fn = compiled[method_instance].func
@@ -24,7 +24,7 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
 
             # remove the non-specialized jfptr functions
             # TODO: Do we need to remove these?
-            if job.cfg.entry_abi === :specfunc
+            if job.config.entry_abi === :specfunc
                 if startswith(LLVM.name(llvmf), "jfptr_")
                     unsafe_delete!(mod, llvmf)
                 end
@@ -60,11 +60,11 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
     end
 
     # rename and process the entry point
-    if job.cfg.kernel
-        LLVM.name!(entry, mangle_call(entry, job.src.tt))
+    if job.config.kernel
+        LLVM.name!(entry, mangle_call(entry, job.source.tt))
     end
     entry = process_entry!(job, mod, entry)
-    if job.cfg.entry_abi === :specfunc
+    if job.config.entry_abi === :specfunc
         func = compiled[method_instance].func
         specfunc = LLVM.name(entry)
     else
@@ -543,7 +543,7 @@ function add_kernel_state!(mod::LLVM.Module)
 
     # check if we even need a kernel state argument
     state = kernel_state_type(job)
-    @assert job.cfg.kernel
+    @assert job.config.kernel
     if state === Nothing
         return false
     end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -373,8 +373,8 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     cache = ci_cache(job)
     mt = method_table(job)
     interp = get_interpreter(job)
-    if ci_cache_lookup(cache, method_instance, job.src.world, job.src.world) === nothing
-        ci_cache_populate(interp, cache, mt, method_instance, job.src.world, job.src.world)
+    if ci_cache_lookup(cache, method_instance, job.source.world, job.source.world) === nothing
+        ci_cache_populate(interp, cache, mt, method_instance, job.source.world, job.source.world)
     end
 
     # create a callback to look-up function in our cache,
@@ -389,7 +389,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     else
         _cache[] = cache
         _method_instances[] = method_instances
-        _world[] = job.src.world
+        _world[] = job.source.world
         lookup_cb = @cfunction(_lookup_fun, Any, (Any, UInt, UInt))
     end
 
@@ -413,9 +413,9 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
             mod = LLVM.Module("start"; ctx=unwrap_context(ctx))
 
             # configure the module
-            triple!(mod, llvm_triple(job.cfg.target))
-            if julia_datalayout(job.cfg.target) !== nothing
-                datalayout!(mod, julia_datalayout(job.cfg.target))
+            triple!(mod, llvm_triple(job.config.target))
+            if julia_datalayout(job.config.target) !== nothing
+                datalayout!(mod, julia_datalayout(job.config.target))
             end
             flags(mod)["Dwarf Version", LLVM.API.LLVMModuleFlagBehaviorWarning] =
                 Metadata(ConstantInt(Int32(4); ctx=unwrap_context(ctx)))
@@ -426,33 +426,33 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
             if VERSION >= v"1.10.0-DEV.645" || v"1.9.0-beta4.23" <= VERSION < v"1.10-"
                 ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint, Cint, Csize_t),
-                      [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0, job.src.world)
+                      [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0, job.source.world)
             elseif VERSION >= v"1.10.0-DEV.204" || v"1.9.0-alpha1.55" <= VERSION < v"1.10-"
-                @in_world job.src.world ccall(:jl_create_native, Ptr{Cvoid},
+                @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint, Cint),
                       [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0)
             elseif VERSION >= v"1.10.0-DEV.75"
-                @in_world job.src.world ccall(:jl_create_native, Ptr{Cvoid},
+                @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint),
                       [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0)
             else
-                @in_world job.src.world ccall(:jl_create_native, Ptr{Cvoid},
+                @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint),
                       [method_instance], ts_mod, Ref(params), CompilationPolicyExtern)
 
             end
         elseif VERSION >= v"1.9.0-DEV.115"
-            @in_world job.src.world ccall(:jl_create_native, Ptr{Cvoid},
+            @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
                   (Vector{MethodInstance}, LLVM.API.LLVMContextRef, Ptr{Base.CodegenParams}, Cint),
                   [method_instance], ctx, Ref(params), CompilationPolicyExtern)
         elseif VERSION >= v"1.8.0-DEV.661"
             @assert ctx == JuliaContext()
-            @in_world job.src.world ccall(:jl_create_native, Ptr{Cvoid},
+            @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
                   (Vector{MethodInstance}, Ptr{Base.CodegenParams}, Cint),
                   [method_instance], Ref(params), CompilationPolicyExtern)
         else
             @assert ctx == JuliaContext()
-            @in_world job.src.world ccall(:jl_create_native, Ptr{Cvoid},
+            @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
                   (Vector{MethodInstance}, Base.CodegenParams, Cint),
                   [method_instance], params, CompilationPolicyExtern)
         end
@@ -482,7 +482,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     # process all compiled method instances
     compiled = Dict()
     for mi in method_instances
-        ci = ci_cache_lookup(cache, mi, job.src.world, job.src.world)
+        ci = ci_cache_lookup(cache, mi, job.source.world, job.source.world)
         ci === nothing && continue
 
         # get the function index
@@ -522,9 +522,9 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
 
     if VERSION < v"1.9.0-DEV.516"
         # configure the module
-        triple!(llvm_mod, llvm_triple(job.cfg.target))
-        if julia_datalayout(job.cfg.target) !== nothing
-            datalayout!(llvm_mod, julia_datalayout(job.cfg.target))
+        triple!(llvm_mod, llvm_triple(job.config.target))
+        if julia_datalayout(job.config.target) !== nothing
+            datalayout!(llvm_mod, julia_datalayout(job.config.target))
         end
     end
 

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -68,7 +68,7 @@ end
 
 
 function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
-    tm = llvm_machine(job.target)
+    tm = llvm_machine(job.cfg.target)
 
     return String(emit(tm, mod, format))
 end

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -68,7 +68,7 @@ end
 
 
 function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
-    tm = llvm_machine(job.cfg.target)
+    tm = llvm_machine(job.config.target)
 
     return String(emit(tm, mod, format))
 end

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -35,7 +35,7 @@ needs_byval(job::CompilerJob{MetalCompilerTarget}) = false
 
 # TODO: encode debug build or not in the compiler job
 #       https://github.com/JuliaGPU/CUDAnative.jl/issues/368
-runtime_slug(job::CompilerJob{MetalCompilerTarget}) = "metal-macos$(job.target.macos)"
+runtime_slug(job::CompilerJob{MetalCompilerTarget}) = "metal-macos$(job.cfg.target.macos)"
 
 isintrinsic(@nospecialize(job::CompilerJob{MetalCompilerTarget}), fn::String) =
     return startswith(fn, "air.")
@@ -55,7 +55,7 @@ end
 function process_entry!(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.source.kernel
+    if job.cfg.kernel
         # calling convention
         callconv!(entry, LLVMMETALKERNELCallConv)
     end
@@ -85,7 +85,7 @@ function finish_module!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mo
     ctx = context(mod)
     entry_fn = LLVM.name(entry)
 
-    if job.source.kernel
+    if job.cfg.kernel
         entry = pass_by_reference!(job, mod, entry)
 
         add_input_arguments!(job, mod, entry)
@@ -102,7 +102,7 @@ function finish_ir!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::L
     ctx = context(mod)
     entry_fn = LLVM.name(entry)
 
-    if job.source.kernel
+    if job.cfg.kernel
         entry = add_address_spaces!(job, mod, entry)
 
         add_argument_metadata!(job, mod, entry)

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -35,7 +35,7 @@ needs_byval(job::CompilerJob{MetalCompilerTarget}) = false
 
 # TODO: encode debug build or not in the compiler job
 #       https://github.com/JuliaGPU/CUDAnative.jl/issues/368
-runtime_slug(job::CompilerJob{MetalCompilerTarget}) = "metal-macos$(job.cfg.target.macos)"
+runtime_slug(job::CompilerJob{MetalCompilerTarget}) = "metal-macos$(job.config.target.macos)"
 
 isintrinsic(@nospecialize(job::CompilerJob{MetalCompilerTarget}), fn::String) =
     return startswith(fn, "air.")
@@ -55,7 +55,7 @@ end
 function process_entry!(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # calling convention
         callconv!(entry, LLVMMETALKERNELCallConv)
     end
@@ -85,7 +85,7 @@ function finish_module!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mo
     ctx = context(mod)
     entry_fn = LLVM.name(entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         entry = pass_by_reference!(job, mod, entry)
 
         add_input_arguments!(job, mod, entry)
@@ -102,7 +102,7 @@ function finish_ir!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::L
     ctx = context(mod)
     entry_fn = LLVM.name(entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         entry = add_address_spaces!(job, mod, entry)
 
         add_argument_metadata!(job, mod, entry)

--- a/src/native.jl
+++ b/src/native.jl
@@ -25,7 +25,7 @@ end
 
 function process_entry!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     ctx = context(mod)
-    if job.target.llvm_always_inline
+    if job.cfg.target.llvm_always_inline
         push!(function_attributes(entry), EnumAttribute("alwaysinline", 0; ctx))
     end
     invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
@@ -33,5 +33,5 @@ end
 
 ## job
 
-runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.target.cpu)-$(hash(job.target.features))$(job.target.jlruntime ? "-jlrt" : "")"
-uses_julia_runtime(job::CompilerJob{NativeCompilerTarget}) = job.target.jlruntime
+runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.cfg.target.cpu)-$(hash(job.cfg.target.features))$(job.cfg.target.jlruntime ? "-jlrt" : "")"
+uses_julia_runtime(job::CompilerJob{NativeCompilerTarget}) = job.cfg.target.jlruntime

--- a/src/native.jl
+++ b/src/native.jl
@@ -25,7 +25,7 @@ end
 
 function process_entry!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     ctx = context(mod)
-    if job.cfg.target.llvm_always_inline
+    if job.config.target.llvm_always_inline
         push!(function_attributes(entry), EnumAttribute("alwaysinline", 0; ctx))
     end
     invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
@@ -33,5 +33,5 @@ end
 
 ## job
 
-runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.cfg.target.cpu)-$(hash(job.cfg.target.features))$(job.cfg.target.jlruntime ? "-jlrt" : "")"
-uses_julia_runtime(job::CompilerJob{NativeCompilerTarget}) = job.cfg.target.jlruntime
+runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.config.target.cpu)-$(hash(job.config.target.features))$(job.config.target.jlruntime ? "-jlrt" : "")"
+uses_julia_runtime(job::CompilerJob{NativeCompilerTarget}) = job.config.target.jlruntime

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -165,8 +165,8 @@ function addOptimizationPasses!(pm, opt_level=2)
 end
 
 function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
-    triple = llvm_triple(job.target)
-    tm = llvm_machine(job.target)
+    triple = llvm_triple(job.cfg.target)
+    tm = llvm_machine(job.cfg.target)
 
     global current_job
     current_job = job
@@ -189,7 +189,7 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
             add!(pm, FunctionPass("LowerGCFrame", lower_gc_frame!))
         end
 
-        if job.source.kernel
+        if job.cfg.kernel
             # GC lowering is the last pass that may introduce calls to the runtime library,
             # and thus additional uses of the kernel state intrinsic.
             # TODO: now that all kernel state-related passes are being run here, merge some?
@@ -298,7 +298,7 @@ function cpu_features!(mod::LLVM.Module)
         # determine whether this back-end supports FMA on this type
         has_fma = if haskey(argtyps, typnam)
             typ = argtyps[typnam]
-            have_fma(job.target, typ)
+            have_fma(job.cfg.target, typ)
         else
             # warn?
             false

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -165,8 +165,8 @@ function addOptimizationPasses!(pm, opt_level=2)
 end
 
 function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
-    triple = llvm_triple(job.cfg.target)
-    tm = llvm_machine(job.cfg.target)
+    triple = llvm_triple(job.config.target)
+    tm = llvm_machine(job.config.target)
 
     global current_job
     current_job = job
@@ -189,7 +189,7 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
             add!(pm, FunctionPass("LowerGCFrame", lower_gc_frame!))
         end
 
-        if job.cfg.kernel
+        if job.config.kernel
             # GC lowering is the last pass that may introduce calls to the runtime library,
             # and thus additional uses of the kernel state intrinsic.
             # TODO: now that all kernel state-related passes are being run here, merge some?
@@ -298,7 +298,7 @@ function cpu_features!(mod::LLVM.Module)
         # determine whether this back-end supports FMA on this type
         has_fma = if haskey(argtyps, typnam)
             typ = argtyps[typnam]
-            have_fma(job.cfg.target, typ)
+            have_fma(job.config.target, typ)
         else
             # warn?
             false

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -67,13 +67,13 @@ have_fma(@nospecialize(target::PTXCompilerTarget), T::Type) = true
 ## job
 
 function Base.show(io::IO, @nospecialize(job::CompilerJob{PTXCompilerTarget}))
-    print(io, "PTX CompilerJob of ", job.src)
-    print(io, " for sm_$(job.cfg.target.cap.major)$(job.cfg.target.cap.minor)")
+    print(io, "PTX CompilerJob of ", job.source)
+    print(io, " for sm_$(job.config.target.cap.major)$(job.config.target.cap.minor)")
 
-    job.cfg.target.minthreads !== nothing && print(io, ", minthreads=$(job.cfg.target.minthreads)")
-    job.cfg.target.maxthreads !== nothing && print(io, ", maxthreads=$(job.cfg.target.maxthreads)")
-    job.cfg.target.blocks_per_sm !== nothing && print(io, ", blocks_per_sm=$(job.cfg.target.blocks_per_sm)")
-    job.cfg.target.maxregs !== nothing && print(io, ", maxregs=$(job.cfg.target.maxregs)")
+    job.config.target.minthreads !== nothing && print(io, ", minthreads=$(job.config.target.minthreads)")
+    job.config.target.maxthreads !== nothing && print(io, ", maxthreads=$(job.config.target.maxthreads)")
+    job.config.target.blocks_per_sm !== nothing && print(io, ", blocks_per_sm=$(job.config.target.blocks_per_sm)")
+    job.config.target.maxregs !== nothing && print(io, ", maxregs=$(job.config.target.maxregs)")
 end
 
 const ptx_intrinsics = ("vprintf", "__assertfail", "malloc", "free")
@@ -82,9 +82,9 @@ isintrinsic(@nospecialize(job::CompilerJob{PTXCompilerTarget}), fn::String) =
 
 # XXX: the debuginfo part should be handled by GPUCompiler as it applies to all back-ends.
 runtime_slug(@nospecialize(job::CompilerJob{PTXCompilerTarget})) =
-    "ptx-sm_$(job.cfg.target.cap.major)$(job.cfg.target.cap.minor)" *
+    "ptx-sm_$(job.config.target.cap.major)$(job.config.target.cap.minor)" *
        "-debuginfo=$(Int(llvm_debug_info(job)))" *
-       "-exitable=$(job.cfg.target.exitable)"
+       "-exitable=$(job.config.target.exitable)"
 
 function process_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}), mod::LLVM.Module)
     ctx = context(mod)
@@ -101,10 +101,10 @@ function process_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}), mod
     # it possible to 'query' these in device code, relying on LLVM to optimize the checks
     # away and generate static code. note that we only do so if there's actual uses of these
     # variables; unconditionally creating a gvar would result in duplicate declarations.
-    for (name, value) in ["sm_major"  => job.cfg.target.cap.major,
-                          "sm_minor"  => job.cfg.target.cap.minor,
-                          "ptx_major" => job.cfg.target.ptx.major,
-                          "ptx_minor" => job.cfg.target.ptx.minor]
+    for (name, value) in ["sm_major"  => job.config.target.cap.major,
+                          "sm_minor"  => job.config.target.cap.minor,
+                          "ptx_major" => job.config.target.ptx.major,
+                          "ptx_minor" => job.config.target.ptx.minor]
         if haskey(globals(mod), name)
             gv = globals(mod)[name]
             initializer!(gv, ConstantInt(LLVM.Int32Type(ctx), value))
@@ -118,7 +118,7 @@ function process_entry!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
                         mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         if LLVM.version() >= v"8"
             # calling convention
             callconv!(entry, LLVM.API.LLVMPTXKernelCallConv)
@@ -131,7 +131,7 @@ end
 function add_lowering_passes!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
                               pm::LLVM.PassManager)
     # hide `unreachable` from LLVM so that it doesn't introduce divergent control flow
-    if !job.cfg.target.unreachable
+    if !job.config.target.unreachable
         add!(pm, FunctionPass("HideUnreachable", hide_unreachable!))
     end
 
@@ -145,7 +145,7 @@ end
 
 function optimize_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
                           mod::LLVM.Module)
-    tm = llvm_machine(job.cfg.target)
+    tm = llvm_machine(job.config.target)
     @dispose pm=ModulePassManager() begin
         add_library_info!(pm, triple(mod))
         add_transform_info!(pm, tm)
@@ -182,7 +182,7 @@ function finish_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
     ctx = context(mod)
     entry = invoke(finish_module!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # work around bad byval codegen (JuliaGPU/GPUCompiler.jl#92)
         entry = lower_byval(job, mod, entry)
     end
@@ -195,7 +195,7 @@ function finish_ir!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
     ctx = context(mod)
     entry = invoke(finish_ir!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # add metadata annotations for the assembler to the module
 
         # property annotations
@@ -206,29 +206,29 @@ function finish_ir!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
                               ConstantInt(Int32(1); ctx)])
 
         ## expected CTA sizes
-        if job.cfg.target.minthreads !== nothing
+        if job.config.target.minthreads !== nothing
             for (dim, name) in enumerate([:x, :y, :z])
-                bound = dim <= length(job.cfg.target.minthreads) ? job.cfg.target.minthreads[dim] : 1
+                bound = dim <= length(job.config.target.minthreads) ? job.config.target.minthreads[dim] : 1
                 append!(annotations, [MDString("reqntid$name"; ctx),
                                       ConstantInt(Int32(bound); ctx)])
             end
         end
-        if job.cfg.target.maxthreads !== nothing
+        if job.config.target.maxthreads !== nothing
             for (dim, name) in enumerate([:x, :y, :z])
-                bound = dim <= length(job.cfg.target.maxthreads) ? job.cfg.target.maxthreads[dim] : 1
+                bound = dim <= length(job.config.target.maxthreads) ? job.config.target.maxthreads[dim] : 1
                 append!(annotations, [MDString("maxntid$name"; ctx),
                                       ConstantInt(Int32(bound); ctx)])
             end
         end
 
-        if job.cfg.target.blocks_per_sm !== nothing
+        if job.config.target.blocks_per_sm !== nothing
             append!(annotations, [MDString("minctasm"; ctx),
-                                  ConstantInt(Int32(job.cfg.target.blocks_per_sm); ctx)])
+                                  ConstantInt(Int32(job.config.target.blocks_per_sm); ctx)])
         end
 
-        if job.cfg.target.maxregs !== nothing
+        if job.config.target.maxregs !== nothing
             append!(annotations, [MDString("maxnreg"; ctx),
-                                  ConstantInt(Int32(job.cfg.target.maxregs); ctx)])
+                                  ConstantInt(Int32(job.config.target.maxregs); ctx)])
         end
 
         push!(metadata(mod)["nvvm.annotations"], MDNode(annotations; ctx))
@@ -239,7 +239,7 @@ end
 
 function llvm_debug_info(@nospecialize(job::CompilerJob{PTXCompilerTarget}))
     # allow overriding the debug info from CUDA.jl
-    if job.cfg.target.debuginfo
+    if job.config.target.debuginfo
         invoke(llvm_debug_info, Tuple{CompilerJob}, job)
     else
         LLVM.API.LLVMDebugEmissionKindNoDebug
@@ -373,7 +373,7 @@ function hide_trap!(mod::LLVM.Module)
 
     # inline assembly to exit a thread, hiding control flow from LLVM
     exit_ft = LLVM.FunctionType(LLVM.VoidType(ctx))
-    exit = if job.cfg.target.exitable
+    exit = if job.config.target.exitable
         InlineAsm(exit_ft, "exit;", "", true)
     else
         InlineAsm(exit_ft, "trap;", "", true)
@@ -459,7 +459,7 @@ function nvvm_reflect!(fun::LLVM.Function)
             # floating-point multiply-add operations (FMAD, FFMA, or DFMA)
             ConstantInt(reflect_typ, fast_math ? 1 : 0)
         elseif reflect_arg == "__CUDA_ARCH"
-            ConstantInt(reflect_typ, job.cfg.target.cap.major*100 + job.cfg.target.cap.minor*10)
+            ConstantInt(reflect_typ, job.config.target.cap.major*100 + job.config.target.cap.minor*10)
         else
             @warn "Unknown __nvvm_reflect argument: $reflect_arg. Please file an issue."
         end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -50,8 +50,8 @@ include("reflection_compat.jl")
 #
 
 @inline function typed_signature(@nospecialize(job::CompilerJob))
-    u = Base.unwrap_unionall(job.source.tt)
-    return Base.rewrap_unionall(Tuple{job.source.ft, u.parameters...}, job.source.tt)
+    u = Base.unwrap_unionall(job.src.tt)
+    return Base.rewrap_unionall(Tuple{job.src.ft, u.parameters...}, job.src.tt)
 end
 
 code_lowered(@nospecialize(job::CompilerJob); kwargs...) =
@@ -175,7 +175,7 @@ See also: [`@device_code_native`](@ref), `InteractiveUtils.code_llvm`
 """
 function code_native(io::IO, @nospecialize(job::CompilerJob); raw::Bool=false, dump_module::Bool=false)
     asm, meta = codegen(:asm, job; strip=!raw, only_entry=!dump_module, validate=false)
-    highlight(io, asm, source_code(job.target))
+    highlight(io, asm, source_code(job.cfg.target))
 end
 code_native(@nospecialize(job::CompilerJob); kwargs...) =
     code_native(stdout, job; kwargs...)
@@ -312,7 +312,7 @@ Evaluates the expression `ex` and dumps all intermediate forms of code to the di
 macro device_code(ex...)
     localUnique = 1
     function hook(job::CompilerJob; dir::AbstractString)
-        name = something(job.source.name, nameof(job.source.ft))
+        name = nameof(job.src.ft)   # TODO: nameof(::FunctionSpec), supporting function types
         fn = "$(name)_$(localUnique)"
         mkpath(dir)
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -50,8 +50,8 @@ include("reflection_compat.jl")
 #
 
 @inline function typed_signature(@nospecialize(job::CompilerJob))
-    u = Base.unwrap_unionall(job.src.tt)
-    return Base.rewrap_unionall(Tuple{job.src.ft, u.parameters...}, job.src.tt)
+    u = Base.unwrap_unionall(job.source.tt)
+    return Base.rewrap_unionall(Tuple{job.source.ft, u.parameters...}, job.source.tt)
 end
 
 code_lowered(@nospecialize(job::CompilerJob); kwargs...) =
@@ -175,7 +175,7 @@ See also: [`@device_code_native`](@ref), `InteractiveUtils.code_llvm`
 """
 function code_native(io::IO, @nospecialize(job::CompilerJob); raw::Bool=false, dump_module::Bool=false)
     asm, meta = codegen(:asm, job; strip=!raw, only_entry=!dump_module, validate=false)
-    highlight(io, asm, source_code(job.cfg.target))
+    highlight(io, asm, source_code(job.config.target))
 end
 code_native(@nospecialize(job::CompilerJob); kwargs...) =
     code_native(stdout, job; kwargs...)
@@ -312,7 +312,7 @@ Evaluates the expression `ex` and dumps all intermediate forms of code to the di
 macro device_code(ex...)
     localUnique = 1
     function hook(job::CompilerJob; dir::AbstractString)
-        name = nameof(job.src.ft)   # TODO: nameof(::FunctionSpec), supporting function types
+        name = nameof(job.source.ft)   # TODO: nameof(::FunctionSpec), supporting function types
         fn = "$(name)_$(localUnique)"
         mkpath(dir)
 

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -101,7 +101,7 @@ function build_runtime(@nospecialize(job::CompilerJob); ctx)
 
     # the compiler job passed into here is identifies the job that requires the runtime.
     # derive a job that represents the runtime itself (notably with kernel=false).
-    config = CompilerConfig(job.cfg; kernel=false)
+    config = CompilerConfig(job.config; kernel=false)
 
     for method in values(Runtime.methods)
         def = if isa(method.def, Symbol)
@@ -110,7 +110,7 @@ function build_runtime(@nospecialize(job::CompilerJob); ctx)
         else
             method.def
         end
-        emit_function!(mod, config, typeof(def), method, job.src.world; ctx)
+        emit_function!(mod, config, typeof(def), method, job.source.world; ctx)
     end
 
     # we cannot optimize the runtime library, because the code would then be optimized again

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -42,7 +42,7 @@ end
 function process_entry!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.source.kernel
+    if job.cfg.kernel
         # calling convention
         callconv!(entry, LLVM.API.LLVMSPIRKERNELCallConv)
     end
@@ -54,7 +54,7 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
     ctx = context(mod)
     entry = invoke(finish_module!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.source.kernel
+    if job.cfg.kernel
         # HACK: Intel's compute runtime doesn't properly support SPIR-V's byval attribute.
         #       they do support struct byval, for OpenCL, so wrap byval parameters in a struct.
         entry = wrap_byval(job, mod, entry)

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -42,7 +42,7 @@ end
 function process_entry!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     entry = invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # calling convention
         callconv!(entry, LLVM.API.LLVMSPIRKERNELCallConv)
     end
@@ -54,7 +54,7 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
     ctx = context(mod)
     entry = invoke(finish_module!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
 
-    if job.cfg.kernel
+    if job.config.kernel
         # HACK: Intel's compute runtime doesn't properly support SPIR-V's byval attribute.
         #       they do support struct byval, for OpenCL, so wrap byval parameters in a struct.
         entry = wrap_byval(job, mod, entry)

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -32,22 +32,22 @@ function MethodError(ft::Type, tt::Type, world::Integer=typemax(UInt))
 end
 
 function check_method(@nospecialize(job::CompilerJob))
-    isa(job.src.ft, Core.Builtin) &&
+    isa(job.source.ft, Core.Builtin) &&
         throw(KernelError(job, "function is not a generic function"))
 
     # get the method
-    ms = method_matches(typed_signature(job); job.src.world)
+    ms = method_matches(typed_signature(job); job.source.world)
     if length(ms) != 1
-        throw(MethodError(job.src.ft, job.src.tt, job.src.world))
+        throw(MethodError(job.source.ft, job.source.tt, job.source.world))
     end
 
     # kernels can't return values
-    if job.cfg.kernel
+    if job.config.kernel
         cache = ci_cache(job)
         mt = method_table(job)
         ip = inference_params(job)
         op = optimization_params(job)
-        interp = GPUInterpreter(cache, mt, job.src.world, ip, op)
+        interp = GPUInterpreter(cache, mt, job.source.world, ip, op)
         rt = return_type(only(ms); interp)
 
         if rt != Nothing
@@ -124,7 +124,7 @@ const DELAYED_BINDING  = "use of an undefined name"
 const DYNAMIC_CALL     = "dynamic function invocation"
 
 function Base.showerror(io::IO, err::InvalidIRError)
-    print(io, "InvalidIRError: compiling ", err.job.src, " resulted in invalid LLVM IR")
+    print(io, "InvalidIRError: compiling ", err.job.source, " resulted in invalid LLVM IR")
     for (kind, bt, meta) in err.errors
         printstyled(io, "\nReason: unsupported $kind"; color=:red)
         if meta !== nothing

--- a/test/definitions/bpf.jl
+++ b/test/definitions/bpf.jl
@@ -9,10 +9,11 @@ end
 
 function bpf_job(@nospecialize(func), @nospecialize(types);
                  kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types); kernel)
+    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
     target = BPFCompilerTarget()
     params = TestCompilerParams()
-    CompilerJob(source, target, params; always_inline), kwargs
+    config = CompilerConfig(target, params; kernel, always_inline)
+    CompilerJob(config, source), kwargs
 end
 
 function bpf_code_llvm(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/gcn.jl
+++ b/test/definitions/gcn.jl
@@ -9,10 +9,11 @@ end
 
 function gcn_job(@nospecialize(func), @nospecialize(types);
                  kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types); kernel)
+    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = TestCompilerParams()
-    CompilerJob(source, target, params; always_inline), kwargs
+    config = CompilerConfig(target, params; kernel, always_inline)
+    CompilerJob(config, source), kwargs
 end
 
 function gcn_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/metal.jl
+++ b/test/definitions/metal.jl
@@ -9,10 +9,11 @@ end
 
 function metal_job(@nospecialize(func), @nospecialize(types);
                    kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types); kernel)
+    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
     target = MetalCompilerTarget(; macos=v"12.2")
     params = TestCompilerParams()
-    CompilerJob(source, target, params; always_inline), kwargs
+    config = CompilerConfig(target, params; kernel, always_inline)
+    CompilerJob(config, source), kwargs
 end
 
 function metal_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/native.jl
+++ b/test/definitions/native.jl
@@ -23,7 +23,7 @@ const method_table = nothing
 end
 
 GPUCompiler.method_table(@nospecialize(job::NativeCompilerJob)) = method_table
-GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.cfg.params.entry_safepoint
+GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.config.params.entry_safepoint
 
 function native_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                     entry_abi=:specfunc, entry_safepoint::Bool=false, always_inline=false,

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -40,12 +40,13 @@ GPUCompiler.runtime_module(::PTXCompilerJob) = PTXTestRuntime
 function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                  minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
                  maxregs=nothing, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types); kernel)
+    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
     target = PTXCompilerTarget(;cap=v"7.0",
                                minthreads, maxthreads,
                                blocks_per_sm, maxregs)
     params = TestCompilerParams()
-    CompilerJob(source, target, params; always_inline), kwargs
+    config = CompilerConfig(target, params; kernel, always_inline)
+    CompilerJob(config, source), kwargs
 end
 
 function ptx_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/spirv.jl
+++ b/test/definitions/spirv.jl
@@ -9,10 +9,11 @@ end
 
 function spirv_job(@nospecialize(func), @nospecialize(types);
                    kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types); kernel)
+    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
     target = SPIRVCompilerTarget()
     params = TestCompilerParams()
-    CompilerJob(source, target, params; always_inline), kwargs
+    config = CompilerConfig(target, params; kernel, always_inline)
+    CompilerJob(config, source), kwargs
 end
 
 function spirv_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/native.jl
+++ b/test/native.jl
@@ -127,38 +127,38 @@ end
         tt = Tuple{Int64}
 
         # initial compilation
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test contains(ir, "add i64 %1, 2")
         @test invocations[] == 1
         @test length(cache) == 1
 
         # cached compilation
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test contains(ir, "add i64 %1, 2")
         @test invocations[] == 1
         @test length(cache) == 1
 
         # redefinition
         @eval $kernel(i) = $child(i)+3
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test contains(ir, "add i64 %1, 3")
         @test invocations[] == 2
         @test length(cache) == 2
 
         # cached compilation
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test contains(ir, "add i64 %1, 3")
         @test invocations[] == 2
         @test length(cache) == 2
 
         # redefining child functions
         @eval @noinline $child(i) = sink(i)+1
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test invocations[] == 3
         @test length(cache) == 3
 
         # cached compilation
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test invocations[] == 3
         @test length(cache) == 3
 
@@ -167,12 +167,12 @@ end
         function background(job)
             notify(c1)
             wait(c2)    # wait for redefinition
-            GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+            GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         end
         t = @async background(job)
         wait(c1)        # make sure the task has started
         @eval $kernel(i) = $child(i)+4
-        ir = GPUCompiler.cached_compilation(cache, job.cfg, ft, tt, compiler, linker)
+        ir = GPUCompiler.cached_compilation(cache, job.config, ft, tt, compiler, linker)
         @test contains(ir, "add i64 %1, 4")
         notify(c2)      # wake up the task
         ir = fetch(t)

--- a/test/native.jl
+++ b/test/native.jl
@@ -122,7 +122,7 @@ end
             return ir
         end
         linker(job, compiled) = compiled
-        cache = Dict()
+        cache = Dict{UInt,Any}()
         ft = typeof(eval(kernel))
         tt = Tuple{Int64}
 


### PR DESCRIPTION
Currently, we need to re-create the entire `CompilerJob` struct every time we want to check the cache because it contains the function we want to compile. For example, simplified from https://github.com/JuliaGPU/CUDA.jl/blob/dbcaca84191fb8621f097d85dad80e1627f1c11b/src/compiler/execution.jl#L299-L308:

```julia
function compile(ft::F, tt::TT) where {F,TT}
    function compiler(job)
        GPUCompiler.compile(:asm, job)[1]
    end
    function linker(job, compiled)
        compiled
    end

    source = FunctionSpec(ft, tt)
    target = NativeCompilerTarget()
    params = TestCompilerParams()
    job = CompilerJob(source, target, params)
    GPUCompiler.cached_compilation(cache, job, compiler, linker)::String
end
```

This results in unnecessary allocations on every kernel launch, even if it didn't cause any compilation:

```
julia> @benchmark main()
BenchmarkTools.Trial: 10000 samples with 5 evaluations.
 Range (min … max):  6.690 μs … 190.522 μs  ┊ GC (min … max): 0.00% … 93.60%
 Time  (median):     7.394 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.391 μs ±   1.973 μs  ┊ GC (mean ± σ):  0.24% ±  0.94%

           ▂▂▂▁      ▁▃▅▇█▆▆▅▃▂
  ▁▁▁▂▃▄▅▇█████▇▇▆▆▆▇██████████▇▆▄▄▃▃▃▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  6.69 μs         Histogram: frequency by time        8.58 μs <

 Memory estimate: 952 bytes, allocs estimate: 4.
```

This PR aims to avoid that by introducing a `CompilerConfig` containing all static bits of the `CompilerJob`, bundling it together with the `FunctionSpec` in the `CompilerJob`. In addition, `cached_compilation` now only takes the function and argument types, so nothing needs to be allocated on the hot path anymore (assuming the `CompilerConfig` can be retrieved from a global dict look-up or something):

```julia
const target = NativeCompilerTarget()
const params = TestCompilerParams()
const config = CompilerConfig(target, params)

const cache = Dict()

function compile(ft::F, tt::TT) where {F,TT}
function compiler(job)
        GPUCompiler.compile(:asm, job)[1]
    end
    function linker(job, compiled)
        compiled
    end
    GPUCompiler.cached_compilation(cache, config, ft, tt, compiler, linker)::String
end
```

```
julia> @benchmark main()
BenchmarkTools.Trial: 10000 samples with 245 evaluations.
 Range (min … max):  309.873 ns …   6.200 μs  ┊ GC (min … max): 0.00% … 93.55%
 Time  (median):     318.204 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   323.585 ns ± 122.187 ns  ┊ GC (mean ± σ):  0.83% ±  2.09%

         ▂▅▇█▇▆▅▃▃▁▂ ▂▁     ▁▁▁▂▃▃▃▃▂▁                          ▂
  ▆▅▄▄▆▆████████████████▇▆▆▇███████████▇▆▆▆▆▄▆▄▄▃▁▅▄▃▁▃▁▁▅▄▃▆▆▇ █
  310 ns        Histogram: log(frequency) by time        357 ns <

 Memory estimate: 96 bytes, allocs estimate: 2.
```