### PR TITLE
Backport 1.9 compatibility changes to GPUCompiler 0.16 (#397)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1.7', '^1.8.0-beta3']
+        version: ['1.6', '1.7', '1.8', '^1.9.0-beta3']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
     steps:
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['release-1.7', 'release-1.8', 'master']
+        branch: ['release-1.7', 'release-1.8', 'release-1.9', 'master']
         os: [ubuntu-latest, macOS-latest]
         arch: [x64]
     steps:


### PR DESCRIPTION
* Update calling convention for jl_create_native

* Update CI to include 1.9

(cherry picked from commit d131ee1e91163c909c5df0af3f6c2fa07b01a723)
