### PR TITLE
Reduce breakage

### DIFF
--- a/examples/kernel.jl
+++ b/examples/kernel.jl
@@ -20,7 +20,7 @@ function main()
     target = NativeCompilerTarget()
     params = TestCompilerParams()
     config = CompilerConfig(target, params)
-    job = CompilerJob(config, source)
+    job = CompilerJob(source, config)
 
     println(GPUCompiler.compile(:asm, job)[1])
 end

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -170,7 +170,7 @@ end
                                       ft::Type, tt::Type, world,
                                       compiler::Function, linker::Function)
     src = FunctionSpec(ft, tt, world)
-    job = CompilerJob(cfg, src)
+    job = CompilerJob(src, cfg)
 
     asm = nothing
     # TODO: consider loading the assembly from an on-disk cache here

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -301,10 +301,10 @@ const __llvm_initialized = Ref(false)
                 # get a job in the appopriate world
                 dyn_job = if dyn_val isa CompilerJob
                     dyn_src = FunctionSpec(dyn_val.source; world=job.source.world)
-                    CompilerJob(dyn_val.config, dyn_src)
+                    CompilerJob(dyn_src, dyn_val.config)
                 elseif dyn_val isa FunctionSpec
                     dyn_src = FunctionSpec(dyn_val; world=job.source.world)
-                    CompilerJob(job.config, dyn_src)
+                    CompilerJob(dyn_src, job.config)
                 else
                     error("invalid deferred job type $(typeof(dyn_val))")
                 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -170,11 +170,11 @@ export CompilerJob
 # a specific invocation of the compiler, bundling everything needed to generate code
 
 struct CompilerJob{T,P}
-    config::CompilerConfig{T,P}
     source::FunctionSpec
+    config::CompilerConfig{T,P}
 
-    CompilerJob(cfg::CompilerConfig{T,P}, src::FunctionSpec) where {T,P} =
-        new{T,P}(cfg, src)
+    CompilerJob(src::FunctionSpec, cfg::CompilerConfig{T,P}) where {T,P} =
+        new{T,P}(src, cfg)
 end
 
 

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -60,6 +60,9 @@ function irgen(@nospecialize(job::CompilerJob), method_instance::Core.MethodInst
     end
 
     # rename and process the entry point
+    if job.config.name !== nothing
+        LLVM.name!(entry, safe_name(string("julia_", job.config.name)))
+    end
     if job.config.kernel
         LLVM.name!(entry, mangle_call(entry, job.source.tt))
     end

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -66,7 +66,7 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method, world; ctx::JuliaContextType)
     tt = Base.to_tuple_type(method.types)
     source = FunctionSpec(f, tt, world)
-    new_mod, meta = codegen(:llvm, CompilerJob(config, source);
+    new_mod, meta = codegen(:llvm, CompilerJob(source, config);
                             optimize=false, libraries=false, validate=false, ctx)
     ft = eltype(llvmtype(meta.entry))
     expected_ft = convert(LLVM.FunctionType, method; ctx=context(new_mod))

--- a/test/definitions/bpf.jl
+++ b/test/definitions/bpf.jl
@@ -13,7 +13,7 @@ function bpf_job(@nospecialize(func), @nospecialize(types);
     target = BPFCompilerTarget()
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(config, source), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function bpf_code_llvm(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/gcn.jl
+++ b/test/definitions/gcn.jl
@@ -13,7 +13,7 @@ function gcn_job(@nospecialize(func), @nospecialize(types);
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(config, source), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function gcn_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/metal.jl
+++ b/test/definitions/metal.jl
@@ -13,7 +13,7 @@ function metal_job(@nospecialize(func), @nospecialize(types);
     target = MetalCompilerTarget(; macos=v"12.2")
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(config, source), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function metal_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/native.jl
+++ b/test/definitions/native.jl
@@ -35,7 +35,7 @@ function native_job(@nospecialize(func), @nospecialize(types); kernel::Bool=fals
     target = NativeCompilerTarget()
     params = NativeCompilerParams(entry_safepoint, method_table)
     config = CompilerConfig(target, params; kernel, entry_abi, always_inline)
-    CompilerJob(config, source), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function native_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
@@ -271,7 +271,7 @@ module LazyCodegen
         #      with jlruntime=false, we reach an unreachable.
         params = NativeCompilerParams()
         config = CompilerConfig(target, params; kernel=false)
-        job = CompilerJob(config, source)
+        job = CompilerJob(source, config)
 
         addr = get_trampoline(job)
         trampoline = pointer(addr)

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -46,7 +46,7 @@ function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                                blocks_per_sm, maxregs)
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(config, source), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function ptx_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/definitions/spirv.jl
+++ b/test/definitions/spirv.jl
@@ -13,7 +13,7 @@ function spirv_job(@nospecialize(func), @nospecialize(types);
     target = SPIRVCompilerTarget()
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(config, source), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function spirv_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)


### PR DESCRIPTION
I had switched the CompilerJob args around in https://github.com/JuliaGPU/GPUCompiler.jl/pull/394 to ensure we spot erroneous uses, but https://github.com/JuliaGPU/GPUCompiler.jl/pull/402 changed it in other incompatible ways, so let's switch the order back to simplify adapting to these changes.

Also adds back the `name` keyword.