### PR TITLE
Metal: Set the SDK Version metadata.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,15 +39,15 @@ version = "1.4.1"
 
 [[LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "df115c31f5c163697eede495918d8e85045c8f04"
+git-tree-sha1 = "1c614dfbecbaee4897b506bba2b432bf0d21f2ed"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "4.16.0"
+version = "4.17.0"
 
 [[LLVMExtra_jll]]
-deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg", "TOML"]
-git-tree-sha1 = "7718cf44439c676bc0ec66a87099f41015a522d6"
+deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "e46e3a40daddcbe851f86db0ec4a4a3d4badf800"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.16+2"
+version = "0.0.19+0"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "4.14.1"
+LLVM = "4.17"
 Scratch = "1"
 TimerOutputs = "0.5"
 julia = "1.6"

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -723,5 +723,8 @@ function add_module_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     air_lang_md = MDNode(air_lang_md; ctx)
     push!(metadata(mod)["air.language_version"], air_lang_md)
 
+    # set sdk version
+    sdk_version!(mod, job.config.target.macos)
+
     return
 end


### PR DESCRIPTION
Our back-end was doing this already, but for some reason the LLVM 14-based Yggdrasil build messes this up. I can't reproduce locally, so just move that operation into GPUCompiler.jl