### PR TITLE
Enable val'able target

### DIFF
--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -4,11 +4,15 @@
 
 export GCNCompilerTarget
 
-Base.@kwdef struct GCNCompilerTarget <: AbstractCompilerTarget
-    dev_isa::String
-    features::String=""
+struct GCNCompilerTarget <: AbstractCompilerTarget
+    dev_isa::Symbol
+    features::Symbol
 end
-GCNCompilerTarget(dev_isa; features="") = GCNCompilerTarget(dev_isa, features)
+GCNCompilerTarget(dev_isa; features="") = GCNCompilerTarget(Symbol(dev_isa), Symbol(features))
+function GCNCompilerTarget(;dev_isa=nothing, features="")
+    @assert dev_isa !== nothing
+    GCNCompilerTarget(Symbol(dev_isa), Symbol(features))
+end
 
 llvm_triple(::GCNCompilerTarget) = "amdgcn-amd-amdhsa"
 
@@ -16,8 +20,8 @@ function llvm_machine(target::GCNCompilerTarget)
     triple = llvm_triple(target)
     t = Target(triple=triple)
 
-    cpu = target.dev_isa
-    feat = target.features
+    cpu = String(target.dev_isa)
+    feat = String(target.features)
     reloc = LLVM.API.LLVMRelocPIC
     tm = TargetMachine(t, triple, cpu, feat; reloc)
     asm_verbosity!(tm, true)

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -7,7 +7,7 @@ const Metal_LLVM_Tools_jll = LazyModule("Metal_LLVM_Tools_jll", UUID("0418c028-f
 export MetalCompilerTarget
 
 Base.@kwdef struct MetalCompilerTarget <: AbstractCompilerTarget
-    macos::VersionNumber
+    macos::ValableVersionNumber
 end
 
 function Base.hash(target::MetalCompilerTarget, h::UInt)
@@ -724,7 +724,7 @@ function add_module_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     push!(metadata(mod)["air.language_version"], air_lang_md)
 
     # set sdk version
-    sdk_version!(mod, job.config.target.macos)
+    sdk_version!(mod, VersionNumber(job.config.target.macos))
 
     return
 end

--- a/src/native.jl
+++ b/src/native.jl
@@ -5,8 +5,8 @@
 export NativeCompilerTarget
 
 Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
-    cpu::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
-    features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
+    cpu::Symbol=Symbol((LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName()))
+    features::Symbol=Symbol((LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures()))
     llvm_always_inline::Bool=false # will mark the job function as always inline
     jlruntime::Bool=false # Use Julia runtime for throwing errors, instead of the GPUCompiler support
 end
@@ -17,7 +17,7 @@ function llvm_machine(target::NativeCompilerTarget)
 
     t = Target(triple=triple)
 
-    tm = TargetMachine(t, triple, target.cpu, target.features)
+    tm = TargetMachine(t, triple, String(target.cpu), String(target.features))
     asm_verbosity!(tm, true)
 
     return tm
@@ -33,5 +33,5 @@ end
 
 ## job
 
-runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(job.config.target.cpu)-$(hash(job.config.target.features))$(job.config.target.jlruntime ? "-jlrt" : "")"
+runtime_slug(job::CompilerJob{NativeCompilerTarget}) = "native_$(String(job.config.target.cpu))-$(hash(String(job.config.target.features)))$(job.config.target.jlruntime ? "-jlrt" : "")"
 uses_julia_runtime(job::CompilerJob{NativeCompilerTarget}) = job.config.target.jlruntime

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -5,8 +5,8 @@
 export PTXCompilerTarget
 
 Base.@kwdef struct PTXCompilerTarget <: AbstractCompilerTarget
-    cap::VersionNumber
-    ptx::VersionNumber = v"6.0" # for compatibility with older versions of CUDA.jl
+    cap::ValableVersionNumber
+    ptx::ValableVersionNumber = v"6.0" # for compatibility with older versions of CUDA.jl
 
     # codegen quirks
     ## can we emit debug info in the PTX assembly?

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -12,7 +12,7 @@ const SPIRV_Tools_jll = LazyModule("SPIRV_Tools_jll", UUID("6ac6d60f-d740-5983-9
 
 export SPIRVCompilerTarget
 
-Base.@kwdef struct SPIRVCompilerTarget <: AbstractCompilerTarget
+struct SPIRVCompilerTarget <: AbstractCompilerTarget
 end
 
 llvm_triple(::SPIRVCompilerTarget) = Int===Int64 ? "spir64-unknown-unknown" : "spirv-unknown-unknown"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -113,3 +113,17 @@ macro unlocked(ex)
     end
     esc(combinedef(def))
 end
+
+struct ValableVersionNumber
+    major::UInt32
+    minor::UInt32
+    patch::UInt32
+end
+function Base.convert(::Type{ValableVersionNumber}, v::VersionNumber)
+	@assert v.build == ()
+	@assert v.prerelease == ()
+	ValableVersionNumber(v.major, v.minor, v.patch)
+end
+function VersionNumber(v::ValableVersionNumber)
+	VersionNumber(v.major, v.minor, v.patch)
+end


### PR DESCRIPTION
We need to be able to create a val version of targets within Enzyme.jl.

However the use of VersionNumber (which itself uses a string), etc, prevents this.

This change converts targets to Val'able versions, while reducing API changes.