### PR TITLE
Replace FunctionSpec with methodinstance

### DIFF
--- a/examples/kernel.jl
+++ b/examples/kernel.jl
@@ -16,7 +16,7 @@ GPUCompiler.runtime_module(::CompilerJob{<:Any,TestCompilerParams}) = TestRuntim
 kernel() = nothing
 
 function main()
-    source = FunctionSpec(typeof(kernel), Tuple{})
+    source = methodinstance(typeof(kernel), Tuple{})
     target = NativeCompilerTarget()
     params = TestCompilerParams()
     config = CompilerConfig(target, params)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,218 +1,13 @@
-# compilation cache
-
-using Core.Compiler: retrieve_code_info, CodeInfo, MethodInstance, SSAValue, SlotNumber, ReturnNode
-using Base: _methods_by_ftype
-
-# generated function that returns the world age of a compilation job. this can be used to
-# drive compilation, e.g. by using it as a key for a cache, as the age will change when a
-# function or any called function is redefined.
-
-
-"""
-    get_world(ft, tt)
-
-A special function that returns the world age in which the current definition of function
-type `ft`, invoked with argument types `tt`, is defined. This can be used to cache
-compilation results:
-
-    compilation_cache = Dict()
-    function cache_compilation(ft, tt)
-        world = get_world(ft, tt)
-        get!(compilation_cache, (ft, tt, world)) do
-            # compile
-        end
-    end
-
-What makes this function special is that it is a generated function, returning a constant,
-whose result is automatically invalidated when the function `ft` (or any called function) is
-redefined. This makes this query ideally suited for hot code, where you want to avoid a
-costly look-up of the current world age on every invocation.
-
-Normally, you shouldn't have to use this function, as it's used by `FunctionSpec`.
-
-!!! warning
-
-    Due to a bug in Julia, JuliaLang/julia#34962, this function's results are only
-    guaranteed to be correctly invalidated when the target function `ft` is executed or
-    processed by codegen (e.g., by calling `code_llvm`).
-"""
-get_world
-
-if VERSION >= v"1.10.0-DEV.873"
-
-# on 1.10 (JuliaLang/julia#48611) the generated function knows which world it was invoked in
-
-function _generated_ex(world, source, ex)
-    stub = Core.GeneratedFunctionStub(identity, Core.svec(:get_world, :ft, :tt), Core.svec())
-    stub(world, source, ex)
-end
-
-function get_world_generator(world::UInt, source, self, ft::Type, tt::Type)
-    @nospecialize
-    @assert Core.Compiler.isType(ft) && Core.Compiler.isType(tt)
-    ft = ft.parameters[1]
-    tt = tt.parameters[1]
-
-    # look up the method
-    method_error = :(throw(MethodError(ft, tt, $world)))
-    Base.isdispatchtuple(tt) || return _generated_ex(world, source, :(error("$tt is not a dispatch tuple")))
-    sig = Tuple{ft, tt.parameters...}
-    min_world = Ref{UInt}(typemin(UInt))
-    max_world = Ref{UInt}(typemax(UInt))
-    has_ambig = Ptr{Int32}(C_NULL)  # don't care about ambiguous results
-    mthds = if VERSION >= v"1.7.0-DEV.1297"
-        Base._methods_by_ftype(sig, #=mt=# nothing, #=lim=# -1,
-                               world, #=ambig=# false,
-                               min_world, max_world, has_ambig)
-        # XXX: use the correct method table to support overlaying kernels
-    else
-        Base._methods_by_ftype(sig, #=lim=# -1,
-                               world, #=ambig=# false,
-                               min_world, max_world, has_ambig)
-    end
-    mthds === nothing && return _generated_ex(world, source, method_error)
-    length(mthds) == 1 || return _generated_ex(world, source, method_error)
-
-    # look up the method and code instance
-    mtypes, msp, m = mthds[1]
-    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), m, mtypes, msp)
-    ci = retrieve_code_info(mi, world)::CodeInfo
-
-    # prepare a new code info
-    new_ci = copy(ci)
-    empty!(new_ci.code)
-    empty!(new_ci.codelocs)
-    resize!(new_ci.linetable, 1)                # see note below
-    empty!(new_ci.ssaflags)
-    new_ci.ssavaluetypes = 0
-    new_ci.min_world = min_world[]
-    new_ci.max_world = max_world[]
-    new_ci.edges = MethodInstance[mi]
-    # XXX: setting this edge does not give us proper method invalidation, see
-    #      JuliaLang/julia#34962 which demonstrates we also need to "call" the kernel.
-    #      invoking `code_llvm` also does the necessary codegen, as does calling the
-    #      underlying C methods -- which GPUCompiler does, so everything Just Works.
-
-    # prepare the slots
-    new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
-    new_ci.slotflags = UInt8[0x00 for i = 1:3]
-
-    # return the world
-    push!(new_ci.code, ReturnNode(world))
-    push!(new_ci.ssaflags, 0x00)   # Julia's native compilation pipeline (and its verifier) expects `ssaflags` to be the same length as `code`
-    push!(new_ci.codelocs, 1)   # see note below
-    new_ci.ssavaluetypes += 1
-
-    # NOTE: we keep the first entry of the original linetable, and use it for location info
-    #       on the call to check_cache. we can't not have a codeloc (using 0 causes
-    #       corruption of the back trace), and reusing the target function's info
-    #       has as advantage that we see the name of the kernel in the backtraces.
-
-    return new_ci
-end
-
-@eval function get_world(ft, tt)
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, get_world_generator))
-end
-
-else
-
-# on older versions of Julia we fall back to looking up the current world. this may be wrong
-# when the generator is invoked in a different world (TODO: when does this happen?)
-
-function get_world_generator(self, ft::Type, tt::Type)
-    @nospecialize
-    @assert Core.Compiler.isType(ft) && Core.Compiler.isType(tt)
-    ft = ft.parameters[1]
-    tt = tt.parameters[1]
-
-    # look up the method
-    method_error = :(throw(MethodError(ft, tt)))
-    Base.isdispatchtuple(tt) || return(:(error("$tt is not a dispatch tuple")))
-    sig = Tuple{ft, tt.parameters...}
-    min_world = Ref{UInt}(typemin(UInt))
-    max_world = Ref{UInt}(typemax(UInt))
-    has_ambig = Ptr{Int32}(C_NULL)  # don't care about ambiguous results
-    mthds = if VERSION >= v"1.7.0-DEV.1297"
-        Base._methods_by_ftype(sig, #=mt=# nothing, #=lim=# -1,
-                               #=world=# typemax(UInt), #=ambig=# false,
-                               min_world, max_world, has_ambig)
-        # XXX: use the correct method table to support overlaying kernels
-    else
-        Base._methods_by_ftype(sig, #=lim=# -1,
-                               #=world=# typemax(UInt), #=ambig=# false,
-                               min_world, max_world, has_ambig)
-    end
-    # XXX: using world=-1 is wrong, but the current world isn't exposed to this generator
-    mthds === nothing && return method_error
-    length(mthds) == 1 || return method_error
-
-    # look up the method and code instance
-    mtypes, msp, m = mthds[1]
-    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), m, mtypes, msp)
-    ci = retrieve_code_info(mi)::CodeInfo
-
-    # XXX: we don't know the world age that this generator was requested to run in, so use
-    # the current world (we cannot use the mi's world because that doesn't update when
-    # called functions are changed). this isn't correct, but should be close.
-    world = Base.get_world_counter()
-
-    # prepare a new code info
-    new_ci = copy(ci)
-    empty!(new_ci.code)
-    empty!(new_ci.codelocs)
-    resize!(new_ci.linetable, 1)                # see note below
-    empty!(new_ci.ssaflags)
-    new_ci.ssavaluetypes = 0
-    new_ci.min_world = min_world[]
-    new_ci.max_world = max_world[]
-    new_ci.edges = MethodInstance[mi]
-    # XXX: setting this edge does not give us proper method invalidation, see
-    #      JuliaLang/julia#34962 which demonstrates we also need to "call" the kernel.
-    #      invoking `code_llvm` also does the necessary codegen, as does calling the
-    #      underlying C methods -- which GPUCompiler does, so everything Just Works.
-
-    # prepare the slots
-    new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
-    new_ci.slotflags = UInt8[0x00 for i = 1:3]
-
-    # return the world
-    push!(new_ci.code, ReturnNode(world))
-    push!(new_ci.ssaflags, 0x00)   # Julia's native compilation pipeline (and its verifier) expects `ssaflags` to be the same length as `code`
-    push!(new_ci.codelocs, 1)   # see note below
-    new_ci.ssavaluetypes += 1
-
-    # NOTE: we keep the first entry of the original linetable, and use it for location info
-    #       on the call to check_cache. we can't not have a codeloc (using 0 causes
-    #       corruption of the back trace), and reusing the target function's info
-    #       has as advantage that we see the name of the kernel in the backtraces.
-
-    return new_ci
-end
-
-@eval function get_world(ft, tt)
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta,
-           :generated,
-           Expr(:new,
-                Core.GeneratedFunctionStub,
-                :get_world_generator,
-                Any[:get_world, :ft, :tt],
-                Any[],
-                @__LINE__,
-                QuoteNode(Symbol(@__FILE__)),
-                true)))
-end
-
-end
+# cached compilation
 
 const cache_lock = ReentrantLock()
 
 """
-    cached_compilation(cache::Dict{UInt}, job::CompilerJob, compiler, linker)
+    cached_compilation(cache::Dict{UInt}, cfg::CompilerConfig, ft::Type, tt::Type,
+                       compiler, linker)
 
-Compile `job` using `compiler` and `linker`, and store the result in `cache`.
+Compile a method instance, identified by its function type `ft` and argument types `tt`,
+using `compiler` and `linker`, and store the result in `cache`.
 
 The `cache` argument should be a dictionary that can be indexed using a `UInt` and store
 whatever the `linker` function returns. The `compiler` function should take a `CompilerJob`
@@ -224,10 +19,9 @@ function cached_compilation(cache::AbstractDict{UInt,V},
                             cfg::CompilerConfig,
                             ft::Type, tt::Type,
                             compiler::Function, linker::Function) where {V}
-    # NOTE: it is OK to index the compilation cache directly with the world age, instead of
-    #       intersecting world age ranges, because we the world age is aquired by calling
-    #       `get_world` and thus will only change when the kernel function is redefined.
-    world = get_world(ft, tt)
+    # NOTE: we only use the codegen world age for invalidation purposes;
+    #       actual compilation happens at the current world age.
+    world = codegen_world_age(ft, tt)
     key = hash(ft)
     key = hash(tt, key)
     key = hash(world, key)
@@ -240,16 +34,15 @@ function cached_compilation(cache::AbstractDict{UInt,V},
 
     LLVM.Interop.assume(isassigned(compile_hook))
     if obj === nothing || compile_hook[] !== nothing
-        obj = actual_compilation(cache, key, cfg, ft, tt, world, compiler, linker)::V
+        obj = actual_compilation(cache, key, cfg, ft, tt, compiler, linker)::V
     end
     return obj::V
 end
 
 @noinline function actual_compilation(cache::AbstractDict, key::UInt,
-                                      cfg::CompilerConfig,
-                                      ft::Type, tt::Type, world,
+                                      cfg::CompilerConfig, ft::Type, tt::Type,
                                       compiler::Function, linker::Function)
-    src = FunctionSpec(ft, tt, world)
+    src = methodinstance(ft, tt)
     job = CompilerJob(src, cfg)
 
     asm = nothing

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -1,6 +1,53 @@
 # compiler driver and main interface
 
+
+## LLVM context handling
+
 export JuliaContext
+
+# transitionary feature to deal versions of Julia that rely on a global context
+#
+# Julia 1.9 removed the global LLVM context, requiring to pass a context to codegen APIs,
+# so the GPUCompiler APIs have been adapted to require passing a Context object as well.
+# however, on older versions of Julia we cannot make codegen emit into that context. we
+# could use a hack (serialize + deserialize) to move code into the correct context, however
+# as it turns out some of our optimization passes erroneously rely on the context being
+# global and unique, resulting in segfaults when we use a local context instead.
+#
+# to work around this mess, and still present a reasonably unified API, we introduce the
+# JuliaContext helper below, which returns a local context on Julia 1.9, and the global
+# unique context on all other versions. Once we only support Julia 1.9, we'll deprecate
+# this helper to a regular `Context()` call.
+function JuliaContext()
+    if VERSION >= v"1.9.0-DEV.115"
+        # Julia 1.9 knows how to deal with arbitrary contexts
+        JuliaContextType()
+    else
+        # earlier versions of Julia claim so, but actually use a global context
+        isboxed_ref = Ref{Bool}()
+        typ = LLVMType(ccall(:jl_type_to_llvm, LLVM.API.LLVMTypeRef,
+                       (Any, Ptr{Bool}), Any, isboxed_ref))
+        context(typ)
+    end
+end
+function JuliaContext(f)
+    if VERSION >= v"1.9.0-DEV.115"
+        JuliaContextType(f)
+    else
+        f(JuliaContext())
+        # we cannot dispose of the global unique context
+    end
+end
+
+if VERSION >= v"1.9.0-DEV.516"
+unwrap_context(ctx::ThreadSafeContext) = context(ctx)
+end
+unwrap_context(ctx::Context) = ctx
+
+
+## compiler entrypoint
+
+export compile
 
 # NOTE: the keyword arguments to compile/codegen control those aspects of compilation that
 #       might have to be changed (e.g. set libraries=false when recursing, or set
@@ -44,56 +91,14 @@ function compile(target::Symbol, @nospecialize(job::CompilerJob);
                    libraries, deferred_codegen, optimize, cleanup, strip, validate, only_entry, ctx)
 end
 
-# transitionary feature to deal versions of Julia that rely on a global context
-#
-# Julia 1.9 removed the global LLVM context, requiring to pass a context to codegen APIs,
-# so the GPUCompiler APIs have been adapted to require passing a Context object as well.
-# however, on older versions of Julia we cannot make codegen emit into that context. we
-# could use a hack (serialize + deserialize) to move code into the correct context, however
-# as it turns out some of our optimization passes erroneously rely on the context being
-# global and unique, resulting in segfaults when we use a local context instead.
-#
-# to work around this mess, and still present a reasonably unified API, we introduce the
-# JuliaContext helper below, which returns a local context on Julia 1.9, and the global
-# unique context on all other versions. Once we only support Julia 1.9, we'll deprecate
-# this helper to a regular `Context()` call.
-function JuliaContext()
-    if VERSION >= v"1.9.0-DEV.115"
-        # Julia 1.9 knows how to deal with arbitrary contexts
-        JuliaContextType()
-    else
-        # earlier versions of Julia claim so, but actually use a global context
-        isboxed_ref = Ref{Bool}()
-        typ = LLVMType(ccall(:jl_type_to_llvm, LLVM.API.LLVMTypeRef,
-                       (Any, Ptr{Bool}), Any, isboxed_ref))
-        context(typ)
-    end
-end
-function JuliaContext(f)
-    if VERSION >= v"1.9.0-DEV.115"
-        JuliaContextType(f)
-    else
-        f(JuliaContext())
-        # we cannot dispose of the global unique context
-    end
-end
-
-if VERSION >= v"1.9.0-DEV.516"
-unwrap_context(ctx::ThreadSafeContext) = context(ctx)
-end
-unwrap_context(ctx::Context) = ctx
-
 function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                  libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
                  cleanup::Bool=true, strip::Bool=false, validate::Bool=true,
                  only_entry::Bool=false, parent_job::Union{Nothing, CompilerJob}=nothing,
                  ctx::Union{JuliaContextType,Nothing}=nothing)
-    ## Julia IR
-
-    mi, mi_meta = emit_julia(job; validate)
-
-    if output == :julia
-        return mi, mi_meta
+    @timeit_debug to "Validation" begin
+        check_method(job)   # not optional
+        validate && check_invocation(job)
     end
 
     temporary_context = ctx === nothing
@@ -112,7 +117,7 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
                      Use a JuliaContext instead.""")
         end
 
-        ir, ir_meta = emit_llvm(job, mi; libraries, deferred_codegen, optimize, cleanup, only_entry, validate, ctx)
+        ir, ir_meta = emit_llvm(job; libraries, deferred_codegen, optimize, cleanup, only_entry, validate, ctx)
 
         if output == :llvm
             if strip
@@ -148,50 +153,10 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     end
 end
 
-@locked function emit_julia(@nospecialize(job::CompilerJob); validate::Bool=true)
-    @timeit_debug to "Validation" begin
-        check_method(job)   # not optional
-        validate && check_invocation(job)
-    end
-
-    @timeit_debug to "Julia front-end" begin
-
-        # get the method instance
-        sig = typed_signature(job)
-        meth = if VERSION >= v"1.10.0-DEV.65"
-            Base._which(sig; world=job.source.world).method
-        elseif VERSION >= v"1.7.0-DEV.435"
-            Base._which(sig, job.source.world).method
-        else
-            ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), sig, job.source.world)
-        end
-
-        (ti, env) = ccall(:jl_type_intersection_with_env, Any,
-                          (Any, Any), sig, meth.sig)::Core.SimpleVector
-
-        meth = Base.func_for_method_checked(meth, ti, env)
-
-        method_instance = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance},
-                      (Any, Any, Any, UInt), meth, ti, env, job.source.world)
-
-        for var in env
-            if var isa TypeVar
-                throw(KernelError(job, "method captures a typevar (you probably use an unbound type variable)"))
-            end
-        end
-    end
-
-    # ensure that the returned method instance is valid in the compilation world.
-    # otherwise, `jl_create_native` won't actually emit any code.
-    @assert method_instance.def.primary_world <= job.source.world <= method_instance.def.deleted_world
-
-    return method_instance, ()
-end
-
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
 # this could both be generalized (e.g. supporting actual function calls, instead of
 # returning a function pointer), and be integrated with the nonrecursive codegen.
-const deferred_codegen_jobs = Dict{Int, Union{FunctionSpec, CompilerJob}}()
+const deferred_codegen_jobs = Dict{Int, Any}()
 
 # We make this function explicitly callable so that we can drive OrcJIT's
 # lazy compilation from, while also enabling recursive compilation.
@@ -201,8 +166,9 @@ end
 
 @generated function deferred_codegen(::Val{ft}, ::Val{tt}) where {ft,tt}
     id = length(deferred_codegen_jobs) + 1
-    deferred_codegen_jobs[id] = FunctionSpec(ft, tt, 0)
-    # don't bother looking up the method's world, as we'll override it during codegen.
+    deferred_codegen_jobs[id] = (; ft, tt)
+    # don't bother looking up the method instance, as we'll do so again during codegen
+    # using the world age of the parent.
     #
     # this also works around an issue on <1.10, where we don't know the world age of
     # generated functions so use the current world counter, which may be too new
@@ -217,7 +183,7 @@ end
 
 const __llvm_initialized = Ref(false)
 
-@locked function emit_llvm(@nospecialize(job::CompilerJob), @nospecialize(method_instance);
+@locked function emit_llvm(@nospecialize(job::CompilerJob);
                            libraries::Bool=true, deferred_codegen::Bool=true, optimize::Bool=true,
                            cleanup::Bool=true, only_entry::Bool=false, validate::Bool=true,
                            ctx::JuliaContextType)
@@ -231,11 +197,11 @@ const __llvm_initialized = Ref(false)
     end
 
     @timeit_debug to "IR generation" begin
-        ir, compiled = irgen(job, method_instance; ctx)
+        ir, compiled = irgen(job; ctx)
         if job.config.entry_abi === :specfunc
-            entry_fn = compiled[method_instance].specfunc
+            entry_fn = compiled[job.source].specfunc
         else
-            entry_fn = compiled[method_instance].func
+            entry_fn = compiled[job.source].func
         end
         entry = functions(ir)[entry_fn]
     end
@@ -305,13 +271,12 @@ const __llvm_initialized = Ref(false)
 
                 # get a job in the appopriate world
                 dyn_job = if dyn_val isa CompilerJob
-                    dyn_src = FunctionSpec(dyn_val.source; world=job.source.world)
-                    CompilerJob(dyn_src, dyn_val.config)
-                elseif dyn_val isa FunctionSpec
-                    dyn_src = FunctionSpec(dyn_val; world=job.source.world)
-                    CompilerJob(dyn_src, job.config)
+                    # trust that the user knows what they're doing
+                    dyn_val
                 else
-                    error("invalid deferred job type $(typeof(dyn_val))")
+                    ft, tt = dyn_val
+                    dyn_src = methodinstance(ft, tt, tls_world_age())
+                    CompilerJob(dyn_src, job.config)
                 end
 
                 push!(get!(worklist, dyn_job, LLVM.CallInst[]), call)

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -1,6 +1,252 @@
 # Julia compiler integration
 
-## cache
+
+## world age lookups
+
+# `tls_world_age` should be used to look up the current world age. in most cases, this is
+# what you should use to invoke the compiler with.
+#
+# `codegen_world_age` is a special function that returns the world age in which the passed
+# method instance (identified by its function and argument types) is to be compiled. the
+# returned constant is automatically invalidated when the method is redefined, and as such
+# can be used to drive cached compilation. it is unlikely that you should use this function
+# directly, instead use `cached_compilation` which handles invalidation for you.
+
+tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
+
+if VERSION >= v"1.10.0-DEV.873"
+
+# on 1.10 (JuliaLang/julia#48611) the generated function knows which world it was invoked in
+
+function _generated_ex(world, source, ex)
+    stub = Core.GeneratedFunctionStub(identity, Core.svec(:methodinstance, :ft, :tt), Core.svec())
+    stub(world, source, ex)
+end
+
+function codegen_world_age_generator(world::UInt, source, self, ft::Type, tt::Type)
+    @nospecialize
+    @assert Core.Compiler.isType(ft) && Core.Compiler.isType(tt)
+    ft = ft.parameters[1]
+    tt = tt.parameters[1]
+
+    # validation
+    ft <: Core.Builtin && error("$(unsafe_function_from_type(ft)) is not a generic function")
+
+    # look up the method
+    method_error = :(throw(MethodError(ft, tt, $world)))
+    sig = Tuple{ft, tt.parameters...}
+    min_world = Ref{UInt}(typemin(UInt))
+    max_world = Ref{UInt}(typemax(UInt))
+    has_ambig = Ptr{Int32}(C_NULL)  # don't care about ambiguous results
+    mthds = if VERSION >= v"1.7.0-DEV.1297"
+        Base._methods_by_ftype(sig, #=mt=# nothing, #=lim=# -1,
+                               world, #=ambig=# false,
+                               min_world, max_world, has_ambig)
+        # XXX: use the correct method table to support overlaying kernels
+    else
+        Base._methods_by_ftype(sig, #=lim=# -1,
+                               world, #=ambig=# false,
+                               min_world, max_world, has_ambig)
+    end
+    mthds === nothing && return _generated_ex(world, source, method_error)
+    length(mthds) == 1 || return _generated_ex(world, source, method_error)
+
+    # look up the method and code instance
+    mtypes, msp, m = mthds[1]
+    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), m, mtypes, msp)
+    ci = retrieve_code_info(mi, world)::CodeInfo
+
+    # prepare a new code info
+    new_ci = copy(ci)
+    empty!(new_ci.code)
+    empty!(new_ci.codelocs)
+    resize!(new_ci.linetable, 1)                # see note below
+    empty!(new_ci.ssaflags)
+    new_ci.ssavaluetypes = 0
+    new_ci.min_world = min_world[]
+    new_ci.max_world = max_world[]
+    new_ci.edges = MethodInstance[mi]
+    # XXX: setting this edge does not give us proper method invalidation, see
+    #      JuliaLang/julia#34962 which demonstrates we also need to "call" the kernel.
+    #      invoking `code_llvm` also does the necessary codegen, as does calling the
+    #      underlying C methods -- which GPUCompiler does, so everything Just Works.
+
+    # prepare the slots
+    new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
+    new_ci.slotflags = UInt8[0x00 for i = 1:3]
+
+    # return the codegen world age
+    push!(new_ci.code, ReturnNode(world))
+    push!(new_ci.ssaflags, 0x00)   # Julia's native compilation pipeline (and its verifier) expects `ssaflags` to be the same length as `code`
+    push!(new_ci.codelocs, 1)   # see note below
+    new_ci.ssavaluetypes += 1
+
+    # NOTE: we keep the first entry of the original linetable, and use it for location info
+    #       on the call to check_cache. we can't not have a codeloc (using 0 causes
+    #       corruption of the back trace), and reusing the target function's info
+    #       has as advantage that we see the name of the kernel in the backtraces.
+
+    return new_ci
+end
+
+@eval function codegen_world_age(ft, tt)
+    $(Expr(:meta, :generated_only))
+    $(Expr(:meta, :generated, codegen_world_age_generator))
+end
+
+else
+
+# on older versions of Julia we fall back to looking up the current world. this may be wrong
+# when the generator is invoked in a different world (TODO: when does this happen?)
+
+function codegen_world_age_generator(self, ft::Type, tt::Type)
+    @nospecialize
+    @assert Core.Compiler.isType(ft) && Core.Compiler.isType(tt)
+    ft = ft.parameters[1]
+    tt = tt.parameters[1]
+
+    # validation
+    ft <: Core.Builtin && error("$(unsafe_function_from_type(ft)) is not a generic function")
+
+    # look up the method
+    method_error = :(throw(MethodError(ft, tt)))
+    sig = Tuple{ft, tt.parameters...}
+    min_world = Ref{UInt}(typemin(UInt))
+    max_world = Ref{UInt}(typemax(UInt))
+    has_ambig = Ptr{Int32}(C_NULL)  # don't care about ambiguous results
+    mthds = if VERSION >= v"1.7.0-DEV.1297"
+        Base._methods_by_ftype(sig, #=mt=# nothing, #=lim=# -1,
+                               #=world=# typemax(UInt), #=ambig=# false,
+                               min_world, max_world, has_ambig)
+        # XXX: use the correct method table to support overlaying kernels
+    else
+        Base._methods_by_ftype(sig, #=lim=# -1,
+                               #=world=# typemax(UInt), #=ambig=# false,
+                               min_world, max_world, has_ambig)
+    end
+    # XXX: using world=-1 is wrong, but the current world isn't exposed to this generator
+    mthds === nothing && return method_error
+    length(mthds) == 1 || return method_error
+
+    # look up the method and code instance
+    mtypes, msp, m = mthds[1]
+    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any), m, mtypes, msp)
+    ci = retrieve_code_info(mi)::CodeInfo
+
+    # prepare a new code info
+    new_ci = copy(ci)
+    empty!(new_ci.code)
+    empty!(new_ci.codelocs)
+    resize!(new_ci.linetable, 1)                # see note below
+    empty!(new_ci.ssaflags)
+    new_ci.ssavaluetypes = 0
+    new_ci.min_world = min_world[]
+    new_ci.max_world = max_world[]
+    new_ci.edges = MethodInstance[mi]
+    # XXX: setting this edge does not give us proper method invalidation, see
+    #      JuliaLang/julia#34962 which demonstrates we also need to "call" the kernel.
+    #      invoking `code_llvm` also does the necessary codegen, as does calling the
+    #      underlying C methods -- which GPUCompiler does, so everything Just Works.
+
+    # prepare the slots
+    new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
+    new_ci.slotflags = UInt8[0x00 for i = 1:3]
+
+    # return the current world age (which is not technically the codegen world age,
+    # but works well enough for invalidation purposes)
+    push!(new_ci.code, ReturnNode(Base.get_world_counter()))
+    push!(new_ci.ssaflags, 0x00)   # Julia's native compilation pipeline (and its verifier) expects `ssaflags` to be the same length as `code`
+    push!(new_ci.codelocs, 1)   # see note below
+    new_ci.ssavaluetypes += 1
+
+    # NOTE: we keep the first entry of the original linetable, and use it for location info
+    #       on the call to check_cache. we can't not have a codeloc (using 0 causes
+    #       corruption of the back trace), and reusing the target function's info
+    #       has as advantage that we see the name of the kernel in the backtraces.
+
+    return new_ci
+end
+
+@eval function codegen_world_age(ft, tt)
+    $(Expr(:meta, :generated_only))
+    $(Expr(:meta,
+           :generated,
+           Expr(:new,
+                Core.GeneratedFunctionStub,
+                :codegen_world_age_generator,
+                Any[:methodinstance, :ft, :tt],
+                Any[],
+                @__LINE__,
+                QuoteNode(Symbol(@__FILE__)),
+                true)))
+end
+
+end
+
+
+## looking up method instances
+
+export methodinstance
+
+using Core.Compiler: retrieve_code_info, CodeInfo, MethodInstance, SSAValue, SlotNumber, ReturnNode
+using Base: _methods_by_ftype
+
+@inline function typed_signature(ft::Type, tt::Type)
+    u = Base.unwrap_unionall(tt)
+    return Base.rewrap_unionall(Tuple{ft, u.parameters...}, tt)
+end
+
+# create a MethodError from a function type
+# TODO: fix upstream
+function unsafe_function_from_type(ft::Type)
+    if isdefined(ft, :instance)
+        ft.instance
+    else
+        # HACK: dealing with a closure or something... let's do somthing really invalid,
+        #       which works because MethodError doesn't actually use the function
+        Ref{ft}()[]
+    end
+end
+function MethodError(ft::Type, tt::Type, world::Integer=typemax(UInt))
+    Base.MethodError(unsafe_function_from_type(ft), tt, world)
+end
+
+"""
+    methodinstance(ft::Type, tt::Type, [world::UInt])
+
+Look up the method instance that corresponds to invoking the function with type `ft` with
+argument typed `tt`. If the `world` argument is specified, the look-up is static and will
+always return the same result. If the `world` argument is not specified, the look-up is
+dynamic and the returned method instance will automatically be invalidated when a relevant
+function is redefined.
+"""
+function methodinstance(ft::Type, tt::Type, world::Integer=tls_world_age())
+    sig = typed_signature(ft, tt)
+
+    # look-up the method
+    meth = if VERSION >= v"1.10.0-DEV.65"
+        Base._which(sig; world).method
+    elseif VERSION >= v"1.7.0-DEV.435"
+        Base._which(sig, world).method
+    else
+        ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), sig, world)
+    end
+
+    (ti, env) = ccall(:jl_type_intersection_with_env, Any,
+                      (Any, Any), sig, meth.sig)::Core.SimpleVector
+
+    meth = Base.func_for_method_checked(meth, ti, env)
+
+    method_instance = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance},
+                            (Any, Any, Any, UInt), meth, ti, env, world)
+
+    return method_instance
+end
+
+Base.@deprecate_binding FunctionSpec methodinstance
+
+
+## code instance cache
 
 using Core.Compiler: CodeInstance, MethodInstance, InferenceParams, OptimizationParams
 
@@ -340,7 +586,6 @@ end
 # for platforms without @cfunction-with-closure support
 const _method_instances = Ref{Any}()
 const _cache = Ref{Any}()
-const _world = Ref{Int}()
 function _lookup_fun(mi, min_world, max_world)
     push!(_method_instances[], mi)
     ci_cache_lookup(_cache[], mi, min_world, max_world)
@@ -367,14 +612,13 @@ macro in_world(world, ex)
     end
 end
 
-function compile_method_instance(@nospecialize(job::CompilerJob),
-                                 method_instance::MethodInstance; ctx::JuliaContextType)
+function compile_method_instance(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
     # populate the cache
     cache = ci_cache(job)
     mt = method_table(job)
     interp = get_interpreter(job)
-    if ci_cache_lookup(cache, method_instance, job.source.world, job.source.world) === nothing
-        ci_cache_populate(interp, cache, mt, method_instance, job.source.world, job.source.world)
+    if ci_cache_lookup(cache, job.source, job.world, job.world) === nothing
+        ci_cache_populate(interp, cache, mt, job.source, job.world, job.world)
     end
 
     # create a callback to look-up function in our cache,
@@ -389,7 +633,6 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     else
         _cache[] = cache
         _method_instances[] = method_instances
-        _world[] = job.source.world
         lookup_cb = @cfunction(_lookup_fun, Any, (Any, UInt, UInt))
     end
 
@@ -426,35 +669,35 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
             if VERSION >= v"1.10.0-DEV.645" || v"1.9.0-beta4.23" <= VERSION < v"1.10-"
                 ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint, Cint, Csize_t),
-                      [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0, job.source.world)
+                      [job.source], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0, job.world)
             elseif VERSION >= v"1.10.0-DEV.204" || v"1.9.0-alpha1.55" <= VERSION < v"1.10-"
-                @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
+                @in_world job.world ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint, Cint),
-                      [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0)
+                      [job.source], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0, #=external linkage=# 0)
             elseif VERSION >= v"1.10.0-DEV.75"
-                @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
+                @in_world job.world ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint),
-                      [method_instance], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0)
+                      [job.source], ts_mod, Ref(params), CompilationPolicyExtern, #=imaging mode=# 0)
             else
-                @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
+                @in_world job.world ccall(:jl_create_native, Ptr{Cvoid},
                       (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint),
-                      [method_instance], ts_mod, Ref(params), CompilationPolicyExtern)
+                      [job.source], ts_mod, Ref(params), CompilationPolicyExtern)
 
             end
         elseif VERSION >= v"1.9.0-DEV.115"
-            @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
+            @in_world job.world ccall(:jl_create_native, Ptr{Cvoid},
                   (Vector{MethodInstance}, LLVM.API.LLVMContextRef, Ptr{Base.CodegenParams}, Cint),
-                  [method_instance], ctx, Ref(params), CompilationPolicyExtern)
+                  [job.source], ctx, Ref(params), CompilationPolicyExtern)
         elseif VERSION >= v"1.8.0-DEV.661"
             @assert ctx == JuliaContext()
-            @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
+            @in_world job.world ccall(:jl_create_native, Ptr{Cvoid},
                   (Vector{MethodInstance}, Ptr{Base.CodegenParams}, Cint),
-                  [method_instance], Ref(params), CompilationPolicyExtern)
+                  [job.source], Ref(params), CompilationPolicyExtern)
         else
             @assert ctx == JuliaContext()
-            @in_world job.source.world ccall(:jl_create_native, Ptr{Cvoid},
+            @in_world job.world ccall(:jl_create_native, Ptr{Cvoid},
                   (Vector{MethodInstance}, Base.CodegenParams, Cint),
-                  [method_instance], params, CompilationPolicyExtern)
+                  [job.source], params, CompilationPolicyExtern)
         end
         @assert native_code != C_NULL
         llvm_mod_ref = if VERSION >= v"1.9.0-DEV.516"
@@ -482,7 +725,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     # process all compiled method instances
     compiled = Dict()
     for mi in method_instances
-        ci = ci_cache_lookup(cache, mi, job.source.world, job.source.world)
+        ci = ci_cache_lookup(cache, mi, job.world, job.world)
         ci === nothing && continue
 
         # get the function index
@@ -493,7 +736,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
               native_code, ci, llvm_func_idx, llvm_specfunc_idx)
 
         # get the function
-        llvm_func = if llvm_func_idx[] != -1
+        llvm_func = if llvm_func_idx[] >=  1
             llvm_func_ref = ccall(:jl_get_llvm_function, LLVM.API.LLVMValueRef,
                                   (Ptr{Cvoid}, UInt32), native_code, llvm_func_idx[]-1)
             @assert llvm_func_ref != C_NULL
@@ -502,8 +745,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
             nothing
         end
 
-
-        llvm_specfunc = if llvm_specfunc_idx[] != -1
+        llvm_specfunc = if llvm_specfunc_idx[] >=  1
             llvm_specfunc_ref = ccall(:jl_get_llvm_function, LLVM.API.LLVMValueRef,
                                       (Ptr{Cvoid}, UInt32), native_code, llvm_specfunc_idx[]-1)
             @assert llvm_specfunc_ref != C_NULL
@@ -518,7 +760,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob),
     end
 
     # ensure that the requested method instance was compiled
-    @assert haskey(compiled, method_instance)
+    @assert haskey(compiled, job.source)
 
     if VERSION < v"1.9.0-DEV.516"
         # configure the module

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -53,9 +53,9 @@ end
 
 ## functionality to build the runtime library
 
-function emit_function!(mod, config::CompilerConfig, f, method, world; ctx::JuliaContextType)
+function emit_function!(mod, config::CompilerConfig, f, method; ctx::JuliaContextType)
     tt = Base.to_tuple_type(method.types)
-    source = FunctionSpec(f, tt, world)
+    source = methodinstance(f, tt)
     new_mod, meta = codegen(:llvm, CompilerJob(source, config);
                             optimize=false, libraries=false, validate=false, ctx)
     ft = eltype(llvmtype(meta.entry))
@@ -100,7 +100,7 @@ function build_runtime(@nospecialize(job::CompilerJob); ctx)
         else
             method.def
         end
-        emit_function!(mod, config, typeof(def), method, job.source.world; ctx)
+        emit_function!(mod, config, typeof(def), method; ctx)
     end
 
     # we cannot optimize the runtime library, because the code would then be optimized again

--- a/test/definitions/bpf.jl
+++ b/test/definitions/bpf.jl
@@ -9,7 +9,7 @@ end
 
 function bpf_job(@nospecialize(func), @nospecialize(types);
                  kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = BPFCompilerTarget()
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)

--- a/test/definitions/gcn.jl
+++ b/test/definitions/gcn.jl
@@ -9,7 +9,7 @@ end
 
 function gcn_job(@nospecialize(func), @nospecialize(types);
                  kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)

--- a/test/definitions/metal.jl
+++ b/test/definitions/metal.jl
@@ -9,7 +9,7 @@ end
 
 function metal_job(@nospecialize(func), @nospecialize(types);
                    kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = MetalCompilerTarget(; macos=v"12.2")
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)

--- a/test/definitions/ptx.jl
+++ b/test/definitions/ptx.jl
@@ -40,7 +40,7 @@ GPUCompiler.runtime_module(::PTXCompilerJob) = PTXTestRuntime
 function ptx_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                  minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
                  maxregs=nothing, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = PTXCompilerTarget(;cap=v"7.0",
                                minthreads, maxthreads,
                                blocks_per_sm, maxregs)

--- a/test/definitions/spirv.jl
+++ b/test/definitions/spirv.jl
@@ -9,7 +9,7 @@ end
 
 function spirv_job(@nospecialize(func), @nospecialize(types);
                    kernel::Bool=false, always_inline=false, kwargs...)
-    source = FunctionSpec(typeof(func), Base.to_tuple_type(types))
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = SPIRVCompilerTarget()
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -84,9 +84,9 @@ end
     end
 
     asm = sprint(io->gcn_code_native(io, entry, Tuple{Int64}; dump_module=true, kernel=true))
-    @test occursin(r"\.amdhsa_kernel _Z\d*julia_entry", asm)
-    @test !occursin(r"\.amdhsa_kernel _Z\d*julia_nonentry", asm)
-    @test occursin(r"\.type.*julia_nonentry_\d*,@function", asm)
+    @test occursin(r"\.amdhsa_kernel \w*entry", asm)
+    @test !occursin(r"\.amdhsa_kernel \w*nonentry", asm)
+    @test occursin(r"\.type.*\w*nonentry\w*,@function", asm)
 end
 
 @testset "child function reuse" begin

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -24,22 +24,22 @@ end
     kernel(x) = return
 
     ir = sprint(io->metal_code_llvm(io, kernel, Tuple{Tuple{Int}}))
-    @test occursin(r"@.*julia.*kernel.*\(({ i64 }|\[1 x i64\])\*", ir)
+    @test occursin(r"@\w*kernel\w*\(({ i64 }|\[1 x i64\])\*", ir)
 
     # for kernels, every pointer argument needs to take an address space
     ir = sprint(io->metal_code_llvm(io, kernel, Tuple{Tuple{Int}}; kernel=true))
-    @test occursin(r"@.*julia.*kernel.*\(({ i64 }|\[1 x i64\]) addrspace\(1\)\*", ir)
+    @test occursin(r"@\w*kernel\w*\(({ i64 }|\[1 x i64\]) addrspace\(1\)\*", ir)
 end
 
 @testset "byref primitives" begin
     kernel(x) = return
 
     ir = sprint(io->metal_code_llvm(io, kernel, Tuple{Int}))
-    @test occursin(r"@.*julia.*kernel.*\(i64 ", ir)
+    @test occursin(r"@\w*kernel\w*\(i64 ", ir)
 
     # for kernels, every pointer argument needs to take an address space
     ir = sprint(io->metal_code_llvm(io, kernel, Tuple{Int}; kernel=true))
-    @test occursin(r"@.*julia.*kernel.*\(i64 addrspace\(1\)\*", ir)
+    @test occursin(r"@\w*kernel\w*\(i64 addrspace\(1\)\*", ir)
 end
 
 @testset "module metadata" begin
@@ -71,11 +71,11 @@ end
     end
 
     ir = sprint(io->metal_code_llvm(io, kernel, Tuple{Core.LLVMPtr{Int,1}}))
-    @test occursin(r"@.*julia.*kernel.*\(.* addrspace\(1\)\* %0\)", ir)
+    @test occursin(r"@\w*kernel\w*\(.* addrspace\(1\)\* %0\)", ir)
     @test occursin(r"call i32 @julia.air.thread_position_in_threadgroup.i32", ir)
 
     ir = sprint(io->metal_code_llvm(io, kernel, Tuple{Core.LLVMPtr{Int,1}}; kernel=true))
-    @test occursin(r"@.*julia.*kernel.*\(.* addrspace\(1\)\* %0, i32 %thread_position_in_threadgroup\)", ir)
+    @test occursin(r"@\w*kernel\w*\(.* addrspace\(1\)\* %0, i32 %thread_position_in_threadgroup\)", ir)
     @test !occursin(r"call i32 @julia.air.thread_position_in_threadgroup.i32", ir)
 end
 
@@ -94,8 +94,8 @@ Sys.isapple() && @testset "asm" begin
                                     dump_module=true, kernel=true))
     @test occursin("[header]", asm)
     @test occursin("[program]", asm)
-    @test occursin(r"name: .*julia.*kernel.*", asm)
-    @test occursin(r"define void @.*julia.*kernel.*", asm)
+    @test occursin(r"name: \w*kernel\w*", asm)
+    @test occursin(r"define void @\w*kernel\w*", asm)
 end
 
 end

--- a/test/spirv.jl
+++ b/test/spirv.jl
@@ -24,10 +24,10 @@ end
     kernel(x) = return
 
     ir = sprint(io->spirv_code_llvm(io, kernel, Tuple{Tuple{Int}}))
-    @test occursin(r"@.*julia_.+_kernel.+\(({ i64 }|\[1 x i64\])\*", ir)
+    @test occursin(r"@\w*kernel\w*\(({ i64 }|\[1 x i64\])\*", ir)
 
     ir = sprint(io->spirv_code_llvm(io, kernel, Tuple{Tuple{Int}}; kernel=true))
-    @test occursin(r"@.*julia_.+_kernel.+\(.*{ ({ i64 }|\[1 x i64\]) }\*.+byval", ir)
+    @test occursin(r"@\w*kernel\w*\(.*{ ({ i64 }|\[1 x i64\]) }\*.+byval", ir)
 end
 
 @testset "byval bug" begin


### PR DESCRIPTION
With the `kernel` and `name` kwargs gone, `FunctionSpec` was becoming useless, so cut it out and replace it with Julia's `MethodInstance`, as suggested by @vtjnash & @vchuravy.

@jpsamaroo This is obviously breaking, but should just require changing `FunctionSpec` to `methodinstance`. In addition, I'm removing `emit_julia` since that function only served to look-up the method instance, but in a follow-up PR I'm going to change things so that you will be able to just call `GPUCompiler.compile` and won't need to call into any specific `emit_` function again.