### PR TITLE
Fix docstring <-> code mismatch of `CompilerConfig`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -62,7 +62,7 @@ export CompilerConfig
 # the configuration of the compiler
 
 """
-    CompilerConfig(target, params; kernel=true, entry_abi=:specfunc, entry_name=nothing,
+    CompilerConfig(target, params; kernel=true, entry_abi=:specfunc, name=nothing,
                                    always_inline=false)
 
 Construct a `CompilerConfig` that will be used to drive compilation for the given `target`
@@ -80,7 +80,7 @@ Several keyword arguments can be used to customize the compilation process:
    pointer to a vector of boxed Julia values and the third argument being the number of
    values, the return value will also be boxed. The `:func` abi will internally call the
    `:specfunc` abi, but is generally easier to invoke directly.
-- `entry_name`: the name that will be used for the entrypoint function. If `nothing` (the
+- `name`: the name that will be used for the entrypoint function. If `nothing` (the
    default), the name will be generated automatically.
 - `always_inline` specifies if the Julia front-end should inline all functions into one if
    possible.

--- a/test/definitions/native.jl
+++ b/test/definitions/native.jl
@@ -114,12 +114,12 @@ module LazyCodegen
             @assert !cc.compiled
             job = cc.job
 
-            entry_name, jitted_mod = JuliaContext() do ctx
+            name, jitted_mod = JuliaContext() do ctx
                 ir, meta = GPUCompiler.compile(:llvm, job; validate=false, ctx)
                 name(meta.entry), compile!(orc, ir)
             end
 
-            addr = addressin(orc, jitted_mod, entry_name)
+            addr = addressin(orc, jitted_mod, name)
             ptr  = pointer(addr)
 
             cc.compiled = true


### PR DESCRIPTION
The docstring said `entry_name`, but the code used `name` as the field - this PR makes them consistently use `entry_name`.