### PR TITLE
Drop prefix from explicitly set entrypoint 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['release-1.7', 'release-1.8', 'backports-release-1.9', 'master']
+        branch: ['release-1.7', 'release-1.8', 'release-1.9', 'master']
         os: [ubuntu-latest, macOS-latest]
         arch: [x64]
     steps:

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -60,7 +60,7 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
 
     # rename and process the entry point
     if job.config.name !== nothing
-        LLVM.name!(entry, safe_name(string("julia_", job.config.name)))
+        LLVM.name!(entry, safe_name(job.config.name))
     elseif job.config.kernel
         LLVM.name!(entry, mangle_sig(job.source.specTypes))
     end


### PR DESCRIPTION
This depends on #422 due to changing the same line in `irgen.jl`. 

Opening as a draft until #422 is closed.