### PR TITLE
Improvements for Metal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.20.1"
+version = "0.20.2"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.20.2"
+version = "0.20.1"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -6,12 +6,15 @@ const Metal_LLVM_Tools_jll = LazyModule("Metal_LLVM_Tools_jll", UUID("0418c028-f
 
 export MetalCompilerTarget
 
-Base.@kwdef struct MetalCompilerTarget <: AbstractCompilerTarget
+struct MetalCompilerTarget <: AbstractCompilerTarget
     # version numbers
     macos::VersionNumber
     air::VersionNumber
     metal::VersionNumber
 end
+
+# for backwards compatibility
+MetalCompilerTarget(macos::VersionNumber) = MetalCompilerTarget(macos, v"2.4", v"2.4")
 
 function Base.hash(target::MetalCompilerTarget, h::UInt)
     h = hash(target.macos, h)

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -7,7 +7,10 @@ const Metal_LLVM_Tools_jll = LazyModule("Metal_LLVM_Tools_jll", UUID("0418c028-f
 export MetalCompilerTarget
 
 Base.@kwdef struct MetalCompilerTarget <: AbstractCompilerTarget
+    # version numbers
     macos::VersionNumber
+    air::VersionNumber
+    metal::VersionNumber
 end
 
 function Base.hash(target::MetalCompilerTarget, h::UInt)
@@ -49,6 +52,22 @@ function process_module!(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module
         #callconv!(f, LLVMMETALFUNCCallConv)
         # XXX: this makes InstCombine erase kernel->func calls.
         #      do we even need this? if we do, do so in metallib-instead.
+    end
+
+    # emit the AIR and Metal version numbers as constants in the module. this makes it
+    # possible to 'query' these in device code, relying on LLVM to optimize the checks away
+    # and generate static code. note that we only do so if there's actual uses of these
+    # variables; unconditionally creating a gvar would result in duplicate declarations.
+    for (name, value) in ["air_major"   => job.config.target.air.major,
+                          "air_minor"   => job.config.target.air.minor,
+                          "metal_major" => job.config.target.metal.major,
+                          "metal_minor" => job.config.target.metal.minor]
+        if haskey(globals(mod), name)
+            gv = globals(mod)[name]
+            initializer!(gv, ConstantInt(LLVM.Int32Type(ctx), value))
+            # change the linkage so that we can inline the value
+            linkage!(gv, LLVM.API.LLVMPrivateLinkage)
+        end
     end
 end
 
@@ -701,18 +720,18 @@ function add_module_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
 
     # add AIR version
     air_md = Metadata[]
-    push!(air_md, Metadata(ConstantInt(Int32(2); ctx)))
-    push!(air_md, Metadata(ConstantInt(Int32(4); ctx)))
-    push!(air_md, Metadata(ConstantInt(Int32(0); ctx)))
+    push!(air_md, Metadata(ConstantInt(Int32(job.config.target.air.major); ctx)))
+    push!(air_md, Metadata(ConstantInt(Int32(job.config.target.air.minor); ctx)))
+    push!(air_md, Metadata(ConstantInt(Int32(job.config.target.air.patch); ctx)))
     air_md = MDNode(air_md; ctx)
     push!(metadata(mod)["air.version"], air_md)
 
-    # add language version
+    # add Metal language version
     air_lang_md = Metadata[]
     push!(air_lang_md, MDString("Metal"; ctx))
-    push!(air_lang_md, Metadata(ConstantInt(Int32(2); ctx)))
-    push!(air_lang_md, Metadata(ConstantInt(Int32(4); ctx)))
-    push!(air_lang_md, Metadata(ConstantInt(Int32(0); ctx)))
+    push!(air_lang_md, Metadata(ConstantInt(Int32(job.config.target.metal.major); ctx)))
+    push!(air_lang_md, Metadata(ConstantInt(Int32(job.config.target.metal.minor); ctx)))
+    push!(air_lang_md, Metadata(ConstantInt(Int32(job.config.target.metal.patch); ctx)))
     air_lang_md = MDNode(air_lang_md; ctx)
     push!(metadata(mod)["air.language_version"], air_lang_md)
 

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -6,7 +6,7 @@ const Metal_LLVM_Tools_jll = LazyModule("Metal_LLVM_Tools_jll", UUID("0418c028-f
 
 export MetalCompilerTarget
 
-struct MetalCompilerTarget <: AbstractCompilerTarget
+Base.@kwdef struct MetalCompilerTarget <: AbstractCompilerTarget
     # version numbers
     macos::VersionNumber
     air::VersionNumber
@@ -14,7 +14,8 @@ struct MetalCompilerTarget <: AbstractCompilerTarget
 end
 
 # for backwards compatibility
-MetalCompilerTarget(macos::VersionNumber) = MetalCompilerTarget(macos, v"2.4", v"2.4")
+MetalCompilerTarget(macos::VersionNumber) =
+    MetalCompilerTarget(; macos, air=v"2.4", metal=v"2.4")
 
 function Base.hash(target::MetalCompilerTarget, h::UInt)
     h = hash(target.macos, h)

--- a/test/definitions/metal.jl
+++ b/test/definitions/metal.jl
@@ -10,7 +10,7 @@ end
 function metal_job(@nospecialize(func), @nospecialize(types);
                    kernel::Bool=false, always_inline=false, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = MetalCompilerTarget(; macos=v"12.2")
+    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
     params = TestCompilerParams()
     config = CompilerConfig(target, params; kernel, always_inline)
     CompilerJob(source, config), kwargs


### PR DESCRIPTION
- adds a device-side version getter for the Metal and AIR version, while making both configurable
- adds function attributes for some intrinsics

We were also always using Metal 2.4.0, even on macOS 13 (while using Metal 3-only features)... Not sure why that did work. I'm also not sure what the difference is between the Metal and AIR version; we emit the same version for both.