### PR TITLE
Refuse opaque closures.

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -88,6 +88,15 @@ function check_invocation(@nospecialize(job::CompilerJob))
         Core.Compiler.isconstType(dt) && continue
         real_arg_i += 1
 
+        @static if VERSION >= v"1.7"
+            # XXX: can we support these for CPU targets?
+            if dt <: Core.OpaqueClosure
+                throw(KernelError(job, "passing an opaque closure",
+                    """Argument $arg_i to your kernel function is an opaque closure.
+                       This is a CPU-only object not supported by GPUCompiler."""))
+            end
+        end
+
         if !isbitstype(dt)
             throw(KernelError(job, "passing and using non-bitstype argument",
                 """Argument $arg_i to your kernel function is of type $dt, which is not isbits:


### PR DESCRIPTION
These are objects containing a CPU pointer. They would also fail the mutability check below, but let's be a little more verbose.