### PR TITLE
Simplify interfaces

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -262,7 +262,7 @@ end
 ## extension points at important stages of compilation
 
 # early extension point used to link-in external bitcode files.
-# this is typically overridden by downstream packages, to link vendor libraries.
+# this is typically used by downstream packages to link vendor libraries.
 link_libraries!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
                 undefined_fns::Vector{String}) = return
 
@@ -279,3 +279,9 @@ finish_ir!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry::LLVM.Functi
 
 # whether an LLVM function is valid for this back-end
 validate_module(@nospecialize(job::CompilerJob), mod::LLVM.Module) = IRError[]
+
+# deprecated
+struct DeprecationMarker end
+process_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = DeprecationMarker()
+process_entry!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry::LLVM.Function) =
+    DeprecationMarker()

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -278,7 +278,7 @@ finish_ir!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry::LLVM.Functi
     entry
 
 # whether an LLVM function is valid for this back-end
-validate_module(@nospecialize(job::CompilerJob), mod::LLVM.Module) = IRError[]
+validate_ir(@nospecialize(job::CompilerJob), mod::LLVM.Module) = IRError[]
 
 # deprecated
 struct DeprecationMarker end

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -39,6 +39,11 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
         end
     end
 
+    deprecation_marker = process_module!(job, mod)
+    if deprecation_marker != DeprecationMarker()
+        Base.depwarn("GPUCompiler.process_module! is deprecated; implement GPUCompiler.finish_module! instead", :process_module)
+    end
+
     # sanitize function names
     # FIXME: Julia should do this, but apparently fails (see maleadt/LLVM.jl#201)
     for f in functions(mod)
@@ -60,6 +65,11 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
         LLVM.name!(entry, safe_name(job.config.name))
     elseif job.config.kernel
         LLVM.name!(entry, mangle_sig(job.source.specTypes))
+    end
+    deprecation_marker = process_entry!(job, mod, entry)
+    if deprecation_marker != DeprecationMarker()
+        Base.depwarn("GPUCompiler.process_entry! is deprecated; implement GPUCompiler.finish_module! instead", :process_entry)
+        entry = deprecation_marker
     end
     if job.config.entry_abi === :specfunc
         func = compiled[job.source].func

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -7,6 +7,7 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
     else
         entry_fn = compiled[job.source].func
     end
+    entry = functions(mod)[entry_fn]
 
     # clean up incompatibilities
     @timeit_debug to "clean-up" begin
@@ -38,10 +39,6 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
         end
     end
 
-    # target-specific processing
-    process_module!(job, mod)
-    entry = functions(mod)[entry_fn]
-
     # sanitize function names
     # FIXME: Julia should do this, but apparently fails (see maleadt/LLVM.jl#201)
     for f in functions(mod)
@@ -64,7 +61,6 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
     elseif job.config.kernel
         LLVM.name!(entry, mangle_sig(job.source.specTypes))
     end
-    entry = process_entry!(job, mod, entry)
     if job.config.entry_abi === :specfunc
         func = compiled[job.source].func
         specfunc = LLVM.name(entry)
@@ -77,27 +73,43 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
         (; compiled[job.source].ci, func, specfunc)
 
     # minimal required optimization
-    @timeit_debug to "rewrite" @dispose pm=ModulePassManager() begin
-        global current_job
-        current_job = job
-
-        linkage!(entry, LLVM.API.LLVMExternalLinkage)
-
-        # internalize all functions, but keep exported global variables
-        exports = String[LLVM.name(entry)]
-        for gvar in globals(mod)
-            push!(exports, LLVM.name(gvar))
+    @timeit_debug to "rewrite" begin
+        if job.config.kernel && needs_byval(job)
+            # pass all bitstypes by value; by default Julia passes aggregates by reference
+            # (this improves performance, and is mandated by certain back-ends like SPIR-V).
+            args = classify_arguments(job, function_type(entry))
+            for arg in args
+                if arg.cc == BITS_REF
+                    attr = if LLVM.version() >= v"12"
+                        TypeAttribute("byval", eltype(arg.codegen.typ); ctx)
+                    else
+                        EnumAttribute("byval", 0; ctx)
+                    end
+                    push!(parameter_attributes(entry, arg.codegen.i), attr)
+                end
+            end
         end
-        internalize!(pm, exports)
 
-        # inline llvmcall bodies
-        always_inliner!(pm)
+        @dispose pm=ModulePassManager() begin
+            global current_job
+            current_job = job
 
-        can_throw(job) || add!(pm, ModulePass("LowerThrow", lower_throw!))
+            linkage!(entry, LLVM.API.LLVMExternalLinkage)
 
-        add_lowering_passes!(job, pm)
+            # internalize all functions, but keep exported global variables
+            exports = String[LLVM.name(entry)]
+            for gvar in globals(mod)
+                push!(exports, LLVM.name(gvar))
+            end
+            internalize!(pm, exports)
 
-        run!(pm, mod)
+            # inline llvmcall bodies
+            always_inliner!(pm)
+
+            can_throw(job) || add!(pm, ModulePass("LowerThrow", lower_throw!))
+
+            run!(pm, mod)
+        end
     end
 
     return mod, compiled

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -91,9 +91,9 @@ function irgen(@nospecialize(job::CompilerJob); ctx::JuliaContextType)
             for arg in args
                 if arg.cc == BITS_REF
                     attr = if LLVM.version() >= v"12"
-                        TypeAttribute("byval", eltype(arg.codegen.typ); ctx)
+                        TypeAttribute("byval", eltype(arg.codegen.typ); ctx=unwrap_context(ctx))
                     else
-                        EnumAttribute("byval", 0; ctx)
+                        EnumAttribute("byval", 0; ctx=unwrap_context(ctx))
                     end
                     push!(parameter_attributes(entry, arg.codegen.i), attr)
                 end

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -97,7 +97,7 @@ function finish_module!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mo
     return functions(mod)[entry_fn]
 end
 
-function validate_module(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module)
+function validate_ir(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module)
     # Metal never supports double precision
     check_ir_values(mod, LLVM.DoubleType(context(mod)))
 end

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -88,6 +88,12 @@ function finish_module!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mo
     # add metadata to AIR intrinsics LLVM doesn't know about
     annotate_air_intrinsics!(job, mod)
 
+    @dispose pm=ModulePassManager() begin
+        # we emit properties (of the device and ptx isa) as private global constants,
+        # so run the optimizer so that they are inlined before the rest of the optimizer runs.
+        global_optimizer!(pm)
+    end
+
     return functions(mod)[entry_fn]
 end
 

--- a/src/native.jl
+++ b/src/native.jl
@@ -23,12 +23,14 @@ function llvm_machine(target::NativeCompilerTarget)
     return tm
 end
 
-function process_entry!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
+function finish_module!(job::CompilerJob{NativeCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
     ctx = context(mod)
+
     if job.config.target.llvm_always_inline
         push!(function_attributes(entry), EnumAttribute("alwaysinline", 0; ctx))
     end
-    invoke(process_entry!, Tuple{CompilerJob, LLVM.Module, LLVM.Function}, job, mod, entry)
+
+    return entry
 end
 
 ## job

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -65,7 +65,7 @@ function finish_module!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
     return entry
 end
 
-function validate_module(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module)
+function validate_ir(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module)
     errors = IRError[]
 
     # support for half and double depends on the target

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -163,7 +163,7 @@ function check_ir!(job, errors::Vector{IRError}, mod::LLVM.Module)
     end
 
     # custom validation
-    append!(errors, validate_module(job, mod))
+    append!(errors, validate_ir(job, mod))
 
     return errors
 end


### PR DESCRIPTION
The 'extension points' had grown to quite a couple: `process_module`, `process_entry`, `link_libraries`, `finish_module`, `optimize_module`, `finish_ir` and `validate_module`. I propose we remove the first two, as they can just be implemented as part of `finish_module` (I don't think there should be a semantic difference).

Added deprecations to avoid yet another version bump.