### PR TITLE
Align GPUInterpreter and NativeInterpreter constructors.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -185,8 +185,9 @@ isintrinsic(@nospecialize(job::CompilerJob), fn::String) = false
 
 # provide a specific interpreter to use.
 get_interpreter(@nospecialize(job::CompilerJob)) =
-    GPUInterpreter(ci_cache(job), method_table(job), job.world,
-                   inference_params(job), optimization_params(job))
+    GPUInterpreter(job.world; method_table=method_table(job),
+                   code_cache=ci_cache(job), inf_params=inference_params(job),
+                   opt_params=optimization_params(job))
 
 # does this target support throwing Julia exceptions with jl_throw?
 # if not, calls to throw will be replaced with calls to the GPU runtime

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -30,12 +30,7 @@ function check_method(@nospecialize(job::CompilerJob))
 
     # kernels can't return values
     if job.config.kernel
-        cache = ci_cache(job)
-        mt = method_table(job)
-        ip = inference_params(job)
-        op = optimization_params(job)
-        interp = GPUInterpreter(cache, mt, job.world, ip, op)
-        rt = typeinf_type(job.source; interp)
+        rt = typeinf_type(job.source; interp=get_interpreter(job))
 
         if rt != Nothing
             throw(KernelError(job, "kernel returns a value of type `$rt`",


### PR DESCRIPTION
Having an identical copy constructor makes it possible to do `typeof(interp)(interp; opt_params=...)`, for example.