### PR TITLE
PTX: Lower unreachable control flow to avoid bad CFG reconstruction

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -53,7 +53,7 @@ function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @assert precompile(Tuple{typeof(GPUCompiler.assign_args!),Expr,Vector{Any}})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_trap!),LLVM.Module})
-    @assert precompile(Tuple{typeof(GPUCompiler.structurize_unreachable!),LLVM.Function})
+    @assert precompile(Tuple{typeof(GPUCompiler.lower_unreachable!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_gc_frame!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_throw!),LLVM.Module})
     #@assert precompile(Tuple{typeof(GPUCompiler.split_kwargs),Tuple{},Vector{Symbol},Vararg{Vector{Symbol}, N} where N})

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -52,8 +52,8 @@ end
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @assert precompile(Tuple{typeof(GPUCompiler.assign_args!),Expr,Vector{Any}})
-    @assert precompile(Tuple{typeof(GPUCompiler.hide_trap!),LLVM.Module})
-    @assert precompile(Tuple{typeof(GPUCompiler.hide_unreachable!),LLVM.Function})
+    @assert precompile(Tuple{typeof(GPUCompiler.lower_trap!),LLVM.Module})
+    @assert precompile(Tuple{typeof(GPUCompiler.structurize_unreachable!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_gc_frame!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_throw!),LLVM.Module})
     #@assert precompile(Tuple{typeof(GPUCompiler.split_kwargs),Tuple{},Vector{Symbol},Vararg{Vector{Symbol}, N} where N})

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -310,6 +310,11 @@ function structurize_unreachable!(f::LLVM.Function)
     # - try cloning paths with multiple predecessors, as those may originate from
     #   differently-divergent regions
 
+    # remove `noreturn` attributes, to avoid the (minimal) optimization that
+    # happens during `prepare_execution!` undoing our work here
+    attrs = function_attributes(f)
+    delete!(attrs, EnumAttribute("noreturn", 0; ctx))
+
     # find unreachable blocks
     unreachable_blocks = Set{BasicBlock}()
     for block in blocks(f)

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -17,6 +17,10 @@ Base.@kwdef struct PTXCompilerTarget <: AbstractCompilerTarget
     maxthreads::Union{Nothing,Int,NTuple{<:Any,Int}} = nothing
     blocks_per_sm::Union{Nothing,Int} = nothing
     maxregs::Union{Nothing,Int} = nothing
+
+    # deprecated; remove with next major version
+    exitable::Union{Nothing,Bool} = nothing
+    unreachable::Union{Nothing,Bool} = nothing
 end
 
 function Base.hash(target::PTXCompilerTarget, h::UInt)


### PR DESCRIPTION
During back-end compilation, `ptxas` inserts instructions to manage the harware's reconvergence stack (SSY and SYNC). In order to do so, it needs to identify
divergent regions:

```
entry:
  // start of divergent region
  @%p0 bra cont;
  ...
  bra.uni cont;
cont:
  // end of divergent region
  bar.sync 0;
```

Meanwhile, LLVM's branch-folder and block-placement MIR passes will try to optimize the block layout, e.g., by placing unlikely blocks at the end of the function:

```
entry:
  // start of divergent region
  @%p0 bra cont;
  @%p1 bra unlikely;
  bra.uni cont;
cont:
  // end of divergent region
  bar.sync 0;
unlikely:
  bra.uni cont;
```

That is not a problem as long as the unlikely block continunes back into the divergent region. Crucially, this is not the case with unreachable control flow:

```
  entry:
  // start of divergent region
  @%p0 bra cont;
  @%p1 bra throw;
  bra.uni cont;
cont:
  bar.sync 0;
throw:
  call throw_and_trap();
  // unreachable
exit:
  // end of divergent region
  ret;
```

Dynamically, this is fine, because the called function does not return. However, `ptxas` does not know that and adds a successor edge to the `exit` block, widening the divergence range. In this example, that's not allowed, as `bar.sync` cannot be executed divergently on Pascal hardware or earlier.

To avoid these fall-through successors that change the control flow, we replace `unreachable` instructions with a branch to the current block (or in case of entry blocks, with a return from the function). That appears sufficient to allow `ptxas` to correctly identify the divergent region.

---

For anybody who would want to review: Ignore the old code when looking at the diff; it's entirely unrelated to the new pass.

Potential fix to https://github.com/JuliaGPU/CUDA.jl/issues/1746; alternative to https://github.com/JuliaGPU/CUDA.jl/pull/1942.