### PR TITLE
Define compile_cache outside __init__()

### DIFF
--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -45,6 +45,10 @@ include("reflection.jl")
 include("precompile.jl")
 _precompile_()
 
+
+
+compile_cache = "" # defined in __init__()
+
 function __init__()
     STDERR_HAS_COLOR[] = get(stderr, :color, false)
 


### PR DESCRIPTION
Potential fix to #470.