### PR TITLE
Version the compilecache.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.21.2"
+version = "0.21.3"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -52,7 +52,16 @@ compile_cache = "" # defined in __init__()
 function __init__()
     STDERR_HAS_COLOR[] = get(stderr, :color, false)
 
-    global compile_cache = @get_scratch!("compiled")
+    dir = @get_scratch!("compiled")
+    ## add the Julia version
+    dir = joinpath(dir, "v$(VERSION.major).$(VERSION.minor)")
+    if VERSION > v"1.9"
+        ## also add the package version
+        pkgver = Base.pkgversion(GPUCompiler)
+        dir = joinpath(dir, "v$(pkgver.major).$(pkgver.minor)")
+    end
+    mkpath(dir)
+    global compile_cache = dir
 end
 
 end # module


### PR DESCRIPTION
While working on GemmKernels.jl, I noticed that the 1.6 tests occasionally failed with `unknown call to julia.get_pgcstack` or LLVM bitcode signature mismatches. Both seem to indicate that we're loading a runtime from a more recent version of Julia. This is possible because CI doesn't wipe scratchspaces, and we don't automatically invalidate the GPUCompiler compilecache (and we shouldn't have to). To prevent that, add the Julia and package version to the compilecache path.