### PR TITLE
Use NewPM wherever possible

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "27e7a553e90a68d1f177019877f2e4b06a23c81a"
+project_hash = "7fba634d9208dc361f8caa397a5e8d2621e56bcf"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -48,15 +48,15 @@ version = "1.5.0"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "8695a49bfe05a2dc0feeefd06b4ca6361a018729"
+git-tree-sha1 = "f7e39b1ecd9531475bbf3b25363027ba14c3e563"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "6.1.0"
+version = "6.2.0"
 
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "c35203c1e1002747da220ffc3c0762ce7754b08c"
+git-tree-sha1 = "7ca6850ae880cc99b59b88517545f91a52020afa"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.23+0"
+version = "0.0.25+0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
-LLVM = "6"
+LLVM = "6.2"
 Scratch = "1"
 TimerOutputs = "0.5"
 julia = "1.8"

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -14,6 +14,8 @@ using Scratch: @get_scratch!
 const CC = Core.Compiler
 using Core: MethodInstance, CodeInstance, CodeInfo
 
+const use_newpm = isdefined(LLVM, :PassBuilder)
+
 include("utils.jl")
 
 # compiler interface and implementations

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -14,7 +14,7 @@ using Scratch: @get_scratch!
 const CC = Core.Compiler
 using Core: MethodInstance, CodeInstance, CodeInfo
 
-const use_newpm = isdefined(LLVM, :PassBuilder)
+const use_newpm = LLVM.has_newpm()
 
 include("utils.jl")
 

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -390,7 +390,7 @@ const __llvm_initialized = Ref(false)
         if cleanup
             @timeit_debug to "clean-up" begin
                 if use_newpm
-                    @dispose pb=PassBuilder() mpm=ModulePassManager(pb) begin
+                    @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
                         add!(mpm, RecomputeGlobalsAAPass())
                         add!(mpm, GlobalOptPass())
                         add!(mpm, GlobalDCEPass())

--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -76,7 +76,6 @@ function optimize_module!(job::CompilerJob{GCNCompilerTarget}, mod::LLVM.Module)
         datalayout!(mod, julia_datalayout(job.config.target))
 
         tm = llvm_machine(job.config.target)
-        # doesn't need newpm because only applies to v<1.9
         @dispose pm=ModulePassManager() begin
             add_library_info!(pm, triple(mod))
             add_transform_info!(pm, tm)

--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -37,26 +37,7 @@ isintrinsic(::CompilerJob{GCNCompilerTarget}, fn::String) = in(fn, gcn_intrinsic
 
 function finish_module!(@nospecialize(job::CompilerJob{GCNCompilerTarget}),
                         mod::LLVM.Module, entry::LLVM.Function)
-    if use_newpm
-        @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
-            add!(mpm) do m, mam
-                if lower_throw_extra!(m)
-                    return no_analyses_preserved()
-                else
-                    return all_analyses_preserved()
-                end
-            end
-            analysis_managers() do lam, fam, cam, mam
-                register!(pb, lam, fam, cam, mam)
-                dispose(run!(mpm, mod, mam))
-            end
-        end
-    else
-        @dispose pm=ModulePassManager() begin
-            add!(pm, ModulePass("LowerThrowExtra", lower_throw_extra!))
-            run!(pm, mod)
-        end
-    end
+    lower_throw_extra!(mod)
 
     if job.config.kernel
         # calling convention

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -96,6 +96,7 @@ function irgen(@nospecialize(job::CompilerJob))
             end
         end
 
+        # TODO No good api to expose internalize via newpm yet
         @dispose pm=ModulePassManager() begin
             global current_job
             current_job = job

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -96,7 +96,7 @@ function irgen(@nospecialize(job::CompilerJob))
             end
         end
 
-        # TODO No good api to expose internalize via newpm yet
+        # TODO: there's no good API to use internalize with the new pass manager yet
         @dispose pm=ModulePassManager() begin
             global current_job
             current_job = job

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -5,6 +5,7 @@
 function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     global current_job
     current_job = job
+
     if use_newpm
         @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
             add!(mpm, RecomputeGlobalsAAPass())
@@ -13,11 +14,10 @@ function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
             add!(legacy2newpm(resolve_cpu_references!), mpm)
             add!(mpm, GlobalDCEPass())
             add!(mpm, StripDeadPrototypesPass())
-            run!(mpm, mod, nothing, [BasicAA(), ScopedNoAliasAA(), TypeBasedAA(), GlobalsAA()])
+            run!(mpm, mod)
         end
     else
         @dispose pm=ModulePassManager() begin
-
             global_optimizer!(pm)
 
             add!(pm, ModulePass("ResolveCPUReferences", resolve_cpu_references!))

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -10,13 +10,7 @@ function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
             add!(mpm, RecomputeGlobalsAAPass())
             add!(mpm, GlobalOptPass())
             resolve_cpu_references!(mod)
-            add!(mpm) do m, mam
-                if resolve_cpu_references!(m)
-                    no_analyses_preserved()
-                else
-                    all_analyses_preserved()
-                end
-            end
+            add!(legacy2newpm(resolve_cpu_references!), mpm)
             add!(mpm, GlobalDCEPass())
             add!(mpm, StripDeadPrototypesPass())
             run!(mpm, mod, nothing, [BasicAA(), ScopedNoAliasAA(), TypeBasedAA(), GlobalsAA()])

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -608,8 +608,6 @@ function optimize_legacypm!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     return
 end
 
-const use_newpm = isdefined(LLVM, :PassBuilder)
-
 function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     if use_newpm
         optimize_newpm!(job, mod)

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -54,7 +54,9 @@ end
 
 function buildEarlySimplificationPipeline(mpm, @nospecialize(job::CompilerJob), opt_level)
     if should_verify()
-        add!(mpm, GCInvariantVerifierPass())
+        add!(mpm, NewPMFunctionPassManager) do fpm
+            add!(fpm, GCInvariantVerifierPass())
+        end
         add!(mpm, VerifierPass())
     end
     add!(mpm, ForceFunctionAttrsPass())

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -132,14 +132,7 @@ function finish_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
     end
 
     if use_newpm
-        @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
-            add!(mpm, GlobalOptPass())
-
-            analysis_managers() do lam, fam, cam, mam
-                register!(pb, lam, fam, cam, mam)
-                dispose(run!(mpm, mod, mam))
-            end
-        end
+        run!(mpm, mod, nothing, [BasicAA(), ScopedNoAliasAA(), TypeBasedAA()])
     else
         @dispose pm=ModulePassManager() begin
             # we emit properties (of the device and ptx isa) as private global constants,

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -65,7 +65,7 @@ function emit_function!(mod, config::CompilerConfig, f, method)
 
     # recent Julia versions include prototypes for all runtime functions, even if unused
     if use_newpm
-        run!(StripDeadPrototypesPass(), new_mod, nothing, [BasicAA(), ScopedNoAliasAA(), TypeBasedAA()])
+        run!(StripDeadPrototypesPass(), new_mod)
     else
         @dispose pm=ModulePassManager() begin
             strip_dead_prototypes!(pm)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -65,14 +65,7 @@ function emit_function!(mod, config::CompilerConfig, f, method)
 
     # recent Julia versions include prototypes for all runtime functions, even if unused
     if use_newpm
-        @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
-            add!(mpm, StripDeadPrototypesPass())
-
-            analysis_managers() do lam, fam, cam, mam
-                register!(pb, lam, fam, cam, mam)
-                run!(mpm, new_mod, mam)
-            end
-        end
+        run!(StripDeadPrototypesPass(), new_mod, nothing, [BasicAA(), ScopedNoAliasAA(), TypeBasedAA()])
     else
         @dispose pm=ModulePassManager() begin
             strip_dead_prototypes!(pm)

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -82,16 +82,45 @@ end
     # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...
     strip_debuginfo!(mod)
 
-    @dispose pm=ModulePassManager() begin
-        # SPIR-V does not support trap, and has no mechanism to abort compute kernels
-        # (OpKill is only available in fragment execution mode)
-        add!(pm, ModulePass("RemoveTrap", rm_trap!))
+    if use_newpm
+        @dispose pb=PassBuilder() mpm=NewPMModulePassManager() begin
+            add!(mpm) do m, mam
+                # SPIR-V does not support trap, and has no mechanism to abort compute kernels
+                # (OpKill is only available in fragment execution mode)
+                if rm_trap!(m)
+                    return no_analyses_preserved()
+                else
+                    return all_analyses_preserved()
+                end
+            end
 
-        # the LLVM to SPIR-V translator does not support the freeze instruction
-        # (SPIRV-LLVM-Translator#1140)
-        add!(pm, ModulePass("RemoveFreeze", rm_freeze!))
+            # the LLVM to SPIR-V translator does not support the freeze instruction
+            # (SPIRV-LLVM-Translator#1140)
+            add!(mpm) do m, mam
+                if rm_freeze!(m)
+                    return no_analyses_preserved()
+                else
+                    return all_analyses_preserved()
+                end
+            end
 
-        run!(pm, mod)
+            analysis_managers() do lam, fam, cam, mam
+                register!(pb, lam, fam, cam, mam)
+                run!(mpm, mod, mam)
+            end
+        end
+    else
+        @dispose pm=ModulePassManager() begin
+            # SPIR-V does not support trap, and has no mechanism to abort compute kernels
+            # (OpKill is only available in fragment execution mode)
+            add!(pm, ModulePass("RemoveTrap", rm_trap!))
+
+            # the LLVM to SPIR-V translator does not support the freeze instruction
+            # (SPIRV-LLVM-Translator#1140)
+            add!(pm, ModulePass("RemoveFreeze", rm_freeze!))
+
+            run!(pm, mod)
+        end
     end
 
 


### PR DESCRIPTION
Anywhere we fail to convert to NewPM/it's very tedious points to a hole in the NewPM API, so this serves to flush out remaining API issues.

Known issues:
- [x] running a single NewPM pass requires a lot of boilerplate
- [x] specifying alias analysis stack/target analyses is very tedious for short pipelines
- [x] adding PassInstrumentationCallbacks to every run of a pass manager is also tedious