### PR TITLE
Add dwarf_version function so targets can choose

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -45,6 +45,7 @@ end
 
 have_fma(@nospecialize(target::AbstractCompilerTarget), T::Type) = false
 
+dwarf_version(target::AbstractCompilerTarget) = Int32(4) # It seems every target supports v4 bar cuda
 
 ## params
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -608,7 +608,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
                     datalayout!(mod, julia_datalayout(job.config.target))
                 end
                 flags(mod)["Dwarf Version", LLVM.API.LLVMModuleFlagBehaviorWarning] =
-                    Metadata(ConstantInt(Int32(4)))
+                    Metadata(ConstantInt(dwarf_version(job.config.target)))
                 flags(mod)["Debug Info Version", LLVM.API.LLVMModuleFlagBehaviorWarning] =
                     Metadata(ConstantInt(DEBUG_METADATA_VERSION()))
             end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -70,6 +70,7 @@ llvm_datalayout(target::PTXCompilerTarget) =
 
 have_fma(@nospecialize(target::PTXCompilerTarget), T::Type) = true
 
+dwarf_version(target::PTXCompilerTarget) = Int32(2) # Cuda only supports dwarfv2
 
 ## job
 


### PR DESCRIPTION
It defaults to 4 like before but PTX sets it to 2 because that's what cuda supports. Following https://github.com/search?q=repo%3Allvm%2Fllvm-project%20GetDefaultDwarfVersion()&type=code