### PR TITLE
Add a function to reset the compile cache

### DIFF
--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -78,5 +78,7 @@ function reset_compile_cache()
 
     return
 end
+# backwards compatibility
+const reset_runtime = reset_compile_cache
 
 end # module

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -51,7 +51,10 @@ compile_cache = "" # defined in __init__()
 
 function __init__()
     STDERR_HAS_COLOR[] = get(stderr, :color, false)
+    create_compile_cache()
+end
 
+function create_compile_cache()
     dir = @get_scratch!("compiled")
     ## add the Julia version
     dir = joinpath(dir, "v$(VERSION.major).$(VERSION.minor)")
@@ -62,6 +65,12 @@ function __init__()
     end
     mkpath(dir)
     global compile_cache = dir
+end
+
+function reset_compile_cache()
+    dir = @get_scratch!("compiled")
+    rm(dir; force=true, recursive=true)
+    create_compile_cache()
 end
 
 end # module

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -67,10 +67,16 @@ function create_compile_cache()
     global compile_cache = dir
 end
 
+# remove the existing cache
+# NOTE: call this function from global scope, so any change triggers recompilation.
 function reset_compile_cache()
     dir = @get_scratch!("compiled")
-    rm(dir; force=true, recursive=true)
-    create_compile_cache()
+    lock(runtime_lock) do
+        rm(dir; force=true, recursive=true)
+        create_compile_cache()
+    end
+
+    return
 end
 
 end # module

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -144,13 +144,3 @@ const runtime_lock = ReentrantLock()
         return lib
     end
 end
-
-# remove the existing cache
-# NOTE: call this function from global scope, so any change triggers recompilation.
-function reset_runtime()
-    lock(runtime_lock) do
-        rm(compile_cache; recursive=true, force=true)
-    end
-
-    return
-end


### PR DESCRIPTION
It can happen sometimes that a bad LLVM module makes it into the compile cache, which is really annoying to debug due to the very unhelpful LLVM error this causes (the `try`/`catch` [here](https://github.com/JuliaGPU/GPUCompiler.jl/blob/d9b8f4747cf789139fb2586ee67ced93967a8237/src/rtlib.jl#L125-L134) never fires, as LLVM seems to kill the process). The easiest fix is just to get a clean slate, by deleting the compile cache in the scratch space. This PR adds a function to do just that - it's already been useful in debugging a bad AVR runtime cache :)