### PR TITLE
Don't disallow Bottom returns.

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -32,11 +32,9 @@ function check_method(@nospecialize(job::CompilerJob))
     if job.config.kernel
         rt = typeinf_type(job.source; interp=get_interpreter(job))
 
-        if rt != Nothing
+        if rt != Nothing && rt != Union{}
             throw(KernelError(job, "kernel returns a value of type `$rt`",
-                """Make sure your kernel function ends in `return`, `return nothing` or `nothing`.
-                   If the returned value is of type `Union{}`, your Julia code probably throws an exception.
-                   Inspect the code with `@device_code_warntype` for more details."""))
+                """Make sure your kernel function ends in `return`, `return nothing` or `nothing`."""))
         end
     end
 


### PR DESCRIPTION
Trial balloon. Currently, we eagerly disallow returns, even of `Union{}` (which indicates an error):

```
julia> @cuda threads=(10, 10) kernel(array_dev)
ERROR: GPU compilation of MethodInstance for kernel(::CuDeviceVector{Int64, 1, Int32}) failed
KernelError: kernel returns a value of type `Union{}`

Make sure your kernel function ends in `return`, `return nothing` or `nothing`.
If the returned value is of type `Union{}`, your Julia code probably throws an exception.
Inspect the code with `@device_code_warntype` for more details.

Stacktrace:
  [1] check_method(job::GPUCompiler.CompilerJob)
    @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/validation.jl:36
  [2] macro expansion
    @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/driver.jl:122 [inlined]
```

I'm not sure that's very user-friendly however, as it requires the user to use Cthulhu or similar to figure out _where_ the error was introduced. If we just allow the error, it's likely that we'll be able to report something better later on:

```
julia> @cuda threads=(10, 10) kernel(array_dev)
ERROR: InvalidIRError: compiling MethodInstance for kernel(::CuDeviceVector{Int64, 1, Int32}) resulted in invalid LLVM IR
...
Reason: unsupported use of an undefined name (use of 'i32')
Stacktrace:
 [1] kernel
   @ ./REPL[3]:2
```

cc @vchuravy 