### PR TITLE
Verify IR after our own validation.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -433,16 +433,16 @@ const __llvm_initialized = Ref(false)
                 empty!(f)
             end
         end
-
-        if should_verify()
-            @timeit_debug to "verification" verify(ir)
-        end
     end
 
     if validate
         @timeit_debug to "Validation" begin
             check_ir(job, ir)
         end
+    end
+
+    if should_verify()
+        @timeit_debug to "verification" verify(ir)
     end
 
     return ir, (; entry, compiled)


### PR DESCRIPTION
Another hotfix for https://github.com/JuliaGPU/GPUCompiler.jl/pull/510: Turns out the LLVM verifier can be unhappy about non-void kernels:

```
julia> invalid_kernel() = throw()
       @oneapi invalid_kernel()
ERROR: LLVM error: Calling convention requires void return type
{}* ()* @_Z14invalid_kernel

Stacktrace:
  [1] verify(mod::LLVM.Module)
    @ LLVM ~/Julia/pkg/LLVM/src/analysis.jl:10
```

... so make sure we validated the IR ourselves first.

It's not perfect, as our reflection macros invoke the driver with `validate=false`:

```
julia> @device_code_llvm @oneapi invalid_kernel()
; GPUCompiler.CompilerJob{GPUCompiler.SPIRVCompilerTarget, oneAPI.oneAPICompilerParams}(MethodInstance for invalid_kernel(), CompilerConfig for GPUCompiler.SPIRVCompilerTarget, 0x0000000000007f13)
ERROR: LLVM error: Calling convention requires void return type
{}* ()* @_Z14invalid_kernel
```