### PR TITLE
Metal: Support vector-valued intrinsics.

### DIFF
--- a/test/metal_tests.jl
+++ b/test/metal_tests.jl
@@ -77,6 +77,14 @@ end
     @test !occursin(r"call i32 @julia.air.thread_position_in_threadgroup.i32", ir)
 end
 
+@testset "vector intrinsics" begin
+    foo(x, y) = ccall("llvm.smax.v2i64", llvmcall, NTuple{2, VecElement{Int64}},
+                      (NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}}), x, y)
+
+    ir = sprint(io->Metal.code_llvm(io, foo, (NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}})))
+    @test occursin("air.max.v2s64", ir)
+end
+
 end
 
 end


### PR DESCRIPTION
Julia emits these on 1.10 when doing CartesianIndices operations:

```
julia> fill!(view(MtlArray{Float32}(undef, 2, 2), 2:2, 2:2), 0)
ERROR: Unsupported intrinsic type: LLVM.VectorType(<2 x i64>)
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] lower_llvm_intrinsics!(job::GPUCompiler.CompilerJob, fun::LLVM.Function)
    @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/metal.jl:893
  [3] finish_ir!(job::GPUCompiler.CompilerJob{GPUCompiler.MetalCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
    @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/metal.jl:129
```