### PR TITLE
Disable the vectorizer pipeline.

### DIFF
--- a/src/optim.jl
+++ b/src/optim.jl
@@ -38,7 +38,9 @@ function buildNewPMPipeline!(mpm, @nospecialize(job::CompilerJob), opt_level=2)
     add!(mpm, NewPMFunctionPassManager) do fpm
         buildLoopOptimizerPipeline(fpm, job, opt_level)
         buildScalarOptimizerPipeline(fpm, job, opt_level)
-        if opt_level >= 2
+        if false && opt_level >= 2
+            # XXX: we disable vectorization, as this generally isn't useful for GPU targets
+            #      and actually causes issues with some back-end compilers (like Metal).
             buildVectorPipeline(fpm, job, opt_level)
         end
         add!(fpm, WarnMissedTransformationsPass())


### PR DESCRIPTION
Although we may want some additional configurability here, let's quickly disable it now as our Legacy PM pipeline doesn't have vectorization passes, because we specifically disabled those. This results in compilation failures with Metal, but I'm sure not all GPU back-ends support arbitrary vector operations (or know how to legalize them).