### PR TITLE
Metal: Emit name metadata.

### DIFF
--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -18,6 +18,9 @@ function irgen(@nospecialize(job::CompilerJob))
                         EnumAttribute("sspstrong", 0))
             end
 
+            delete!(function_attributes(llvmf),
+                    StringAttribute("probe-stack", "inline-asm"))
+
             if Sys.iswindows()
                 personality!(llvmf, nothing)
             end

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -699,6 +699,12 @@ function add_argument_metadata!(@nospecialize(job::CompilerJob), mod::LLVM.Modul
         push!(md, MDString("air.arg_type_align_size"))
         push!(md, Metadata(ConstantInt(Int32(Base.datatype_alignment(arg_type)))))
 
+        push!(md, MDString("air.arg_type_name"))
+        push!(md, MDString(repr(arg.typ)))
+
+        push!(md, MDString("air.arg_name"))
+        push!(md, MDString(String(arg.name)))
+
         push!(arg_infos, MDNode(md))
 
         i += 1


### PR DESCRIPTION
This seems required now on macOS Sonoma, and the compiler crashes without it.

Fixes https://github.com/JuliaGPU/Metal.jl/issues/201