### PR TITLE
Add env var to control use of newpm.

### DIFF
--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -14,7 +14,7 @@ using Scratch: @get_scratch!
 const CC = Core.Compiler
 using Core: MethodInstance, CodeInstance, CodeInfo
 
-const use_newpm = LLVM.has_newpm()
+const use_newpm = Ref(LLVM.has_newpm())
 
 include("utils.jl")
 include("mangling.jl")
@@ -65,6 +65,10 @@ function __init__()
     end
     mkpath(dir)
     global compile_cache = dir
+
+    if use_newpm[]
+        use_newpm[] = parse(Bool, get(ENV, "JULIA_GPUCOMPILER_NEWPM", "true"))
+    end
 end
 
 end # module

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -342,7 +342,7 @@ const __llvm_initialized = Ref(false)
                 # which also need to happen _after_ regular optimization.
                 # XXX: make these part of the optimizer pipeline?
                 if has_deferred_jobs
-                    if use_newpm
+                    if use_newpm[]
                         @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
                             add!(mpm, NewPMFunctionPassManager) do fpm
                                 add!(fpm, InstCombinePass())
@@ -381,7 +381,7 @@ const __llvm_initialized = Ref(false)
 
         if cleanup
             @timeit_debug to "clean-up" begin
-                if use_newpm
+                if use_newpm[]
                     @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
                         add!(mpm, RecomputeGlobalsAAPass())
                         add!(mpm, GlobalOptPass())

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -6,7 +6,7 @@ function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     global current_job
     current_job = job
 
-    if use_newpm
+    if use_newpm[]
         @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
             add!(mpm, RecomputeGlobalsAAPass())
             add!(mpm, GlobalOptPass())

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -89,7 +89,7 @@ function finish_module!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mo
 
     # we emit properties (of the air and metal version) as private global constants,
     # so run the optimizer so that they are inlined before the rest of the optimizer runs.
-    if use_newpm
+    if use_newpm[]
         @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
             add!(mpm, RecomputeGlobalsAAPass())
             add!(mpm, GlobalOptPass())
@@ -130,7 +130,7 @@ function finish_ir!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::L
     end
     if changed
         # lowering may have introduced additional functions marked `alwaysinline`
-        if use_newpm
+        if use_newpm[]
             @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
                 add!(mpm, AlwaysInlinerPass())
                 add!(mpm, NewPMFunctionPassManager) do fpm
@@ -178,7 +178,7 @@ end
         end
 
         if any_noreturn
-            if use_newpm
+            if use_newpm[]
                 @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
                     add!(mpm, AlwaysInlinerPass())
                     add!(mpm, NewPMFunctionPassManager) do fpm
@@ -325,7 +325,7 @@ function add_address_spaces!(@nospecialize(job::CompilerJob), mod::LLVM.Module, 
     LLVM.name!(new_f, fn)
 
     # clean-up after this pass (which runs after optimization)
-    if use_newpm
+    if use_newpm[]
        @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
             add!(mpm, NewPMFunctionPassManager) do fpm
                 add!(fpm, SimplifyCFGPass())

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -1,7 +1,7 @@
 # LLVM IR optimization
 
 function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
-    if use_newpm
+    if use_newpm[]
         optimize_newpm!(job, mod)
     else
         optimize_legacypm!(job, mod)
@@ -49,7 +49,7 @@ function buildNewPMPipeline!(mpm, @nospecialize(job::CompilerJob), opt_level=2)
     buildCleanupPipeline(mpm, job, opt_level)
 end
 
-if use_newpm
+if LLVM.has_newpm()
     const BasicSimplifyCFGOptions = SimplifyCFGPassOptions(true, true, true, true, false, false, 1)
     const AggressiveSimplifyCFGOptions = SimplifyCFGPassOptions(true, true, true, true, true, false, 1)
 end

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -134,7 +134,7 @@ function finish_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
 
     # we emit properties (of the device and ptx isa) as private global constants,
     # so run the optimizer so that they are inlined before the rest of the optimizer runs.
-    if use_newpm
+    if use_newpm[]
         @dispose pb=PassBuilder() mpm=NewPMModulePassManager(pb) begin
             add!(mpm, RecomputeGlobalsAAPass())
             add!(mpm, GlobalOptPass())

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -64,7 +64,7 @@ function emit_function!(mod, config::CompilerConfig, f, method)
     end
 
     # recent Julia versions include prototypes for all runtime functions, even if unused
-    if use_newpm
+    if use_newpm[]
         run!(StripDeadPrototypesPass(), new_mod)
     else
         @dispose pm=ModulePassManager() begin


### PR DESCRIPTION
Not intended to get merged; but as a test to see of newpm causes the regressions in https://github.com/JuliaGPU/GemmKernels.jl/pull/155.