### PR TITLE
After conversion to LLVM we should be able to delete the inferred source of the kernel.

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -114,7 +114,7 @@ end
     obj = nothing
 
     # fast path: find an applicable CodeInstance and see if we have compiled it before
-    ci = ci_cache_lookup(ci_cache(job), src, world, world)::Union{Nothing,CodeInstance}
+    ci = ci_cache_lookup(ci_cache(job), src, world, world; allow_uninferred=true)::Union{Nothing,CodeInstance}
     if ci !== nothing && haskey(cache, ci)
         obj = cache[ci]
     end
@@ -130,7 +130,7 @@ end
         end
 
         obj = linker(job, asm)
-        ci = ci_cache_lookup(ci_cache(job), src, world, world)::CodeInstance
+        ci = ci_cache_lookup(ci_cache(job), src, world, world; allow_uninferred=true)::CodeInstance
         cache[ci] = obj
     end
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -413,7 +413,7 @@ end
 function ci_cache_lookup(cache, mi, min_world, max_world; allow_uninferred=false)
     wvc = WorldView(cache, min_world, max_world)
     ci = CC.get(wvc, mi, nothing)
-    if ci !== nothing && (allow_uninferred || ci.inferred === nothing)
+    if ci !== nothing && (!allow_uninferred && ci.inferred === nothing)
         # if for some reason we did end up with a codeinfo without inferred source, e.g.,
         # because of calling `Base.return_types` which only sets rettyp, pretend we didn't
         # run inference so that we re-infer now and not during codegen (which is disallowed)

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -376,12 +376,6 @@ function CC.getindex(wvc::WorldView{CodeCache}, mi::MethodInstance)
 end
 
 function CC.setindex!(wvc::WorldView{CodeCache}, ci::CodeInstance, mi::MethodInstance)
-    src = if ci.inferred isa Vector{UInt8}
-        ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any),
-                mi.def, C_NULL, ci.inferred)
-    else
-        ci.inferred
-    end
     CC.setindex!(wvc.cache, ci, mi)
 end
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -615,7 +615,8 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
 
     if job.config.kernel
         # Don't cache the top-level inference result.
-        compiled[job.source].ci.inferred = nothing
+        ci = compiled[job.source].ci
+        Base.@atomic :release ci.inferred = nothing
     end
 
     return llvm_mod, compiled

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -616,7 +616,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
     if job.config.kernel
         # Don't cache the top-level inference result.
         ci = compiled[job.source].ci
-@static VERSION < v"1.9.0"
+@static if VERSION < v"1.9.0"
         ci.inferred = nothing
 else
         Base.@atomic :release ci.inferred = nothing

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -616,7 +616,11 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
     if job.config.kernel
         # Don't cache the top-level inference result.
         ci = compiled[job.source].ci
+@static VERSION < v"1.9.0"
+        ci.inferred = nothing
+else
         Base.@atomic :release ci.inferred = nothing
+end
     end
 
     return llvm_mod, compiled

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -613,5 +613,10 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
         end
     end
 
+    if job.config.kernel
+        # Don't cache the top-level inference result.
+        compiled[job.source].ci.inferred = nothing
+    end
+
     return llvm_mod, compiled
 end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -410,10 +410,10 @@ function ci_cache_populate(interp, cache, mi, min_world, max_world)
     return ci
 end
 
-function ci_cache_lookup(cache, mi, min_world, max_world)
+function ci_cache_lookup(cache, mi, min_world, max_world; allow_uninferred=false)
     wvc = WorldView(cache, min_world, max_world)
     ci = CC.get(wvc, mi, nothing)
-    if ci !== nothing && ci.inferred === nothing
+    if ci !== nothing && (allow_uninferred || ci.inferred === nothing)
         # if for some reason we did end up with a codeinfo without inferred source, e.g.,
         # because of calling `Base.return_types` which only sets rettyp, pretend we didn't
         # run inference so that we re-infer now and not during codegen (which is disallowed)


### PR DESCRIPTION
@simonbyrne has shown me a heap-snapshot were the inferred source took up >>1GB of ram.
