### PR TITLE
Only warn about missed transformations when debug output is enabled.

### DIFF
--- a/src/optim.jl
+++ b/src/optim.jl
@@ -43,7 +43,9 @@ function buildNewPMPipeline!(mpm, @nospecialize(job::CompilerJob), opt_level=2)
             #      and actually causes issues with some back-end compilers (like Metal).
             buildVectorPipeline(fpm, job, opt_level)
         end
-        add!(fpm, WarnMissedTransformationsPass())
+        if isdebug(:optim)
+            add!(fpm, WarnMissedTransformationsPass())
+        end
     end
     buildIntrinsicLoweringPipeline(mpm, job, opt_level)
     buildCleanupPipeline(mpm, job, opt_level)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -17,6 +17,9 @@ should_verify() = ccall(:jl_is_debugbuild, Cint, ()) == 1 ||
                   Base.JLOptions().debug_level >= 2 ||
                   parse(Bool, get(ENV, "CI", "false"))
 
+isdebug(group, mod=GPUCompiler) =
+    Base.CoreLogging.current_logger_for_env(Base.CoreLogging.Debug, group, mod) !== nothing
+
 
 ## lazy module loading
 


### PR DESCRIPTION
```julia
julia> function main()
           function kernel(a)
               @loopinfo unroll for i = eachindex(a)
                   a[i] = 0
               end
               return
           end

           arr = CUDA.zeros(10)
           @cuda kernel(arr)
       end
main (generic function with 1 method)

julia> empty!(CUDA.compiler_cache(context())); main()
CUDA.HostKernel for kernel(CuDeviceVector{Float32, 1})

julia> ENV["JULIA_DEBUG"] = "GPUCompiler"
"GPUCompiler"

julia> empty!(CUDA.compiler_cache(context())); main()
warning: abstractarray.jl:699:0: loop not unrolled: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering
CUDA.HostKernel for kernel(CuDeviceVector{Float32, 1})
```

cc @pchintalapudi 