### PR TITLE
PTX: Improve handling of trap

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.24.5"
+version = "0.25.0"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -52,7 +52,6 @@ end
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @assert precompile(Tuple{typeof(GPUCompiler.assign_args!),Expr,Vector{Any}})
-    @assert precompile(Tuple{typeof(GPUCompiler.lower_trap!),LLVM.Module})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_unreachable!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_gc_frame!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_throw!),LLVM.Module})


### PR DESCRIPTION
Reviewing https://github.com/llvm/llvm-project/pull/67478, I realized that we shouldn't be throwing away `trap` as eagerly as we are. Instead, we should just actively call `exit` when we expect recovery, i.e., when we're handling an exception. This will require a change in CUDA.jl.