### PR TITLE
Add generic interface to change codegen params

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -185,6 +185,10 @@ get_interpreter(@nospecialize(job::CompilerJob)) =
 # if not, calls to throw will be replaced with calls to the GPU runtime
 can_throw(@nospecialize(job::CompilerJob)) = uses_julia_runtime(job)
 
+function codegen_params(@nospecialize(job::CompilerJob))
+    return (;)
+end
+
 # does this target support loading from Julia safepoints?
 # if not, safepoints at function entry will not be emitted
 can_safepoint(@nospecialize(job::CompilerJob)) = uses_julia_runtime(job)

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -492,6 +492,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
     @static if VERSION >= v"1.10.0-DEV.1499"
         cgparams = merge(cgparams, (;gcstack_arg = false))
     end
+    cgparams = merge(cgparams, codegen_params(job))
     params = Base.CodegenParams(; cgparams...)
 
     # generate IR

--- a/test/native_tests.jl
+++ b/test/native_tests.jl
@@ -419,6 +419,18 @@ end
     end
 end
 
+@static if VERSION > v"1.11.0-DEV.398"
+    # TODO: teach the verifier to accept ccalls without the plt
+    @testset "invalid LLVM IR (ccall)" begin
+        foobar(p) = (unsafe_store!(p, ccall(:time, Cint, ())); nothing)
+
+        @test_throws_message(InvalidIRError,
+                            Native.code_execution(foobar, Tuple{Ptr{Int}}), use_jlplt=true) do msg
+            occursin("Reason: unsupported call to the Julia runtime", msg)
+        end
+    end
+end
+
 @testset "delayed bindings" begin
     kernel() = (undefined; return)
 


### PR DESCRIPTION
Adding new things every time a codegen_param gets added is problably getting old quite quickly, so add a generic interface for it.