### PR TITLE
Use the new jl_method_lookup_by_tt API on 1.11.

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -61,15 +61,16 @@ methodinstance
 # Julia's cached method lookup to simply look up method instances at run time.
 if VERSION >= v"1.11.0-DEV.1552"
 
+# XXX: version of Base.method_instance that uses a function type
 function methodinstance(ft, tt, world=tls_world_age())
-    # XXX: Base.method_instance uses f not ft...
     sig = signature_type_by_tt(ft, tt)
+
     mi = ccall(:jl_method_lookup_by_tt, Any,
-            (Any, Csize_t, Any),
-            sig, world, #=method_table=# nothing)
-    # XXX: MethodError takes `f` not `ft`?
+               (Any, Csize_t, Any),
+               sig, world, #=method_table=# nothing)
     mi === nothing && throw(MethodError(ft, tt, world))
-    return mi
+
+    return mi::MethodInstance
 end
 
 # on older versions of Julia, the run-time lookup is much slower, so we'll need to cache it


### PR DESCRIPTION
GPUCompiler's `methodinstance` function is pretty slow and allocates:

```julia
julia> @benchmark GPUCompiler.methodinstance(typeof(identity), Tuple{Nothing}, GPUCompiler.tls_world_age())
BenchmarkTools.Trial: 10000 samples with 204 evaluations.
 Range (min … max):  378.623 ns …  11.078 μs  ┊ GC (min … max): 0.00% … 95.51%
 Time  (median):     389.853 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   401.785 ns ± 312.086 ns  ┊ GC (mean ± σ):  2.66% ±  3.28%

               ▂▆▇█▆▄▂▁▁▂▁▂▁
  ▂▂▂▂▁▂▂▂▂▂▃▄▆██████████████▇▅▄▄▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▄
  379 ns           Histogram: frequency by time          414 ns <

 Memory estimate: 288 bytes, allocs estimate: 6.
```

That's why on 1.10, we improved this by using a generated function to cache the dynamic case, automatically invalidating the result when the world age changes:

```julia
julia> @benchmark GPUCompiler.methodinstance(typeof(identity), Tuple{Nothing})
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  1.889 ns … 7.470 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.920 ns             ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.918 ns ± 0.112 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                               ▃             █
  ▂▃▁▁▁▁▁▁▁▁▁▁▁▂▁▅▁▁▁▁▁▁▁▁▁▁▁▂▁█▁▁▁▁▁▁▁▁▁▁▁▂▁█▁▁▁▁▁▁▁▁▁▁▁▂▄ ▂
  1.89 ns        Histogram: frequency by time       1.93 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

This however is not always valid, see https://github.com/JuliaGPU/GPUCompiler.jl/issues/530. That's why @vchuravy exposed Julia's methodinstance cache in https://github.com/JuliaLang/julia/pull/52572, so that starting on 1.11 we can now always perform a runtime call that's still reasonably fast:

```julia
julia> @benchmark GPUCompiler.methodinstance(typeof(identity), Tuple{Nothing}, GPUCompiler.tls_world_age())
BenchmarkTools.Trial: 10000 samples with 983 evaluations.
 Range (min … max):  57.720 ns … 93.692 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     61.383 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   61.848 ns ±  3.046 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      ▁▃▃▃▄▆█▇▅▃▂
  ▂▂▄▇████████████▆▅▅▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▁▂▂▁▂▂▂▂▂▂▂▂▂ ▃
  57.7 ns         Histogram: frequency by time        78.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark GPUCompiler.methodinstance(typeof(identity), Tuple{Nothing})
BenchmarkTools.Trial: 10000 samples with 982 evaluations.
 Range (min … max):  58.982 ns … 98.370 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     64.938 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   65.184 ns ±  3.429 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                ▄█▁ ▂▅
  ▁▁▂▆▇▄▂▄▆▅▄▄▅▄███▆███▅▆▆▃▃▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  59 ns           Histogram: frequency by time        80.9 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Although slower than our previous cache, it fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/530:

```julia
julia> using GPUCompiler

julia> function foo end
foo (generic function with 0 methods)

julia> methodinstance(Base._stable_typeof(foo), Base.to_tuple_type(()))
ERROR: MethodError: no method matching invoke foo()
The function `foo` exists, but no method is defined for this combination of argument types.
Stacktrace:
 [1] methodinstance(ft::Type, tt::Type, world::UInt64)
   @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/jlgen.jl:71
 [2] methodinstance(ft::Type, tt::Type)
   @ GPUCompiler ~/Julia/pkg/GPUCompiler/src/jlgen.jl:66
 [3] top-level scope
   @ REPL[6]:1

julia> foo() = nothing
foo (generic function with 1 method)

julia> methodinstance(Base._stable_typeof(foo), Base.to_tuple_type(()))
MethodInstance for foo()
```

I would propose to keep using the old version on 1.10 though, as nobody except @topolarity had run into its issues so far.