### PR TITLE
Specialize MI if necessary

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -14,7 +14,7 @@ tls_world_age() = ccall(:jl_get_tls_world_age, UInt, ())
 export methodinstance
 
 @inline function signature_type_by_tt(ft::Type, tt::Type)
-    u = Base.unwrap_unionall(tt)
+    u = Base.unwrap_unionall(tt)::DataType
     return Base.rewrap_unionall(Tuple{ft, u.parameters...}, tt)
 end
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -71,10 +71,8 @@ if VERSION >= v"1.11.0-DEV.1552"
     mi === nothing && throw(MethodError(ft, tt, world))
     mi = mi::MethodInstance
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
-    if !isdispatchtuple(mi.specTypes) && sig != mi.specTypes
-        mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)
-        @assert mi !== nothing
-    end
+    mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)
+    @assert mi !== nothing
     return mi
 end
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -61,6 +61,10 @@ methodinstance
 # Julia's cached method lookup to simply look up method instances at run time.
 if VERSION >= v"1.11.0-DEV.1552"
 
+@inline function specialize(mi::MethodInstance, @nospecialize(sig::Type))
+    @invoke CC.specialize_method(mi.def::Method, sig::Type, Core.svec(), preexisting=true)
+end
+
 # XXX: version of Base.method_instance that uses a function type
 function methodinstance(ft, tt, world=tls_world_age())
     sig = signature_type_by_tt(ft, tt)
@@ -72,9 +76,7 @@ function methodinstance(ft, tt, world=tls_world_age())
     mi = mi::MethodInstance
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
     if mi.specTypes !== sig
-        # XXX: This slows down the lookup significantly
-        #      Do we really need this? We need the mi where we will insert our CodeInstance.
-        mi = CC.specialize_method(mi.def, sig, Core.svec(), preexisting=true)
+        mi = specialize(mi, sig)
         mi === nothing && throw(MethodError(ft, tt, world))
     end
     return mi

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -72,8 +72,8 @@ if VERSION >= v"1.11.0-DEV.1552"
     mi = mi::MethodInstance
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
     if !isdispatchtuple(mi.specTypes) && sig != mi.specTypes
-        mi = CC.specialize_method(mi.def, sig, Core.svec(), preexisting=true)
-        mi === nothing && throw(MethodError(ft, tt, world))
+        mi = CC.specialize_method(mi.def, sig, mi.sparams_vals)
+        @assert mi !== nothing
     end
     return mi
 end
@@ -87,7 +87,7 @@ function methodinstance(ft::Type, tt::Type, world::Integer)
     match, _ = CC._findsup(sig, nothing, world)
     match === nothing && throw(MethodError(ft, tt, world))
 
-    mi = CC.specialize_method(match) # XXX: preexisting=true?
+    mi = CC.specialize_method(match)
 
     return mi::MethodInstance
 end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -70,11 +70,12 @@ if VERSION >= v"1.11.0-DEV.1552"
                sig, world, #=method_table=# nothing)
     mi === nothing && throw(MethodError(ft, tt, world))
     mi = mi::MethodInstance
+
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
-    if !Base.isdispatchtuple(mi.specTypes) && sig !== mi.specTypes
-        mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)
-        @assert mi !== nothing
+    if !Base.isdispatchtuple(mi.specTypes)
+        mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)::MethodInstance
     end
+
     return mi
 end
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -71,7 +71,7 @@ if VERSION >= v"1.11.0-DEV.1552"
     mi === nothing && throw(MethodError(ft, tt, world))
     mi = mi::MethodInstance
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
-    if mi.specTypes !== sig
+    if !isdispatchtuple(mi.specTypes) && sig != mi.specTypes
         mi = CC.specialize_method(mi.def, sig, Core.svec(), preexisting=true)
         mi === nothing && throw(MethodError(ft, tt, world))
     end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -72,7 +72,7 @@ if VERSION >= v"1.11.0-DEV.1552"
     mi = mi::MethodInstance
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
     if !isdispatchtuple(mi.specTypes) && sig != mi.specTypes
-        mi = CC.specialize_method(mi.def, sig, mi.sparams_vals)
+        mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)
         @assert mi !== nothing
     end
     return mi

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -71,8 +71,10 @@ if VERSION >= v"1.11.0-DEV.1552"
     mi === nothing && throw(MethodError(ft, tt, world))
     mi = mi::MethodInstance
     # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
-    mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)
-    @assert mi !== nothing
+    if !Base.isdispatchtuple(mi.specTypes) && sig !== mi.specTypes
+        mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)
+        @assert mi !== nothing
+    end
     return mi
 end
 


### PR DESCRIPTION
@vtjnash is there a way to speedup this query? For `identity(::Int)` this currently takes ~500ns

The goal here is to compute the `mi` we would have `invoked`.
