### PR TITLE
Make the cache token incorporate the entire compile configuration.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -221,13 +221,12 @@ valid_function_pointer(@nospecialize(job::CompilerJob), ptr::Ptr{Cvoid}) = false
 # By default that is just always_inline
 # the cache token is compared with jl_egal
 struct GPUCompilerCacheToken
-    target_type::Type
-    always_inline::Bool
+    config::CompilerConfig
     method_table::Core.MethodTable
 end
 
 ci_cache_token(@nospecialize(job::CompilerJob)) =
-    GPUCompilerCacheToken(typeof(job.config.target), job.config.always_inline, method_table(job))
+    GPUCompilerCacheToken(job.config, method_table(job))
 
 # the codeinfo cache to use -- should only be used for the constructor
 if VERSION >= v"1.11.0-DEV.1552"


### PR DESCRIPTION
Fixes #560. This is what the split of `CompilerJob` in `CompilerConfig` + `MethodInstance` was intended for.

@vchuravy IIRC you opposed this because of Enzyme storing runtime values in the compiler params, but that could be fixed by having a custom `ci_cache_token` for Enzyme's compiler job, no?