### PR TITLE
Include the compiler config in the runtime cache lookup.

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -115,8 +115,11 @@ end
 
     # fast path: find an applicable CodeInstance and see if we have compiled it before
     ci = ci_cache_lookup(ci_cache(job), src, world, world)::Union{Nothing,CodeInstance}
-    if ci !== nothing && haskey(cache, ci)
-        obj = cache[ci]
+    if ci !== nothing
+        key = (ci, cfg)
+        if haskey(cache, key)
+            obj = cache[key]
+        end
     end
 
     # slow path: compile and link
@@ -128,10 +131,13 @@ end
             # we got here because of a *compile* hook; don't bother linking
             return obj
         end
-
         obj = linker(job, asm)
-        ci = ci_cache_lookup(ci_cache(job), src, world, world)::CodeInstance
-        cache[ci] = obj
+
+        if ci === nothing
+            ci = ci_cache_lookup(ci_cache(job), src, world, world)::CodeInstance
+            key = (ci, cfg)
+        end
+        cache[key] = obj
     end
 
     return obj

--- a/test/native_tests.jl
+++ b/test/native_tests.jl
@@ -78,10 +78,6 @@ end
         @eval @noinline $child(i) = i
         @eval $kernel(i) = $child(i)+1
 
-        target = NativeCompilerTarget()
-        params = Native.CompilerParams()
-        config = CompilerConfig(target, params; kernel=false)
-
         # smoke test
         job, _ = Native.create_job(eval(kernel), (Int64,))
         ir = sprint(io->GPUCompiler.code_llvm(io, job))
@@ -141,6 +137,12 @@ end
         # cached compilation
         ir = Base.invokelatest(GPUCompiler.cached_compilation, cache, source, job.config, compiler, linker)
         @test invocations[] == 3
+
+        # change in configuration
+        config = CompilerConfig(job.config; name="foobar")
+        ir = Base.invokelatest(GPUCompiler.cached_compilation, cache, source, config, compiler, linker)
+        @test invocations[] == 4
+        @test contains(ir, "foobar")
 
         # tasks running in the background should keep on using the old version
         c1, c2 = Condition(), Condition()


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/560, alternative to https://github.com/JuliaGPU/GPUCompiler.jl/pull/561.