### PR TITLE
Metal: Work around function attribute changes in LLVM 16.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.26.3"
+version = "0.26.4"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
Works around the changes from https://reviews.llvm.org/D135780. I'm not sure why the IR Autoupgrader didn't kick in...

x-ref https://github.com/JuliaGPU/GPUCompiler.jl/issues/565