### PR TITLE
Add an interface extension point to prepare before anything happens.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -128,6 +128,8 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
         validate && check_invocation(job)
     end
 
+    prepare_job!(job)
+
 
     ## LLVM IR
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -277,6 +277,10 @@ end
 
 ## extension points at important stages of compilation
 
+# prepare the environment for compilation of a job. this can involve, e.g.,
+# priming the cache with entries that cannot be easily inferred.
+prepare_job!(@nospecialize(job::CompilerJob)) = return
+
 # early extension point used to link-in external bitcode files.
 # this is typically used by downstream packages to link vendor libraries.
 link_libraries!(@nospecialize(job::CompilerJob), mod::LLVM.Module,

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -505,6 +505,7 @@ end # HAS_INTEGRATED_CACHE
 function ci_cache_populate(interp, cache, mi, min_world, max_world)
     if VERSION >= v"1.12.0-DEV.15"
         inferred_ci = CC.typeinf_ext_toplevel(interp, mi, CC.SOURCE_MODE_FORCE_SOURCE) # or SOURCE_MODE_FORCE_SOURCE_UNCACHED?
+        @assert inferred_ci !== nothing "Inference of $mi failed"
 
         # inference should have populated our cache
         wvc = WorldView(cache, min_world, max_world)


### PR DESCRIPTION
This is convenient for some experiments I'm doing with GPU opaque closures, where we want to insert additional CIs in the cache that are not inferrable by themselves.