### PR TITLE
Use a pidfile to guard againstn runtime corruption.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.26.4"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -15,11 +16,12 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ExprTools = "0.1"
+FileWatching = "1"
 InteractiveUtils = "1"
+LLVM = "7.1"
 Libdl = "1"
 Logging = "1"
-UUIDs = "1"
-LLVM = "7.1"
 Scratch = "1"
 TimerOutputs = "0.5"
+UUIDs = "1"
 julia = "1.8"


### PR DESCRIPTION
Cost: 50us/10%, but probably worth it given the widespread (if occasional) corruption that happens. Fixes https://github.com/JuliaGPU/GPUCompiler.jl/issues/570