### PR TITLE
[Experiment] Add deferred_with

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -130,6 +130,9 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     error("Unknown compilation output $output")
 end
 
+@noinline function var"gpuc.deferred"(f, args...) end
+@noinline function var"gpuc.lookup"(mi, f, args...) end
+
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
 # this could both be generalized (e.g. supporting actual function calls, instead of
 # returning a function pointer), and be integrated with the nonrecursive codegen.

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -130,8 +130,8 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
     error("Unknown compilation output $output")
 end
 
-@noinline function var"gpuc.deferred"(f, args...) end
-@noinline function var"gpuc.lookup"(mi, f, args...) end
+# GPUCompiler intrinsic that marks deferred compilation
+function var"gpuc.deferred" end
 
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
 # this could both be generalized (e.g. supporting actual function calls, instead of

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -131,9 +131,10 @@ function codegen(output::Symbol, @nospecialize(job::CompilerJob);
 end
 
 # GPUCompiler intrinsic that marks deferred compilation
-# In contrast to `deferred_codegen` this doesn't support arbitrary
-# jobs as call targets.
 function var"gpuc.deferred" end
+
+# GPUCompiler intrinsic that marks deferred compilation, across backends
+function var"gpuc.deferred.with" end
 
 # primitive mechanism for deferred compilation, for implementing CUDA dynamic parallelism.
 # this could both be generalized (e.g. supporting actual function calls, instead of

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -435,12 +435,27 @@ function CC.concrete_eval_eligible(interp::GPUInterpreter,
     return ret
 end
 
+struct DeferredCallInfo <: CC.CallInfo
+    rt::DataType
+    info::CC.CallInfo
+end
+
 function CC.abstract_call_known(interp::GPUInterpreter, @nospecialize(f),
         arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.AbsIntState,
         max_methods::Int = CC.get_max_methods(interp, f, sv))
-    if f === var"gpuc.deferred" ||
-       f === var"gpuc.lookup"
-        return CC.CallMeta(Ptr{Cvoid}, Union{}, CC.Effects(), CC.NoCallInfo())
+    (; fargs, argtypes) = arginfo
+    if f === var"gpuc.deferred"
+        argvec = argtypes[2:end]
+        call = CC.abstract_call(interp, CC.ArgInfo(nothing, argvec), si, sv, max_methods)
+        callinfo = DeferredCallInfo(call.rt, call.info)
+        @static if VERSION < v"1.11.0-"
+            return CC.CallMeta(Ptr{Cvoid}, CC.Effects(), callinfo)
+        else
+            return CC.CallMeta(Ptr{Cvoid}, Union{}, CC.Effects(), callinfo)
+        end
+    end
+    if f === var"gpuc.lookup"
+        error("Unimplemented")
     end
     return @invoke CC.abstract_call_known(interp::CC.AbstractInterpreter, f,
         arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.AbsIntState,

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -814,6 +814,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob), compiled::IdDi
     # Collect the deferred edges
     outstanding = Any[]
     for mi in method_instances
+        !haskey(mi, compiled) && continue # Equivalent to ci_cache_lookup == nothing
         ci = compiled[mi].ci
         @static if VERSION >= v"1.11.0-"
             edges = CC.traverse_analysis_results(ci) do @nospecialize result

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -454,9 +454,6 @@ function CC.abstract_call_known(interp::GPUInterpreter, @nospecialize(f),
             return CC.CallMeta(Ptr{Cvoid}, Union{}, CC.Effects(), callinfo)
         end
     end
-    if f === var"gpuc.lookup"
-        error("Unimplemented")
-    end
     return @invoke CC.abstract_call_known(interp::CC.AbstractInterpreter, f,
         arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.AbsIntState,
         max_methods::Int)
@@ -479,10 +476,17 @@ function CC.handle_call!(todo::Vector{Pair{Int,Any}},
     @assert case isa CC.InvokeCase
     @assert stmt.head === :call
 
-    # rewrite the marker function
-    stmt.args[1] = var"gpuc.lookup"
-    # insert the mi
-    insert!(stmt.args, 2, case.invoke)
+    args = Any[
+        "extern gpuc.lookup",
+        Ptr{Cvoid},
+        Core.svec(Any, Any, match.spec_types.parameters[2:end]...), # Must use Any for MethodInstance or ftype
+        0,
+        QuoteNode(:llvmcall),
+        case.invoke,
+        stmt.args[2:end]...
+    ]
+    stmt.head = :foreigncall
+    stmt.args = args
     return nothing
 end
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -435,6 +435,17 @@ function CC.concrete_eval_eligible(interp::GPUInterpreter,
     return ret
 end
 
+function CC.abstract_call_known(interp::GPUInterpreter, @nospecialize(f),
+        arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.AbsIntState,
+        max_methods::Int = CC.get_max_methods(interp, f, sv))
+    if f === var"gpuc.deferred" ||
+       f === var"gpuc.lookup"
+        return CC.CallMeta(Ptr{Cvoid}, Union{}, CC.Effects(), CC.NoCallInfo())
+    end
+    return @invoke CC.abstract_call_known(interp::CC.AbstractInterpreter, f,
+        arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.AbsIntState,
+        max_methods::Int)
+end
 
 ## world view of the cache
 using Core.Compiler: WorldView

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -462,6 +462,50 @@ function CC.abstract_call_known(interp::GPUInterpreter, @nospecialize(f),
         max_methods::Int)
 end
 
+# Customize the optimization pipeline
+Base.iterate(compact::CC.IncrementalCompact, state=nothing) = CC.iterate(compact, state)
+Base.getindex(compact::CC.IncrementalCompact, idx) = CC.getindex(compact, idx)
+
+function deferred_pass!(ir)
+    compact = CC.IncrementalCompact(ir)
+    for ((old_idx, idx), stmt) in compact
+        if CC.is_known_call(stmt, var"gpuc.deferred", compact)
+            @safe_show stmt
+        end
+    end
+    CC.non_dce_finish!(compact)
+    CC.simple_dce!(compact)
+    ir = CC.complete(compact)
+    return ir
+end
+
+function CC.optimize(interp::GPUInterpreter, opt::CC.OptimizationState, caller::CC.InferenceResult)
+    CC.@timeit "optimizer" ir = CC.run_passes(opt.src, opt, caller)
+    # Customizing the ipo_safe pipeline is a pain
+    ir = deferred_pass!(ir)
+    @static if VERSION >= v"1.11.0-"
+        CC.ipo_dataflow_analysis!(interp, ir, caller)
+    end
+    return CC.finish(interp, opt, ir, caller)
+end
+
+function CC.typeinf_ircode(interp::GPUInterpreter, mi::CC.MethodInstance,
+                        optimize_until::Union{Integer,AbstractString,Nothing})
+    start_time = ccall(:jl_typeinf_timing_begin, UInt64, ())
+    frame = CC.typeinf_frame(interp, mi, false)
+    if frame === nothing
+        ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
+        return nothing, Any
+    end
+    (; result) = frame
+    opt = CC.OptimizationState(frame, interp)
+    ir = CC.run_passes(opt.src, opt, result, optimize_until)
+    ir = deferred_pass!(ir)
+    rt = CC.widenconst(CC.ignorelimited(result.result))
+    ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
+    return ir, rt
+end
+
 ## world view of the cache
 using Core.Compiler: WorldView
 

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -461,9 +461,9 @@ function CC.abstract_call_known(interp::AbstractGPUInterpreter, @nospecialize(f)
 end
 
 # Use the Inlining infrastructure to perform our refinement
-# TODO: @aviatesk This is not reached on 1.11
+const FlagType = VERSION >= v"1.11.0-" ? UInt32 : UInt8
 function CC.handle_call!(todo::Vector{Pair{Int,Any}},
-    ir::CC.IRCode, idx::CC.Int, stmt::Expr, info::DeferredCallInfo, flag::UInt8, sig::CC.Signature,
+    ir::CC.IRCode, idx::CC.Int, stmt::Expr, info::DeferredCallInfo, flag::FlagType, sig::CC.Signature,
     state::CC.InliningState)
 
     minfo = info.info

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -814,7 +814,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob), compiled::IdDi
     # Collect the deferred edges
     outstanding = Any[]
     for mi in method_instances
-        !haskey(mi, compiled) && continue # Equivalent to ci_cache_lookup == nothing
+        !haskey(compiled, mi) && continue # Equivalent to ci_cache_lookup == nothing
         ci = compiled[mi].ci
         @static if VERSION >= v"1.11.0-"
             edges = CC.traverse_analysis_results(ci) do @nospecialize result

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -318,7 +318,8 @@ else
     get_method_table_view(world::UInt, mt::MTType) = OverlayMethodTable(world, mt)
 end
 
-struct GPUInterpreter <: CC.AbstractInterpreter
+abstract type AbstractGPUInterpreter <: CC.AbstractInterpreter end
+struct GPUInterpreter <: AbstractGPUInterpreter
     world::UInt
     method_table::GPUMethodTableView
 
@@ -440,7 +441,7 @@ struct DeferredCallInfo <: CC.CallInfo
     info::CC.CallInfo
 end
 
-function CC.abstract_call_known(interp::GPUInterpreter, @nospecialize(f),
+function CC.abstract_call_known(interp::AbstractGPUInterpreter, @nospecialize(f),
         arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.AbsIntState,
         max_methods::Int = CC.get_max_methods(interp, f, sv))
     (; fargs, argtypes) = arginfo

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -462,48 +462,28 @@ function CC.abstract_call_known(interp::GPUInterpreter, @nospecialize(f),
         max_methods::Int)
 end
 
-# Customize the optimization pipeline
-Base.iterate(compact::CC.IncrementalCompact, state=nothing) = CC.iterate(compact, state)
-Base.getindex(compact::CC.IncrementalCompact, idx) = CC.getindex(compact, idx)
+# Use the Inlining infrastructure to perform our refinement
+function CC.handle_call!(todo::Vector{Pair{Int,Any}},
+    ir::CC.IRCode, idx::CC.Int, stmt::Expr, info::DeferredCallInfo, flag::UInt8, sig::CC.Signature,
+    state::CC.InliningState)
 
-function deferred_pass!(ir)
-    compact = CC.IncrementalCompact(ir)
-    for ((old_idx, idx), stmt) in compact
-        if CC.is_known_call(stmt, var"gpuc.deferred", compact)
-            @safe_show stmt
-        end
+    minfo = info.info
+    results = minfo.results
+    if length(results.matches) != 1
+        return nothing
     end
-    CC.non_dce_finish!(compact)
-    CC.simple_dce!(compact)
-    ir = CC.complete(compact)
-    return ir
-end
+    match = only(results.matches)
 
-function CC.optimize(interp::GPUInterpreter, opt::CC.OptimizationState, caller::CC.InferenceResult)
-    CC.@timeit "optimizer" ir = CC.run_passes(opt.src, opt, caller)
-    # Customizing the ipo_safe pipeline is a pain
-    ir = deferred_pass!(ir)
-    @static if VERSION >= v"1.11.0-"
-        CC.ipo_dataflow_analysis!(interp, ir, caller)
-    end
-    return CC.finish(interp, opt, ir, caller)
-end
+    # lookup the target mi with correct edge tracking
+    case = CC.compileable_specialization(match, CC.Effects(), CC.InliningEdgeTracker(state), info)
+    @assert case isa CC.InvokeCase
+    @assert stmt.head === :call
 
-function CC.typeinf_ircode(interp::GPUInterpreter, mi::CC.MethodInstance,
-                        optimize_until::Union{Integer,AbstractString,Nothing})
-    start_time = ccall(:jl_typeinf_timing_begin, UInt64, ())
-    frame = CC.typeinf_frame(interp, mi, false)
-    if frame === nothing
-        ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
-        return nothing, Any
-    end
-    (; result) = frame
-    opt = CC.OptimizationState(frame, interp)
-    ir = CC.run_passes(opt.src, opt, result, optimize_until)
-    ir = deferred_pass!(ir)
-    rt = CC.widenconst(CC.ignorelimited(result.result))
-    ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
-    return ir, rt
+    # rewrite the marker function
+    stmt.args[1] = var"gpuc.lookup"
+    # insert the mi
+    insert!(stmt.args, 2, case.invoke)
+    return nothing
 end
 
 ## world view of the cache

--- a/test/native_tests.jl
+++ b/test/native_tests.jl
@@ -162,6 +162,20 @@ end
         ir = fetch(t)
         @test contains(ir, r"add i64 %\d+, 3")
     end
+
+    @testset "deferred" begin
+        @gensym child kernel unrelated
+        @eval @noinline $child(i) = i
+        @eval $kernel(i) = GPUCompiler.var"gpuc.deferred"($child, i)
+
+        # smoke test
+        job, _ = Native.create_job(eval(kernel), (Int64,))
+
+        ci, rt = only(GPUCompiler.code_typed(job))
+        @test rt === Ptr{Cvoid}
+
+        ir = sprint(io->GPUCompiler.code_llvm(io, job))
+    end
 end
 
 ############################################################################################


### PR DESCRIPTION
Currently the pattern to embedd Enzyme into a GPU kernel looks something like this:

```
function kernel(#=....=#)
    # ...
end

function dkernel(#=...=#)
    autodiff_deferred(Reverse, kernel, #=...=#)
end
```

Internally this would create a job for Enzyme to later process using the deferred compilation
mechanism originally built for CUDA.jl

In #582 I am reworking this to embedd the necessary information into the IR,
instead of relying on a runtime dictionary inside GPUCompiler.

For deferred compilation ala CUDA.jl we have it relativly easy. We just need to process the discovered method-instance
and link it into the output module.

For the Enzyme use-case it becomes more tricky. We can't embed a CompilerJob since that captures a lot of superflous information,
yet we do need to capture enough information to construct an approprate CompilerJob.

Taking a note from https://github.com/JuliaLang/julia/pull/52964 I propose that we add something like

```
struct EnzymeContext
   mode
   f_activity
   rt_activity
   args_activity
   width
   #...#
end
```

@wsmoses essentially everything that the `NonGenABI` requires.

And essentially rename `Enzyme.thunk` to `GPUCompiler.var"gpuc.deferred.with"(EnzymeContext(#=...=#), f, args...)`
(actually `lookup.with`) since that will have the `mi`. An issue might be ReverseModePrimal/ReverseModeGradient since that 
returns more than a single return value. 

The question arises, why not just have `gpuc.deferred.with` and remove `gpuc.deferred`?
I am not sure, how the worklist integration will look like, but I for me there is a symmetry to `invoke_within` and `invoke`
in the Compiler plugins proposal. (I should probably call this `gpuc.deferred.within` xD )

Opening this up so that I can unload my brain for now and have it percolate a bit.


