### PR TITLE
Set codegen kwargs based on toplevel setting (NFC)

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -56,10 +56,10 @@ function _precompile_()
     @assert precompile(Tuple{typeof(GPUCompiler.lower_gc_frame!),LLVM.Function})
     @assert precompile(Tuple{typeof(GPUCompiler.lower_throw!),LLVM.Module})
     #@assert precompile(Tuple{typeof(GPUCompiler.split_kwargs),Tuple{},Vector{Symbol},Vararg{Vector{Symbol}, N} where N})
-    let fbody = try __lookup_kwbody__(which(GPUCompiler.compile, (Symbol,GPUCompiler.CompilerJob,))) catch missing end
-        if !ismissing(fbody)
-            @assert precompile(fbody, (Bool,Bool,Bool,Bool,Bool,Bool,Bool,typeof(GPUCompiler.compile),Symbol,GPUCompiler.CompilerJob,))
-            @assert precompile(fbody, (Bool,Bool,Bool,Bool,Bool,Bool,Bool,typeof(GPUCompiler.compile),Symbol,GPUCompiler.CompilerJob,))
-        end
-    end
+    # let fbody = try __lookup_kwbody__(which(GPUCompiler.compile, (Symbol,GPUCompiler.CompilerJob,))) catch missing end
+    #     if !ismissing(fbody)
+    #         @assert precompile(fbody, (Bool,Bool,Bool,Bool,Bool,Bool,Bool,typeof(GPUCompiler.compile),Symbol,GPUCompiler.CompilerJob,))
+    #         @assert precompile(fbody, (Bool,Bool,Bool,Bool,Bool,Bool,Bool,typeof(GPUCompiler.compile),Symbol,GPUCompiler.CompilerJob,))
+    #     end
+    # end
 end

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -56,8 +56,7 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method)
     tt = Base.to_tuple_type(method.types)
     source = generic_methodinstance(f, tt)
-    new_mod, meta = codegen(:llvm, CompilerJob(source, config);
-                            optimize=false, libraries=false, validate=false)
+    new_mod, meta = codegen(:llvm, CompilerJob(source, config); toplevel=false)
     ft = function_type(meta.entry)
     expected_ft = convert(LLVM.FunctionType, method)
     if return_type(ft) != return_type(expected_ft)


### PR DESCRIPTION
This simplifies the kwarg values used in `compile`/`codegen`, and should make a little more clear what's happening and when.

It breaks the `precompile.jl`, but with the recent work by @vchuravy I take it we better move to an actual precompilation workload anyway?