### PR TITLE
Be more strict about runtime function misuse.

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -51,9 +51,6 @@ end
 
 const methods = Dict{Symbol,RuntimeMethodInstance}()
 function get(name::Symbol)
-    if !haskey(methods, name)
-        display(methods)
-    end
     methods[name]
 end
 


### PR DESCRIPTION
Generates better error messages for https://github.com/JuliaGPU/GPUCompiler.jl/issues/596:
- detects the argument count mismatch (`Incorrect number of arguments for runtime function: passing 1 argument(s) to 'void () report_exception'`)
- in addition, refuses to generate an intrinsic call to a pre-defined function in the module (`Calling an intrinsic function that clashes with an existing definition: void (i64) report_exception`). This is fairly strict, but without controlling the intrinsic definition it's possible that it doesn't match the expected behavior (i.e., what probably caused #596 in the first place).