### PR TITLE
Default to using NewPM.

### DIFF
--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -16,8 +16,6 @@ using Preferences
 const CC = Core.Compiler
 using Core: MethodInstance, CodeInstance, CodeInfo
 
-const use_newpm = LLVM.has_newpm()
-
 include("utils.jl")
 include("mangling.jl")
 

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -74,14 +74,7 @@ function emit_function!(mod, config::CompilerConfig, f, method)
     end
 
     # recent Julia versions include prototypes for all runtime functions, even if unused
-    if use_newpm
-        run!(StripDeadPrototypesPass(), new_mod, llvm_machine(config.target))
-    else
-        @dispose pm=ModulePassManager() begin
-            strip_dead_prototypes!(pm)
-            run!(pm, new_mod)
-        end
-    end
+    run!(StripDeadPrototypesPass(), new_mod, llvm_machine(config.target))
 
     temp_name = LLVM.name(meta.entry)
     link!(mod, new_mod)


### PR DESCRIPTION
Now that we only support Julia 1.10, which ships LLVM 15, we can almost entirely switch to LLVM's new pass manager.

Also fixes use of the InternalizePass for 1.12.