### PR TITLE
Add CI jobs for AMDGPU

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,6 +96,31 @@ steps:
     soft_fail:
       - exit_status: 3
 
+  - label: "AMDGPU.jl 1.11 opaque pointers"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+       julia -e 'println("--- :julia: Instantiating project")
+                 using Pkg
+                 Pkg.develop(; path=pwd())
+                 Pkg.develop(; name="AMDGPU")' || exit 3
+
+       julia -e 'println("+++ :julia: Running tests")
+                 using Pkg
+                 Pkg.test("AMDGPU"; coverage=true)'
+    agents:
+      queue: "juliagpu"
+      rocm: "*"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 120
+    soft_fail:
+      - exit_status: 3
+    env:
+      JULIA_LLVM_ARGS: "-opaque-pointers"
+
   - label: "Enzyme.jl"
     plugins:
       - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,28 +73,28 @@ steps:
     soft_fail:
       - exit_status: 3
 
-  # - label: "AMDGPU.jl"
-  #   plugins:
-  #     - JuliaCI/julia#v1:
-  #         version: "1.10"
-  #     - JuliaCI/julia-coverage#v1:
-  #         codecov: true
-  #   command: |
-  #      julia -e 'println("--- :julia: Instantiating project")
-  #                using Pkg
-  #                Pkg.develop(; path=pwd())
-  #                Pkg.develop(; name="AMDGPU")' || exit 3
+  - label: "AMDGPU.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+       julia -e 'println("--- :julia: Instantiating project")
+                 using Pkg
+                 Pkg.develop(; path=pwd())
+                 Pkg.develop(; name="AMDGPU")' || exit 3
 
-  #      julia -e 'println("+++ :julia: Running tests")
-  #                using Pkg
-  #                Pkg.test("AMDGPU"; coverage=true)'
-  #   agents:
-  #     queue: "juliagpu"
-  #     rocm: "*"
-  #   if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
-  #   timeout_in_minutes: 120
-  #   soft_fail:
-  #     - exit_status: 3
+       julia -e 'println("+++ :julia: Running tests")
+                 using Pkg
+                 Pkg.test("AMDGPU"; coverage=true)'
+    agents:
+      queue: "juliagpu"
+      rocm: "*"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 120
+    soft_fail:
+      - exit_status: 3
 
   - label: "Enzyme.jl"
     plugins:

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -66,7 +66,8 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method)
     tt = Base.to_tuple_type(method.types)
     source = generic_methodinstance(f, tt)
-    new_mod, meta = codegen(:llvm, CompilerJob(source, config); toplevel=false)
+    new_mod, meta = codegen(:llvm, CompilerJob(source, config);
+        optimize=false, libraries=false, validate=false)
     ft = function_type(meta.entry)
     expected_ft = convert(LLVM.FunctionType, method)
     if return_type(ft) != return_type(expected_ft)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -66,8 +66,7 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method)
     tt = Base.to_tuple_type(method.types)
     source = generic_methodinstance(f, tt)
-    new_mod, meta = codegen(:llvm, CompilerJob(source, config);
-        optimize=false, libraries=false, validate=false)
+    new_mod, meta = codegen(:llvm, CompilerJob(source, config); toplevel=false)
     ft = function_type(meta.entry)
     expected_ft = convert(LLVM.FunctionType, method)
     if return_type(ft) != return_type(expected_ft)


### PR DESCRIPTION
~~- Fix issues observed in CI after 0.27 update:
https://buildkite.com/julialang/amdgpu-dot-jl/builds/2551#019128fc-5ca0-4674-bf9c-2ebc853bfad3/6-24~~

- Enable AMDGPU CI (for 1.10 and 1.11 with opaque pointers enabled).

- Remove unused GCN functionality.