### PR TITLE
Fix use of Base.rename for 1.12

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -244,12 +244,13 @@ end
         @static if VERSION >= v"1.11.0-"
             if !ondisk_hit && path !== nothing && disk_cache_enabled()
                 @debug "Writing out on-disk cache" job path
-                tmppath, io = mktemp(;cleanup=false)
+                mkpath(dirname(path))
                 entry = DiskCacheEntry(src.specTypes, cfg, asm)
+
+                # atomic write to disk
+                tmppath, io = mktemp(dirname(path); cleanup=false)
                 serialize(io, entry)
                 close(io)
-                # atomic move
-                mkpath(dirname(path))
                 @static if VERSION >= v"1.12.0-DEV.1023"
                     mv(tmppath, path; force=true)
                 else

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -250,7 +250,11 @@ end
                 close(io)
                 # atomic move
                 mkpath(dirname(path))
-                Base.rename(tmppath, path, force=true)
+                @static if VERSION >= v"1.12.0-DEV.1023"
+                    mv(tmppath, path; force=true)
+                else
+                    Base.rename(tmppath, path, force=true)
+                end
             end
         end
 

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -153,7 +153,11 @@ const runtime_lock = ReentrantLock()
             temp_path, io = mktemp(dirname(path); cleanup=false)
             write(io, lib)
             close(io)
-            Base.rename(temp_path, path; force=true)
+            @static if VERSION >= v"1.12.0-DEV.1023"
+                mv(temp_path, path; force=true)
+            else
+                Base.rename(temp_path, path, force=true)
+            end
         end
 
         return lib


### PR DESCRIPTION
The `force` keyword argument to `rename` was removed in https://github.com/JuliaLang/julia/pull/55384 to replace the stopgap solution added in https://github.com/JuliaLang/julia/pull/36638#discussion_r453820564 by making the regular `mv(tmppath, cachefile; force = true)` more atomic.