### PR TITLE
fix mangling of booleans and zeros

### DIFF
--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -83,8 +83,26 @@ function mangle_param(t, substitutions=String[])
         end
 
         str
-    elseif isa(t, Integer)
-        t > 0 ? "Li$(t)E" : "Lin$(abs(t))E"
+    elseif isa(t, Union{Bool, Cchar, Cuchar, Cshort, Cushort, Cint, Cuint, Clong, Culong, Clonglong, Culonglong, Int128, UInt128})
+        ts = t isa Bool       ? 'b' : # bool
+             t isa Cchar      ? 'a' : # signed char
+             t isa Cuchar     ? 'h' : # unsigned char
+             t isa Cshort     ? 's' : # short
+             t isa Cushort    ? 't' : # unsigned short
+             t isa Cint       ? 'i' : # int
+             t isa Cuint      ? 'j' : # unsigned int
+             t isa Clong      ? 'l' : # long
+             t isa Culong     ? 'm' : # unsigned long
+             t isa Clonglong  ? 'x' : # long long, __int64
+             t isa Culonglong ? 'y' : # unsigned long long, __int64
+             t isa Int128     ? 'n' : # __int128
+             t isa UInt128    ? 'o' : # unsigned __int128
+             error("Invalid type")
+        tn = string(abs(t), base=10)
+        if t < 0
+            tn = 'n'*tn
+        end
+        "L$(ts)$(tn)E"
     else
         tn = safe_name(t)   # TODO: actually does support digits...
         if startswith(tn, r"\d")

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -9,4 +9,14 @@
     @test groups[3] == [:(d=4)]
 end
 
+@testset "mangle" begin
+    struct XX{T} end
+    # values checked with c++filt / cu++filt
+    @test GPUCompiler.mangle_sig(Tuple{typeof(sin), XX{false}})      == "_Z3sin2XXILb0EE"    # "sin(XX<false>)"
+    @test GPUCompiler.mangle_sig(Tuple{typeof(sin), XX{true}})       == "_Z3sin2XXILb1EE"    # "sin(XX<true>)"
+    @test GPUCompiler.mangle_sig(Tuple{typeof(sin), XX{Int64(10)}})  == "_Z3sin2XXILl10EE"   # "sin(XX<10l>)"
+    @test GPUCompiler.mangle_sig(Tuple{typeof(sin), XX{Int64(0)}})   == "_Z3sin2XXILl0EE"    # "sin(XX<0l>)"
+    @test GPUCompiler.mangle_sig(Tuple{typeof(sin), XX{Int64(-10)}}) == "_Z3sin2XXILln10EE"  # "sin(XX<-10l>)"
+end
+
 end


### PR DESCRIPTION
Fixes #609.

I also noticed that zeros were not being mangled correctly (the `n` prefix should only be added if the value is negative, not if equal to zero).