### PR TITLE
Replace current, not global logger in safe loggers

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,9 +61,11 @@ for level in [:debug, :info, :warn, :error]
             macrocall.args[1] = Symbol($"@$level")
             quote
                 io = IOContext(Core.stderr, :color=>STDERR_HAS_COLOR[])
-                # global_logger() is more likely to have a sane min_level than
-                # current_logger(), as the latter is more likely to be a custom logger that
-                # relies solely on Logging.shouldlog() for filtering
+                # ideally we call Logging.shouldlog() here, but that is likely to yield,
+                # so instead we rely on the min_enabled_level of the logger.
+                # in the case of custom loggers that may be an issue, because,
+                # they may expect Logging.shouldlog() getting called, so we use
+                # the global_logger()'s min level which is more likely to be usable.
                 min_level = _invoked_min_enabled_level(global_logger())
                 with_logger(Logging.ConsoleLogger(io, min_level)) do
                     $(esc(macrocall))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,36 +46,8 @@ using Logging
 
 const STDERR_HAS_COLOR = Ref{Bool}(false)
 
-struct SafeLogger{L<:Logging.AbstractLogger} <: Logging.AbstractLogger
-    current_logger::L
-    safe_logger::ConsoleLogger
-
-    function SafeLogger(current_logger)
-        io = IOContext(Core.stderr, :color => STDERR_HAS_COLOR[])
-        safe_logger = ConsoleLogger(io, _invoked_min_enabled_level(current_logger))
-        return new{typeof(current_logger)}(current_logger, safe_logger)
-    end
-end
-
-function Logging.handle_message(logger::SafeLogger, args...)
-    return Logging.handle_message(logger.safe_logger, args...)
-end
-
-function Logging.shouldlog(logger::SafeLogger, args...)
-    return _invoked_shouldlog(logger.current_logger, args...)
-end
-
-function Logging.min_enabled_level(logger::SafeLogger)
-    return Logging.min_enabled_level(logger.safe_logger)
-end
-
 # Prevent invalidation when packages define custom loggers
 # Using invoke in combination with @nospecialize eliminates backedges to these methods
-function _invoked_shouldlog(@nospecialize(logger), @nospecialize(args...))
-    types = Tuple{typeof(logger), typeof.(args)...}
-    return invoke(Logging.shouldlog, types, logger, args...)::Bool
-end
-
 function _invoked_min_enabled_level(@nospecialize(logger))
     return invoke(Logging.min_enabled_level, Tuple{typeof(logger)}, logger)::LogLevel
 end
@@ -88,7 +60,12 @@ for level in [:debug, :info, :warn, :error]
             # NOTE: `@placeholder` in order to avoid hard-coding @__LINE__ etc
             macrocall.args[1] = Symbol($"@$level")
             quote
-                with_logger(SafeLogger(current_logger())) do
+                io = IOContext(Core.stderr, :color=>STDERR_HAS_COLOR[])
+                # global_logger() is more likely to have a sane min_level than
+                # current_logger(), as the latter is more likely to be a custom logger that
+                # relies solely on Logging.shouldlog() for filtering
+                min_level = _invoked_min_enabled_level(global_logger())
+                with_logger(Logging.ConsoleLogger(io, min_level)) do
                     $(esc(macrocall))
                 end
             end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -40,6 +40,7 @@ end
         GPUCompiler.@safe_info "safe_info"
         GPUCompiler.@safe_warn "safe_warn"
         GPUCompiler.@safe_error "safe_error"
+        GPUCompiler.@safe_show "safe_show"
     end
 
     @test begin
@@ -54,10 +55,16 @@ end
                 sleep(0.1)
                 @error "error"
                 sleep(0.1)
+                @show "show"
+                sleep(0.1)
             end
+            pipe = Pipe()
+            Base.link_pipe!(pipe; reader_supports_async=true, writer_supports_async=true)
+            Threads.@spawn print(stdout, read(pipe, String))
             Threads.@spawn Logging.with_logger(YieldingLogger()) do
                 sleep(0.1)
-                f()
+                redirect_stdout(f, pipe)
+                close(pipe)
             end
         end
         true

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -19,4 +19,49 @@ end
     @test GPUCompiler.mangle_sig(Tuple{typeof(sin), XX{Int64(-10)}}) == "_Z3sin2XXILln10EE"  # "sin(XX<-10l>)"
 end
 
+@testset "safe loggers" begin
+    using Logging: Logging
+
+    struct YieldingLogger <: Logging.AbstractLogger
+        logger::Logging.AbstractLogger
+        YieldingLogger() = new(Logging.current_logger())
+    end
+
+    function Logging.handle_message(logger::YieldingLogger, args...)
+        yield()
+        return Logging.handle_message(logger.logger, args...)
+    end
+
+    Logging.shouldlog(::YieldingLogger, ::Any...) = true
+    Logging.min_enabled_level(::YieldingLogger) = Logging.Debug
+
+    GPUCompiler.@locked function f()
+        GPUCompiler.@safe_debug "safe_debug"
+        GPUCompiler.@safe_info "safe_info"
+        GPUCompiler.@safe_warn "safe_warn"
+        GPUCompiler.@safe_error "safe_error"
+    end
+
+    @test begin
+        @sync begin
+            Threads.@spawn begin
+                sleep(0.1)
+                @debug "debug"
+                sleep(0.1)
+                @info "info"
+                sleep(0.1)
+                @warn "warn"
+                sleep(0.1)
+                @error "error"
+                sleep(0.1)
+            end
+            Threads.@spawn Logging.with_logger(YieldingLogger()) do
+                sleep(0.1)
+                f()
+            end
+        end
+        true
+    end
+end
+
 end


### PR DESCRIPTION
GPUCompiler's safe loggers temporarily replace the global logger with a simple non-yielding logger. But this does nothing if a different current logger is set, in which case the loggers are unsafe and will error if the custom logger yields, as seen in https://github.com/fonsp/Pluto.jl/issues/3012. This PR changes the safe loggers to use `with_logger` instead of `global_logger`, to ensure that the yield-free logger is the one that's actually used.

In addition, I made it so that the safe logger inherits `Logging.shouldlog` from the current logger, not just `Logging.min_enabled_level`. The reasoning is that many loggers set `min_enabled_level` to the minimum possible value and rely on `shouldlog` for filtering; Pluto's logger is a case in point. I implemented a dedicated `SafeLogger` type to achieve this. Let me know if this is too heavy and you'd rather stick to a more barebones design without a dedicated type (in which case I think `min_enabled_level` should inherit from the global logger rather than the current logger).

I'm not sure how to write tests for this, since I'm not sure how to call the `@safe_<loglevel>` macros from a context where task switching raises an error. Suggestions or edits to the PR welcome.