### PR TITLE
Metal: switch order of unreachable rewrite passes.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.27.3"
+version = "0.27.4"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
`replace_unreachable!` currently doesn't handle trivial trapping functions, but `hide_noreturn!` does, so just switch the order of these two passes.

https://github.com/JuliaGPU/Metal.jl/pull/321#issuecomment-2313201384