### PR TITLE
Add exceptions to check_ir_values

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -90,7 +90,7 @@ function validate_ir(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module)
     errors = IRError[]
 
     # Metal never supports double precision
-    append!(errors, check_ir_values(mod, LLVM.DoubleType(), allow=(LLVM.FPExtInst,)))
+    append!(errors, check_ir_values(mod, LLVM.DoubleType()))
     append!(errors, check_ir_values(mod, LLVM.IntType(128)))
 
     errors

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -90,7 +90,7 @@ function validate_ir(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module)
     errors = IRError[]
 
     # Metal never supports double precision
-    append!(errors, check_ir_values(mod, LLVM.DoubleType()))
+    append!(errors, check_ir_values(mod, LLVM.DoubleType(), allow=(LLVM.FPExtInst,)))
     append!(errors, check_ir_values(mod, LLVM.IntType(128)))
 
     errors

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -322,7 +322,8 @@ function check_ir_values(mod::LLVM.Module, T_bad::LLVMType)
     errors = IRError[]
 
     for fun in functions(mod), bb in blocks(fun), inst in instructions(bb)
-        if value_type(inst) == T_bad || any(param->value_type(param) == T_bad, operands(inst))
+        if value_type(inst) == T_bad && !haskey(metadata(inst), "ir_check_ignore") ||
+           any(op -> value_type(op) == T_bad && !(op isa Instruction && haskey(metadata(op), "ir_check_ignore")), operands(inst))
             bt = backtrace(inst)
             push!(errors, ("use of $(string(T_bad)) value", bt, inst))
         end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -318,25 +318,15 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
 end
 
 # helper function to check if a LLVM module uses values of a certain type
-function check_ir_values(mod::LLVM.Module, T_bad::LLVMType; allow=())
+function check_ir_values(mod::LLVM.Module, T_bad::LLVMType)
     errors = IRError[]
 
     for fun in functions(mod), bb in blocks(fun), inst in instructions(bb)
-        if typeof(inst) in allow
-            continue
+        if value_type(inst) == T_bad && !haskey(metadata(inst), "ir_check_ignore") ||
+           any(op -> value_type(op) == T_bad && !(op isa Instruction && haskey(metadata(op), "ir_check_ignore")), operands(inst))
+            bt = backtrace(inst)
+            push!(errors, ("use of $(string(T_bad)) value", bt, inst))
         end
-
-        if haskey(metadata(inst), "ir_check_ignore")
-            continue
-        end
-
-        if value_type(inst) != T_bad &&
-           all(op -> value_type(op) != T_bad || (op isa Instruction && haskey(metadata(op), "ir_check_ignore")), operands(inst))
-           continue
-        end
-
-        bt = backtrace(inst)
-        push!(errors, ("use of $(string(T_bad)) value", bt, inst))
     end
 
     return errors

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -330,3 +330,16 @@ function check_ir_values(mod::LLVM.Module, T_bad::LLVMType)
 
     return errors
 end
+
+function check_ir_values(mod::LLVM.Module, T_bad)
+    errors = IRError[]
+
+    for fun in functions(mod), bb in blocks(fun), inst in instructions(bb)
+        if T_bad(inst) || any(T_bad, operands(inst))
+            bt = backtrace(inst)
+            push!(errors, ("use of $(string(inst))", bt, inst))
+        end
+    end
+
+    return errors
+end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -322,8 +322,7 @@ function check_ir_values(mod::LLVM.Module, T_bad::LLVMType)
     errors = IRError[]
 
     for fun in functions(mod), bb in blocks(fun), inst in instructions(bb)
-        if value_type(inst) == T_bad && !haskey(metadata(inst), "ir_check_ignore") ||
-           any(op -> value_type(op) == T_bad && !(op isa Instruction && haskey(metadata(op), "ir_check_ignore")), operands(inst))
+        if value_type(inst) == T_bad || any(param->value_type(param) == T_bad, operands(inst))
             bt = backtrace(inst)
             push!(errors, ("use of $(string(T_bad)) value", bt, inst))
         end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -317,24 +317,18 @@ function check_ir!(job, errors::Vector{IRError}, inst::LLVM.CallInst)
     return errors
 end
 
-# helper function to check if a LLVM module uses values of a certain type
-
-function check_illegal_value_type(inst::LLVM.Instruction, errors, T_bad::LLVMType)
-    if value_type(inst) == T_bad || any(param->value_type(param) == T_bad, operands(inst))
-        bt = backtrace(inst)
-        err = ("use of $(string(T_bad)) value", bt, inst)
-        push!(errors, err)
-    end
-end
-
-check_ir_values(mod::LLVM.Module, T_bad::LLVMType) = check_ir_values(mod, (x,errs)->check_illegal_value_type(x, errs, T_bad))
-
-function check_ir_values(mod::LLVM.Module, T_bad)
+# helper function to check for illegal values in an LLVM module
+function check_ir_values(mod::LLVM.Module, predicate, msg="value")
     errors = IRError[]
-
     for fun in functions(mod), bb in blocks(fun), inst in instructions(bb)
-        T_bad(inst, errors)
+        if predicate(inst) || any(predicate, operands(inst))
+            bt = backtrace(inst)
+            push!(errors, (msg, bt, inst))
+        end
     end
-
     return errors
+end
+## shorthand to check for illegal value types
+function check_ir_values(mod::LLVM.Module, T_bad::LLVMType)
+    check_ir_values(mod, val -> value_type(val) == T_bad, "use of $(string(T_bad)) value")
 end


### PR DESCRIPTION
Allow `double` for C's default argument promotions used in variable-length argument lists by introducing `ir_check_ignore` metadata and a allow argument for `check_ir_values` that is used to allow `fpext` in Metal.

needed for https://github.com/JuliaGPU/Metal.jl/pull/418