### PR TITLE
Fix and test mangling

### DIFF
--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -95,6 +95,8 @@ function mangle_param(t, substitutions=String[])
         end
 
         str
+    elseif isa(t, UnionAll)
+        mangle_param(t.body, substitutions)
     elseif isa(t, Union{Bool, Cchar, Cuchar, Cshort, Cushort, Cint, Cuint, Clong, Culong, Clonglong, Culonglong, Int128, UInt128})
         ts = t isa Bool       ? 'b' : # bool
              t isa Cchar      ? 'a' : # signed char

--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -46,7 +46,8 @@ function mangle_param(t, substitutions=String[])
         elseif sub == 1
             str = "S_"
         else
-            str = "S$(sub-2)_"
+            seq_id = uppercase(string(sub-2; base=36))
+            str = "S$(seq_id)_"
         end
 
         # encode typevars as template parameters

--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -117,6 +117,12 @@ function mangle_param(t, substitutions=String[])
             tn = 'n'*tn
         end
         "L$(ts)$(tn)E"
+    elseif t isa Float32
+        bits = string(reinterpret(UInt32, t); base=16)
+        "Lf$(bits)E"
+    elseif t isa Float64
+        bits = string(reinterpret(UInt64, t); base=16)
+        "Ld$(bits)E"
     else
         tn = safe_name(t)   # TODO: actually does support digits...
         if startswith(tn, r"\d")

--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -119,6 +119,10 @@ function mangle_param(t, substitutions=Any[])
              t isa UInt128    ? 'o' : # unsigned __int128
              error("Invalid type")
         tn = string(abs(t), base=10)
+        # for legibility, encode Julia-native integers as C-native integers, if possible
+        if t isa Int && typemin(Cint) <= t <= typemax(Cint)
+            ts = 'i'
+        end
         if t < 0
             tn = 'n'*tn
         end

--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -57,6 +57,17 @@ function mangle_param(t, substitutions=String[])
                 str *= mangle_param(t, substitutions)
             end
             str *= "E"
+
+            # handle substitutions
+            sub = findfirst(isequal(str), substitutions)
+            if sub === nothing
+                push!(substitutions, str)
+            elseif sub == 1
+                str = "S_"
+            else
+                seq_id = uppercase(string(sub-2; base=36))
+                str = "S$(seq_id)_"
+            end
         end
 
         str

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,6 +10,7 @@ SPIRV_LLVM_Translator_unified_jll = "85f0d8ed-5b39-5caa-b1ae-7472de402361"
 SPIRV_Tools_jll = "6ac6d60f-d740-5983-97d7-a4482c0689f4"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+demumble_jll = "1e29f10c-031c-5a83-9565-69cddfc27673"
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
I was finally fed up with some complex signatures not rendering nicely in the profiler, but it took a couple of hours to squash all the bugs. We can now successfully mangle the following:

```julia
julia> GPUCompiler.mangle_sig(Tuple{GPUArrays.var"#35#37", CUDA.CuKernelContext, CuDeviceMatrix{Float32, 1}, Base.Broadcast.Broadcasted{CUDA.CuArrayStyle{2, CUDA.DeviceMemory}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}, typeof(Base.literal_pow), Tuple{CUDA.CuRefValue{typeof(^)}, Base.Broadcast.Extruded{CuDeviceMatrix{Float32, 1}, Tuple{Bool, Bool}, Tuple{Int64, Int64}}, CUDA.CuRefValue{Val{2}}}}, Int64})
"_Z3_3515CuKernelContext13CuDeviceArrayI7Float32Li2ELi1EE11BroadcastedI12CuArrayStyleILi2E12DeviceMemoryE5TupleI5OneToI5Int64ESA_E11literal_powS7_I10CuRefValueI1_E8ExtrudedIS2_S7_I4BoolSH_ES7_IS9_S9_EESD_I3ValILi2EEEEES9_"

shell> c++filt _Z3_3515CuKernelContext13CuDeviceArrayI7Float32Li2ELi1EE11BroadcastedI12CuArrayStyleILi2E12DeviceMemoryE5TupleI5OneToI5Int64ESA_E11literal_powS7_I10CuRefValueI1_E8ExtrudedIS2_S7_I4BoolSH_ES7_IS9_S9_EESD_I3ValILi2EEEEES9_
_35(CuKernelContext, CuDeviceArray<Float32, 2, 1>, Broadcasted<CuArrayStyle<2, DeviceMemory>, Tuple<OneTo<Int64>, OneTo<Int64> >, literal_pow, Tuple<CuRefValue<_>, Extruded<CuDeviceArray<Float32, 2, 1>, Tuple<Bool, Bool>, Tuple<Int64, Int64> >, CuRefValue<Val<2> > > >, Int64)
```

Includes tests based on [demumble](https://github.com/nico/demumble), a `c++filt`-like tool.