### PR TITLE
Make GPUInterpreter extensible

### DIFF
--- a/test/bpf_testsetup.jl
+++ b/test/bpf_testsetup.jl
@@ -10,7 +10,8 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types);
-                    kernel::Bool=false, always_inline=false, kwargs...)
+                    kernel::Bool=false, always_inline=false,
+                    meta=nothing, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = BPFCompilerTarget()
     params = CompilerParams()

--- a/test/gcn_testsetup.jl
+++ b/test/gcn_testsetup.jl
@@ -10,11 +10,12 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types);
-                 kernel::Bool=false, always_inline=false, kwargs...)
+                 kernel::Bool=false, always_inline=false,
+                 meta=nothing, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
+    config = CompilerConfig(target, params; kernel, always_inline, meta)
     CompilerJob(source, config), kwargs
 end
 

--- a/test/metal_testsetup.jl
+++ b/test/metal_testsetup.jl
@@ -10,11 +10,12 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types);
-                    kernel::Bool=false, always_inline=false, kwargs...)
+                    kernel::Bool=false, always_inline=false,
+                    meta=nothing, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
+    config = CompilerConfig(target, params; kernel, always_inline, meta)
     CompilerJob(source, config), kwargs
 end
 

--- a/test/native_tests.jl
+++ b/test/native_tests.jl
@@ -43,12 +43,12 @@ end
 
             meth = only(methods(outer, (Int,)))
 
-            mis = filter(mi->mi.def == meth, keys(meta.compiled))
+            mis = filter(edge->edge.mi.def == meth, keys(meta.compiled))
             @test length(mis) == 1
 
-            other_mis = filter(mi->mi.def != meth, keys(meta.compiled))
+            other_mis = filter(edge->edge.mi.def != meth, keys(meta.compiled))
             @test length(other_mis) == 1
-            @test only(other_mis).def in methods(inner)
+            @test only(other_mis).mi.def in methods(inner)
         end
     end
 
@@ -63,11 +63,11 @@ end
 
             meth = only(methods(foo, (Float64,)))
 
-            mis = filter(mi->mi.def == meth, keys(meta.compiled))
+            mis = filter(edge->edge.mi.def == meth, keys(meta.compiled))
             @test length(mis) == 1
 
-            inner_methods = filter(keys(meta.compiled)) do mi
-                mi.def in methods(inner) && mi.specTypes == Tuple{typeof(inner), Float64}
+            inner_methods = filter(keys(meta.compiled)) do edge
+                edge.mi.def in methods(inner) && edge.mi.specTypes == Tuple{typeof(inner), Float64}
             end
             @test length(inner_methods) == 1
         end
@@ -166,7 +166,7 @@ end
     @testset "deferred" begin
         @gensym child kernel unrelated
         @eval @noinline $child(i) = i
-        @eval $kernel(i) = GPUCompiler.var"gpuc.deferred"($child, i)
+        @eval $kernel(i) = GPUCompiler.var"gpuc.deferred"(nothing, $child, i)
 
         # smoke test
         job, _ = Native.create_job(eval(kernel), (Int64,))

--- a/test/native_testsetup.jl
+++ b/test/native_testsetup.jl
@@ -26,11 +26,12 @@ GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.config.pa
 
 function create_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                     entry_abi=:specfunc, entry_safepoint::Bool=false, always_inline=false,
-                    method_table=test_method_table, kwargs...)
+                    method_table=test_method_table,
+                    meta=nothing, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = NativeCompilerTarget()
     params = CompilerParams(entry_safepoint, method_table)
-    config = CompilerConfig(target, params; kernel, entry_abi, always_inline)
+    config = CompilerConfig(target, params; kernel, entry_abi, always_inline, meta)
     CompilerJob(source, config), kwargs
 end
 

--- a/test/plugin_testsetup.jl
+++ b/test/plugin_testsetup.jl
@@ -28,4 +28,47 @@ end
 GPUCompiler.register_plugin!("gpucompiler.mark", false, 
                              pipeline_callback=remove_mark!)
 
+current_inlinestate() = nothing
+
+abstract type InlineStateMeta end
+struct AlwaysInlineMeta <: InlineStateMeta end
+struct NeverInlineMeta <: InlineStateMeta end
+
+import GPUCompiler: abstract_call_known, GPUInterpreter
+import Core.Compiler: CallMeta, Effects, NoCallInfo, ArgInfo,
+                      StmtInfo, AbsIntState, EFFECTS_TOTAL,
+                      MethodResultPure
+
+function abstract_call_known(meta::InlineStateMeta, interp::GPUInterpreter, @nospecialize(f),
+                             arginfo::ArgInfo, si::StmtInfo, sv::AbsIntState, max_methods::Int)
+    (; fargs, argtypes) = arginfo
+
+    if f === current_inlinestate
+        if length(argtypes) != 1
+            @static if VERSION < v"1.11.0-"
+                return CallMeta(Union{}, Effects(), NoCallInfo())
+            else
+                return CallMeta(Union{}, Union{}, Effects(), NoCallInfo())
+            end
+        end
+        @static if VERSION < v"1.11.0-"
+            return CallMeta(Core.Const(meta), EFFECTS_TOTAL, MethodResultPure())
+        else
+            return CallMeta(Core.Const(meta), Union{}, EFFECTS_TOTAL, MethodResultPure())
+        end
+    end
+    return nothing
+end
+
+import GPUCompiler: inlining_handler, NoInlineCallInfo, AlwaysInlineCallInfo
+function inlining_handler(meta::InlineStateMeta, interp::GPUInterpreter, @nospecialize(atype), callinfo)
+    if meta isa NeverInlineMeta
+        return NoInlineCallInfo(callinfo, atype, :default)
+    elseif meta isa AlwaysInlineMeta
+        return AlwaysInlineCallInfo(callinfo, atype)
+    end
+    return nothing
+end
+
+
 end

--- a/test/ptx_testsetup.jl
+++ b/test/ptx_testsetup.jl
@@ -39,13 +39,13 @@ GPUCompiler.runtime_module(::PTXCompilerJob) = PTXTestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
                     minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
-                    maxregs=nothing, always_inline=false, kwargs...)
+                    maxregs=nothing, always_inline=false, meta=nothing, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = PTXCompilerTarget(;cap=v"7.0",
                                minthreads, maxthreads,
                                blocks_per_sm, maxregs)
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
+    config = CompilerConfig(target, params; kernel, always_inline, meta)
     CompilerJob(source, config), kwargs
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ runtests(GPUCompiler; nworkers=min(Sys.CPU_THREADS,4), nworker_threads=1,
         end
     end
 
-    if ti.name in ["PTX", "GCN", "PTX precompile"] && Sys.isapple()
+    if ti.name in ["PTX", "GCN", "PTX precompile", "PTX plugin"] && Sys.isapple()
         # support for AMDGPU and NVTX on macOS has been removed from Julia's LLVM build
         return false
     end

--- a/test/spirv_testsetup.jl
+++ b/test/spirv_testsetup.jl
@@ -11,11 +11,12 @@ GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types);
                    kernel::Bool=false, always_inline=false,
-                   supports_fp16=true, supports_fp64=true, kwargs...)
+                   supports_fp16=true, supports_fp64=true, 
+                   meta=nothing, kwargs...)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = SPIRVCompilerTarget(; supports_fp16, supports_fp64)
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
+    config = CompilerConfig(target, params; kernel, always_inline, meta)
     CompilerJob(source, config), kwargs
 end
 


### PR DESCRIPTION
Currently Enzyme uses it's own AbstractInterpreter, in particular to
handle inlining blocking of functions with custom rules and to handle
nested autodiff operations.

- [ ] Create a version of Enzyme with this
- [ ] Support a version of `gpuc.deferred(meta)`