### PR TITLE
Validator: Permit all fieldless objects.

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -88,6 +88,12 @@ function check_invocation(@nospecialize(job::CompilerJob))
                    This is a CPU-only object not supported by GPUCompiler."""))
         end
 
+        # If an object doesn't have fields, it can only be used by identity, so we can allow
+        # them to be passed to the GPU (this also applies to e.g. Symbols).
+        if fieldcount(dt) == 0
+            continue
+        end
+
         if !isbitstype(dt)
             throw(KernelError(job, "passing non-bitstype argument",
                 """Argument $arg_i to your kernel function is of type $dt, which is not a bitstype:

--- a/test/native_tests.jl
+++ b/test/native_tests.jl
@@ -162,6 +162,18 @@ end
         ir = fetch(t)
         @test contains(ir, r"add i64 %\d+, 3")
     end
+
+    @testset "allowed mutable types" begin
+        # when types have no fields, we should always allow them
+        mod = @eval module $(gensym())
+            struct Empty end
+        end
+
+        Native.code_execution(Returns(nothing), (mod.Empty,))
+
+        # this also applies to Symbols
+        Native.code_execution(Returns(nothing), (Symbol,))
+    end
 end
 
 ############################################################################################


### PR DESCRIPTION
Since we cannot load from these, we can tolerate passing them to a GPU. This makes it possible to use symbols.