### PR TITLE
Support code emission of nvptx on Apple

### DIFF
--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -13,6 +13,9 @@ GCNCompilerTarget(dev_isa; features="") = GCNCompilerTarget(dev_isa, features)
 llvm_triple(::GCNCompilerTarget) = "amdgcn-amd-amdhsa"
 
 function llvm_machine(target::GCNCompilerTarget)
+    @static if :AMDGPU ∉ LLVM.backends()
+        return nothing
+    end
     triple = llvm_triple(target)
     t = Target(triple=triple)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -23,6 +23,7 @@ source_code(@nospecialize(target::AbstractCompilerTarget)) = "text"
 
 llvm_triple(@nospecialize(target::AbstractCompilerTarget)) = error("Not implemented")
 
+# may return nothing if the target is not support by the current version of LLVM.
 function llvm_machine(@nospecialize(target::AbstractCompilerTarget))
     triple = llvm_triple(target)
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -48,10 +48,14 @@ function llvm_machine(target::PTXCompilerTarget)
     triple = llvm_triple(target)
 
     # Julia does not ship NVPTX support in its LLVM on Apple
+    # We fail to run passes therefore during a cross compile on Apple
+    # In that case, just use the local machine triple (since we can't
+    # run nvptx locally anyways, and the only use case is a cross
+    # compile to local architectures).
     t = @static if !Sys.isapple()
         Target(triple=triple)
     else
-        Target(triple="")
+        Target(triple=Sys.MACHINE)
     end
 
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -45,21 +45,17 @@ source_code(target::PTXCompilerTarget) = "ptx"
 llvm_triple(target::PTXCompilerTarget) = Int===Int64 ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda"
 
 function llvm_machine(target::PTXCompilerTarget)
-    # Julia does not ship NVPTX support in its LLVM on Apple
-    # We fail to run passes therefore during a cross compile on Apple
-    # In that case, don't pass a TM.
-    @static if !Sys.isapple()
-        triple = llvm_triple(target)
-        t = Target(triple=triple)
-    
-        tm = TargetMachine(t, triple, "sm_$(target.cap.major)$(target.cap.minor)",
-                           "+ptx$(target.ptx.major)$(target.ptx.minor)")
-        asm_verbosity!(tm, true)
-    
-        return tm
-    else
+    @static if :NVPTX ∉ LLVM.backends()
         return nothing
     end
+    triple = llvm_triple(target)
+    t = Target(triple=triple)
+
+    tm = TargetMachine(t, triple, "sm_$(target.cap.major)$(target.cap.minor)",
+                        "+ptx$(target.ptx.major)$(target.ptx.minor)")
+    asm_verbosity!(tm, true)
+
+    return tm
 end
 
 # the default datalayout does not match the one in the NVPTX user guide

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -51,7 +51,7 @@ function llvm_machine(target::PTXCompilerTarget)
     t = @static if !Sys.isapple()
         Target(triple=triple)
     else
-        Target()
+        Target(triple="")
     end
 
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -45,14 +45,21 @@ source_code(target::PTXCompilerTarget) = "ptx"
 llvm_triple(target::PTXCompilerTarget) = Int===Int64 ? "nvptx64-nvidia-cuda" : "nvptx-nvidia-cuda"
 
 function llvm_machine(target::PTXCompilerTarget)
-    triple = llvm_triple(target)
-    t = Target(triple=triple)
-
-    tm = TargetMachine(t, triple, "sm_$(target.cap.major)$(target.cap.minor)",
-                       "+ptx$(target.ptx.major)$(target.ptx.minor)")
-    asm_verbosity!(tm, true)
-
-    return tm
+    # Julia does not ship NVPTX support in its LLVM on Apple
+    # We fail to run passes therefore during a cross compile on Apple
+    # In that case, don't pass a TM.
+    @static if !Sys.isapple()
+        triple = llvm_triple(target)
+        t = Target(triple=triple)
+    
+        tm = TargetMachine(t, triple, "sm_$(target.cap.major)$(target.cap.minor)",
+                           "+ptx$(target.ptx.major)$(target.ptx.minor)")
+        asm_verbosity!(tm, true)
+    
+        return tm
+    else
+        return nothing
+    end
 end
 
 # the default datalayout does not match the one in the NVPTX user guide
@@ -137,14 +144,7 @@ function finish_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
     @dispose pb=NewPMPassBuilder() begin
         add!(pb, RecomputeGlobalsAAPass())
         add!(pb, GlobalOptPass())
-        # Julia does not ship NVPTX support in its LLVM on Apple
-        # We fail to run passes therefore during a cross compile on Apple
-        # In that case, don't pass a TM.
-        @static if !Sys.isapple()
-          run!(pb, mod, llvm_machine(job.config.target))
-        else
-          run!(pb, mod)
-        end
+        run!(pb, mod, llvm_machine(job.config.target))
     end
 
     return entry

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -46,7 +46,14 @@ llvm_triple(target::PTXCompilerTarget) = Int===Int64 ? "nvptx64-nvidia-cuda" : "
 
 function llvm_machine(target::PTXCompilerTarget)
     triple = llvm_triple(target)
-    t = Target(triple=triple)
+
+    # Julia does not ship NVPTX support in its LLVM on Apple
+    t = @static if !Sys.isapple()
+        Target(triple=triple)
+    else
+        Target()
+    end
+
 
     tm = TargetMachine(t, triple, "sm_$(target.cap.major)$(target.cap.minor)",
                        "+ptx$(target.ptx.major)$(target.ptx.minor)")

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -52,7 +52,7 @@ function llvm_machine(target::PTXCompilerTarget)
     t = Target(triple=triple)
 
     tm = TargetMachine(t, triple, "sm_$(target.cap.major)$(target.cap.minor)",
-                        "+ptx$(target.ptx.major)$(target.ptx.minor)")
+                       "+ptx$(target.ptx.major)$(target.ptx.minor)")
     asm_verbosity!(tm, true)
 
     return tm

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -1,3 +1,4 @@
+if :AMDGPU in LLVM.backends()
 @testset "IR" begin
 
 @testset "kernel calling convention" begin
@@ -14,7 +15,6 @@ end
 end
 
 ############################################################################################
-if :AMDGPU in LLVM.backends()
 @testset "assembly" begin
 
 @testset "skip scalar trap" begin

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -14,7 +14,7 @@ end
 end
 
 ############################################################################################
-
+if :AMDGPU in LLVM.backends()
 @testset "assembly" begin
 
 @testset "skip scalar trap" begin
@@ -214,3 +214,4 @@ end
 end
 
 end
+end # :AMDGPU in LLVM.backends()

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -124,7 +124,7 @@ end
 end
 
 ############################################################################################
-
+@static if !Sys.isapple()
 @testset "assembly" begin
 
 @testset "child functions" begin
@@ -324,6 +324,7 @@ end
 
 
     @test !occursin("gpu_gc_pool_alloc", asm)
+end
 end
 
 @testset "float boxes" begin

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -124,7 +124,7 @@ end
 end
 
 ############################################################################################
-@static if !Sys.isapple()
+if :NVPTX in LLVM.backends()
 @testset "assembly" begin
 
 @testset "child functions" begin
@@ -325,7 +325,6 @@ end
 
     @test !occursin("gpu_gc_pool_alloc", asm)
 end
-end
 
 @testset "float boxes" begin
     function kernel(a,b)
@@ -344,3 +343,4 @@ end
 end
 
 end
+end # NVPTX in LLVM.backends()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,10 +116,6 @@ end
         push!(skip_tests, "metal")
     end
 end
-if Sys.isapple()
-    # support for AMDGPU and NVTX on macOS has been removed from Julia's LLVM build
-    append!(skip_tests, ["gcn"])
-end
 if !(SPIRV_LLVM_Translator_unified_jll.is_available() && SPIRV_Tools_jll.is_available())
     # SPIRV needs it's tools to be available
     push!(skip_tests, "spirv")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,7 +118,7 @@ end
 end
 if Sys.isapple()
     # support for AMDGPU and NVTX on macOS has been removed from Julia's LLVM build
-    append!(skip_tests, ["ptx", "gcn"])
+    append!(skip_tests, ["gcn"])
 end
 if !(SPIRV_LLVM_Translator_unified_jll.is_available() && SPIRV_Tools_jll.is_available())
     # SPIRV needs it's tools to be available


### PR DESCRIPTION
When cross compiling a cuda kernel (for eventual CPU execution) on Apple, GPUCompiler presently errs:

```
Square Kernel: Error During Test at /Users/wmoses/git/Reactant.jl/test/integration/cuda.jl:22
  Got exception outside of a @test
  ArgumentError: No available targets are compatible with triple "nvptx64-nvidia-cuda"
  Stacktrace:
    [1] LLVM.Target(; name::Nothing, triple::String)
      @ LLVM ~/.julia/packages/LLVM/b3kFs/src/target.jl:33
    [2] Target
      @ ~/.julia/packages/LLVM/b3kFs/src/target.jl:23 [inlined]
    [3] llvm_machine(target::GPUCompiler.PTXCompilerTarget)
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/ptx.jl:49
    [4] macro expansion
      @ ~/.julia/packages/GPUCompiler/Nxf8r/src/ptx.jl:140 [inlined]
    [5] macro expansion
      @ ~/.julia/packages/LLVM/b3kFs/src/base.jl:97 [inlined]
    [6] finish_module!(job::GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget}, mod::LLVM.Module, entry::LLVM.Function)
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/ptx.jl:137
    [7] finish_module!(job::GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}, mod::LLVM.Module, entry::LLVM.Function)
      @ CUDA ~/.julia/packages/CUDA/1kIOw/src/compiler/compilation.jl:58
    [8] macro expansion
      @ ~/.julia/packages/GPUCompiler/Nxf8r/src/driver.jl:183 [inlined]
    [9] emit_llvm(job::GPUCompiler.CompilerJob; toplevel::Bool, libraries::Bool, optimize::Bool, cleanup::Bool, validate::Bool, only_entry::Bool)
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/utils.jl:108
   [10] emit_llvm
      @ ~/.julia/packages/GPUCompiler/Nxf8r/src/utils.jl:106 [inlined]
   [11] codegen(output::Symbol, job::GPUCompiler.CompilerJob; toplevel::Bool, libraries::Bool, optimize::Bool, cleanup::Bool, validate::Bool, strip::Bool, only_entry::Bool, parent_job::Nothing)
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/driver.jl:100
   [12] compile(target::Symbol, job::GPUCompiler.CompilerJob; kwargs::@Kwargs{optimize::Bool, cleanup::Bool, validate::Bool, libraries::Bool})
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/driver.jl:79
   [13] compile
      @ ~/.julia/packages/GPUCompiler/Nxf8r/src/driver.jl:74 [inlined]
   [14] (::ReactantCUDAExt.var"#7#10"{GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}})(ctx::LLVM.Context)
      @ ReactantCUDAExt ~/git/Reactant.jl/ext/ReactantCUDAExt.jl:344
   [15] JuliaContext(f::ReactantCUDAExt.var"#7#10"{GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}}; kwargs::@Kwargs{})
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/driver.jl:34
   [16] JuliaContext
      @ ~/.julia/packages/GPUCompiler/Nxf8r/src/driver.jl:25 [inlined]
   [17] compile(job::GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams})
      @ ReactantCUDAExt ~/git/Reactant.jl/ext/ReactantCUDAExt.jl:343
   [18] actual_compilation(cache::Dict{Any, ReactantCUDAExt.LLVMFunc}, src::Core.MethodInstance, world::UInt64, cfg::GPUCompiler.CompilerConfig{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}, compiler::typeof(ReactantCUDAExt.compile), linker::typeof(ReactantCUDAExt.link))
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/execution.jl:237
   [19] cached_compilation(cache::Dict{Any, ReactantCUDAExt.LLVMFunc}, src::Core.MethodInstance, cfg::GPUCompiler.CompilerConfig{GPUCompiler.PTXCompilerTarget, CUDA.CUDACompilerParams}, compiler::Function, linker::Function)
      @ GPUCompiler ~/.julia/packages/GPUCompiler/Nxf8r/src/execution.jl:151
   [20] macro expansion
      @ ~/git/Reactant.jl/ext/ReactantCUDAExt.jl:772 [inlined]
   [21] macro expansion
      @ ./lock.jl:267 [inlined]
   [22] cufunction(f::typeof(Main.var"##CUDA#241".square_kernel!), tt::Type{Tuple{ReactantCUDAExt.CuTracedArray{Int64, 1, 1, (64,)}, ReactantCUDAExt.CuTracedArray{Int64, 1, 1, (64,)}}}; kwargs::@Kwargs{})
      @ ReactantCUDAExt ~/git/Reactant.jl/ext/ReactantCUDAExt.jl:750
   [23] #cufunction
      @ ~/git/Reactant.jl/ext/ReactantCUDAExt.jl:747 [inlined]
   [24] cufunction(none::typeof(Main.var"##CUDA#241".square_kernel!), none::Type{Tuple{ReactantCUDAExt.CuTracedArray{Int64, 1, 1, (64,)}, ReactantCUDAExt.CuTracedArray{Int64, 1, 1, (64,)}}})
      @ Reactant ./<missing>:0
   [25] #cufunction
      @ ~/git/Reactant.jl/ext/ReactantCUDAExt.jl:747 [inlined]
   [26] call_with_reactant(::typeof(CUDA.cufunction), ::typeof(Main.var"##CUDA#241".square_kernel!), ::Type{Tuple{ReactantCUDAExt.CuTracedArray{Int64, 1, 1, (64,)}, ReactantCUDAExt.CuTracedArray{Int64, 1, 1, (64,)}}})
      @ Reactant ~/git/Reactant.jl/src/utils.jl:0
   [27] macro expansion
      @ ~/.julia/packages/CUDA/1kIOw/src/compiler/execution.jl:112 [inlined]
   [28] square!
      @ ~/git/Reactant.jl/test/integration/cuda.jl:15 [inlined]
   [29] square!(none::Reactant.TracedRArray{Int64, 1}, none::Reactant.TracedRArray{Int64, 1})
      @ Reactant ./<missing>:0
   [30] macro expansion
      @ ~/.julia/packages/CUDA/1kIOw/src/compiler/execution.jl:108 [inlined]
   [31] square!
      @ ~/git/Reactant.jl/test/integration/cuda.jl:15 [inlined]
   [32] call_with_reactant(::typeof(Main.var"##CUDA#241".square!), ::Reactant.TracedRArray{Int64, 1}, ::Reactant.TracedRArray{Int64, 1})
      @ Reactant ~/git/Reactant.jl/src/utils.jl:0
   [33] make_mlir_fn(f::Function, args::Tuple{ConcreteRArray{Int64, 1}, ConcreteRArray{Int64, 1}}, kwargs::Tuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, do_transpose::Bool, no_args_in_result::Bool)
      @ Reactant.TracedUtils ~/git/Reactant.jl/src/TracedUtils.jl:216
   [34] make_mlir_fn
      @ ~/git/Reactant.jl/src/TracedUtils.jl:129 [inlined]
   [35] compile_mlir!(mod::Reactant.MLIR.IR.Module, f::Function, args::Tuple{ConcreteRArray{Int64, 1}, ConcreteRArray{Int64, 1}}; optimize::Bool, no_nan::Bool, backend::String)
      @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:448
   [36] compile_mlir!
      @ ~/git/Reactant.jl/src/Compiler.jl:437 [inlined]
   [37] compile_xla(f::Function, args::Tuple{ConcreteRArray{Int64, 1}, ConcreteRArray{Int64, 1}}; client::Nothing, optimize::Bool, no_nan::Bool, device::Nothing)
      @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:1005
   [38] compile_xla
      @ ~/git/Reactant.jl/src/Compiler.jl:984 [inlined]
   [39] compile(f::Function, args::Tuple{ConcreteRArray{Int64, 1}, ConcreteRArray{Int64, 1}}; sync::Bool, kwargs::@Kwargs{client::Nothing, no_nan::Bool, device::Nothing, optimize::Bool})
      @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:1057
   [40] macro expansion
      @ ~/git/Reactant.jl/src/Compiler.jl:707 [inlined]
   [41] macro expansion
      @ ~/git/Reactant.jl/test/integration/cuda.jl:26 [inlined]
   [42] macro expansion
      @ ~/.julia/juliaup/julia-1.10.8+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
   [43] top-level scope
      @ ~/git/Reactant.jl/test/integration/cuda.jl:23
   [44] include(mod::Module, _path::String)
      @ Base ./Base.jl:495
   [45] include(x::String)
      @ Main.var"##CUDA#241" ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:28
   [46] macro expansion
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:24 [inlined]
   [47] macro expansion
      @ ~/.julia/juliaup/julia-1.10.8+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
   [48] top-level scope
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:24
   [49] eval(m::Module, e::Any)
      @ Core ./boot.jl:385
   [50] macro expansion
      @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:28 [inlined]
   [51] macro expansion
      @ ~/git/Reactant.jl/test/runtests.jl:67 [inlined]
   [52] macro expansion
      @ ~/.julia/juliaup/julia-1.10.8+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
   [53] top-level scope
      @ ~/git/Reactant.jl/test/runtests.jl:45
   [54] include(fname::String)
      @ Base.MainInclude ./client.jl:494
   [55] top-level scope
      @ none:6
   [56] eval
      @ ./boot.jl:385 [inlined]
   [57] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:296
```