### PR TITLE
Resolve binding MethodError directly on 1.12

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -32,6 +32,7 @@ function unsafe_function_from_type(ft::Type)
         Ref{ft}()[]
     end
 end
+global MethodError
 function MethodError(ft::Type{<:Function}, tt::Type, world::Integer=typemax(UInt))
     Base.MethodError(unsafe_function_from_type(ft), tt, world)
 end


### PR DESCRIPTION
`MethodError` is pulled in implicitly and we need to disambiguate our usage here

x-ref: https://github.com/JuliaLang/julia/issues/57290

ought to fix the GPUCompiler issue in https://github.com/JuliaLang/julia/issues/57332
