### PR TITLE
Move arguments to compile/codegen into the CompilerConfig struct

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -199,8 +199,7 @@ const __llvm_initialized = Ref(false)
                 # cached compilation
                 dyn_entry_fn = get!(jobs, dyn_job) do
                     config = CompilerConfig(dyn_job.config; toplevel=false)
-                    dyn_ir, dyn_meta =
-                        codegen(:llvm, CompilerJob(dyn_job; config, parent=job))
+                    dyn_ir, dyn_meta = codegen(:llvm, CompilerJob(dyn_job; config))
                     dyn_entry_fn = LLVM.name(dyn_meta.entry)
                     merge!(compiled, dyn_meta.compiled)
                     @assert context(dyn_ir) == context(ir)

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -53,24 +53,31 @@ Compile a `job` to one of the following formats as specified by the `target` arg
 `:julia` for Julia IR, `:llvm` for LLVM IR and `:asm` for machine code.
 """
 function compile(target::Symbol, @nospecialize(job::CompilerJob); kwargs...)
+    # XXX: remove on next major version
     if !isempty(kwargs)
         Base.depwarn("The GPUCompiler `compile` API does not take keyword arguments anymore. Use CompilerConfig instead.", :compile)
         config = CompilerConfig(job.config; kwargs...)
         job = CompilerJob(job.source, config)
     end
+
     if compile_hook[] !== nothing
         compile_hook[](job)
     end
 
-    return codegen(target, job)
+    return compile_unhooked(target, job)
 end
 
+# XXX: remove on next major version
 function codegen(output::Symbol, @nospecialize(job::CompilerJob); kwargs...)
     if !isempty(kwargs)
-        Base.depwarn("The GPUCompiler `codegen` API does not take keyword arguments anymore. Use CompilerConfig instead.", :codegen)
+        Base.depwarn("The GPUCompiler `codegen` function is an internal API. Use `GPUCompiler.compile` (with any kwargs passed to `CompilerConfig`) instead.", :codegen)
         config = CompilerConfig(job.config; kwargs...)
         job = CompilerJob(job.source, config)
     end
+    compile_unhooked(output, job)
+end
+
+function compile_unhooked(output::Symbol, @nospecialize(job::CompilerJob); kwargs...)
     if context(; throw_error=false) === nothing
         error("No active LLVM context. Use `JuliaContext()` do-block syntax to create one.")
     end
@@ -144,7 +151,14 @@ end
 
 const __llvm_initialized = Ref(false)
 
-@locked function emit_llvm(@nospecialize(job::CompilerJob))
+@locked function emit_llvm(@nospecialize(job::CompilerJob); kwargs...)
+    # XXX: remove on next major version
+    if !isempty(kwargs)
+        Base.depwarn("The GPUCompiler `emit_llvm` function is an internal API. Use `GPUCompiler.compile` (with any kwargs passed to `CompilerConfig`) instead.", :emit_llvm)
+        config = CompilerConfig(job.config; kwargs...)
+        job = CompilerJob(job.source, config)
+    end
+
     if !__llvm_initialized[]
         InitializeAllTargets()
         InitializeAllTargetInfos()

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -52,7 +52,12 @@ const compile_hook = Ref{Union{Nothing,Function}}(nothing)
 Compile a `job` to one of the following formats as specified by the `target` argument:
 `:julia` for Julia IR, `:llvm` for LLVM IR and `:asm` for machine code.
 """
-function compile(target::Symbol, @nospecialize(job::CompilerJob))
+function compile(target::Symbol, @nospecialize(job::CompilerJob); kwargs...)
+    if !isempty(kwargs)
+        Base.depwarn("The GPUCompiler `compile` API does not take keyword arguments anymore. Use CompilerConfig instead.", :compile)
+        config = CompilerConfig(job.config; kwargs...)
+        job = CompilerJob(job.source, config)
+    end
     if compile_hook[] !== nothing
         compile_hook[](job)
     end
@@ -60,7 +65,12 @@ function compile(target::Symbol, @nospecialize(job::CompilerJob))
     return codegen(target, job)
 end
 
-function codegen(output::Symbol, @nospecialize(job::CompilerJob))
+function codegen(output::Symbol, @nospecialize(job::CompilerJob); kwargs...)
+    if !isempty(kwargs)
+        Base.depwarn("The GPUCompiler `codegen` API does not take keyword arguments anymore. Use CompilerConfig instead.", :codegen)
+        config = CompilerConfig(job.config; kwargs...)
+        job = CompilerJob(job.source, config)
+    end
     if context(; throw_error=false) === nothing
         error("No active LLVM context. Use `JuliaContext()` do-block syntax to create one.")
     end

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -270,7 +270,16 @@ end
         obj = linker(job, asm)
 
         if ci === nothing
-            ci = ci_cache_lookup(ci_cache(job), src, world, world)::CodeInstance
+            ci = ci_cache_lookup(ci_cache(job), src, world, world)
+            if ci === nothing
+                error("""Did not find CodeInstance for $job.
+
+                         Pleaase make sure that the `compiler` function passed to `cached_compilation`
+                         invokes GPUCompiler with exactly the same configuration as passed to the API.
+
+                         Note that you should do this by calling `GPUCompiler.compile`, and not by
+                         using reflection functions (which alter the compiler configuration).""")
+            end
             key = (ci, cfg)
         end
         cache[key] = obj

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -135,7 +135,7 @@ session-dependent objects (e.g., a `CuModule`).
 """
 function cached_compilation(cache::AbstractDict{<:Any,V},
                             src::MethodInstance, cfg::CompilerConfig,
-                            compiler::Function, linker::Function; kwargs...) where {V}
+                            compiler::Function, linker::Function) where {V}
     # NOTE: we index the cach both using (mi, world, cfg) keys, for the fast look-up,
     #       and using CodeInfo keys for the slow look-up. we need to cache both for
     #       performance, but cannot use a separate private cache for the ci->obj lookup
@@ -156,7 +156,7 @@ function cached_compilation(cache::AbstractDict{<:Any,V},
     unlock(cache_lock)
 
     if obj === nothing || compile_hook[] !== nothing
-        obj = actual_compilation(cache, src, world, cfg, compiler, linker; kwargs...)::V
+        obj = actual_compilation(cache, src, world, cfg, compiler, linker)::V
         lock(cache_lock)
         cache[key] = obj
         unlock(cache_lock)
@@ -196,9 +196,8 @@ struct DiskCacheEntry
 end
 
 @noinline function actual_compilation(cache::AbstractDict, src::MethodInstance, world::UInt,
-                                      cfg::CompilerConfig, compiler::Function, linker::Function;
-                                      kwargs...)
-    job = CompilerJob(src, cfg, world; kwargs...)
+                                      cfg::CompilerConfig, compiler::Function, linker::Function)
+    job = CompilerJob(src, cfg, world)
     obj = nothing
 
     # fast path: find an applicable CodeInstance and see if we have compiled it before

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -201,6 +201,7 @@ function Base.hash(job::CompilerJob, h::UInt)
     return h
 end
 
+
 ## default definitions that can be overridden to influence GPUCompiler's behavior
 
 # Has the runtime available and does not require special handling

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -202,6 +202,15 @@ CompilerJob(job::CompilerJob; source=job.source, config=job.config, world=job.wo
             toplevel=job.toplevel, parent=job.parent) =
     CompilerJob(source, config, world; toplevel, parent)
 
+function Base.hash(job::CompilerJob, h::UInt)
+    h = hash(job.source, h)
+    h = hash(job.config, h)
+    h = hash(job.world, h)
+
+    h = hash(job.toplevel, h)
+    h = hash(job.parent, h)
+    return h
+end
 
 ## default definitions that can be overridden to influence GPUCompiler's behavior
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -75,27 +75,26 @@ and `params`.
 
 Several keyword arguments can be used to customize the compilation process:
 
-- `kernel`: specifies if the function should be compiled as a kernel, or as a regular
-   function. This is used to determine the calling convention and for validation purposes.
-- `entry_abi`: can be either `:specfunc` the default, or `:func`. `:specfunc` expects the
-   arguments to be passed in registers, simple return values are returned in registers as
-   well, and complex return values are returned on the stack using `sret`, the calling
-   convention is `fastcc`. The `:func` abi is simpler with a calling convention of the first
-   argument being the function itself (to support closures), the second argument being a
-   pointer to a vector of boxed Julia values and the third argument being the number of
-   values, the return value will also be boxed. The `:func` abi will internally call the
-   `:specfunc` abi, but is generally easier to invoke directly.
+- `kernel`: specifies if the function should be compiled as a kernel (the default) or as a
+   plain function. This toggles certain optimizations, rewrites and validations.
+- `entry_abi`: can be either `:specfunc` (the default), or `:func`.
+   - `:specfunc` expects the arguments to be passed in registers, simple return values are
+     returned in registers as well, and complex return values are returned on the stack
+     using `sret`, the calling convention is `fastcc`.
+   - The `:func` abi is simpler with a calling convention of the first argument being the
+     function itself (to support closures), the second argument being a pointer to a vector
+     of boxed Julia values and the third argument being the number of values, the return
+     value will also be boxed. The `:func` abi will internally call the `:specfunc` abi, but
+     is generally easier to invoke directly.
 - `name`: the name that will be used for the entrypoint function. If `nothing` (the
    default), the name will be generated automatically.
 - `always_inline` specifies if the Julia front-end should inline all functions into one if
    possible.
-- `libraries`: link the GPU runtime and `libdevice` libraries (default: true, if toplevel)
-- `optimize`: optimize the code (default: true, if toplevel)
-- `cleanup`: run cleanup passes on the code (default: true, if toplevel)
-- `validate`: enable optional validation of input and outputs (default: true, if toplevel)
+- `libraries`: link the GPU runtime and `libdevice` libraries (default: true)
+- `optimize`: optimize the code (default: true)
+- `cleanup`: run cleanup passes on the code (default: true)
+- `validate`: enable optional validation of input and outputs (default: true)
 - `strip`: strip non-functional metadata and debug information (default: false)
-- `only_entry`: only keep the entry function, remove all others (default: false).
-   This option is only for internal use, to implement reflection's `dump_module`.
 """
 struct CompilerConfig{T,P}
     target::T
@@ -111,6 +110,8 @@ struct CompilerConfig{T,P}
     cleanup::Bool
     validate::Bool
     strip::Bool
+
+    # internal
     only_entry::Bool
 
     function CompilerConfig(target::AbstractCompilerTarget, params::AbstractCompilerParams;

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -27,12 +27,12 @@ using PrecompileTools: @setup_workload, @compile_workload
         target = NativeCompilerTarget()
         params = precompile_module.DummyCompilerParams()
         config = CompilerConfig(target, params)
-        job = CompilerJob(source, config)
+        # XXX: on Windows, compiling the GPU runtime leaks GPU code in the native cache,
+        #      so prevent building the runtime library (see JuliaGPU/GPUCompiler.jl#601)
+        job = CompilerJob(source, config; libraries=false)
 
         JuliaContext() do ctx
-            # XXX: on Windows, compiling the GPU runtime leaks GPU code in the native cache,
-            #      so prevent building the runtime library (see JuliaGPU/GPUCompiler.jl#601)
-            GPUCompiler.compile(:asm, job; libraries=false)
+            GPUCompiler.compile(:asm, job)
         end
     end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -26,10 +26,10 @@ using PrecompileTools: @setup_workload, @compile_workload
         source = methodinstance(typeof(kernel), Tuple{})
         target = NativeCompilerTarget()
         params = precompile_module.DummyCompilerParams()
-        config = CompilerConfig(target, params)
         # XXX: on Windows, compiling the GPU runtime leaks GPU code in the native cache,
         #      so prevent building the runtime library (see JuliaGPU/GPUCompiler.jl#601)
-        job = CompilerJob(source, config; libraries=false)
+        config = CompilerConfig(target, params; libraries=false)
+        job = CompilerJob(source, config)
 
         JuliaContext() do ctx
             GPUCompiler.compile(:asm, job)

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -186,9 +186,9 @@ See also: [`@device_code_llvm`](@ref), `InteractiveUtils.code_llvm`
 function code_llvm(io::IO, @nospecialize(job::CompilerJob); optimize::Bool=true, raw::Bool=false,
                    debuginfo::Symbol=:default, dump_module::Bool=false, kwargs...)
     # NOTE: jl_dump_function_ir supports stripping metadata, so don't do it in the driver
-    reflection_job = CompilerJob(job; optimize, validate=false, strip=false, kwargs...)
+    config = CompilerConfig(job.config; validate=false, strip=false)
     str = JuliaContext() do ctx
-        ir, meta = compile(:llvm, reflection_job)
+        ir, meta = compile(:llvm, CompilerJob(job; config))
         ts_mod = ThreadSafeModule(ir)
         entry_fn = meta.entry
         GC.@preserve ts_mod entry_fn begin
@@ -217,9 +217,9 @@ See also: [`@device_code_native`](@ref), `InteractiveUtils.code_llvm`
 """
 function code_native(io::IO, @nospecialize(job::CompilerJob);
                      raw::Bool=false, dump_module::Bool=false)
-    reflection_job = CompilerJob(job; strip=!raw, only_entry=!dump_module, validate=false)
+    config = CompilerConfig(job.config; strip=!raw, only_entry=!dump_module, validate=false)
     asm, meta = JuliaContext() do ctx
-        compile(:asm, reflection_job)
+        compile(:asm, CompilerJob(job; config))
     end
     highlight(io, asm, source_code(job.config.target))
 end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -186,8 +186,9 @@ See also: [`@device_code_llvm`](@ref), `InteractiveUtils.code_llvm`
 function code_llvm(io::IO, @nospecialize(job::CompilerJob); optimize::Bool=true, raw::Bool=false,
                    debuginfo::Symbol=:default, dump_module::Bool=false, kwargs...)
     # NOTE: jl_dump_function_ir supports stripping metadata, so don't do it in the driver
+    reflection_job = CompilerJob(job; optimize, validate=false, strip=false, kwargs...)
     str = JuliaContext() do ctx
-        ir, meta = compile(:llvm, job; optimize=optimize, strip=false, validate=false, kwargs...)
+        ir, meta = compile(:llvm, reflection_job)
         ts_mod = ThreadSafeModule(ir)
         entry_fn = meta.entry
         GC.@preserve ts_mod entry_fn begin
@@ -214,9 +215,11 @@ The following keyword arguments are supported:
 
 See also: [`@device_code_native`](@ref), `InteractiveUtils.code_llvm`
 """
-function code_native(io::IO, @nospecialize(job::CompilerJob); raw::Bool=false, dump_module::Bool=false)
+function code_native(io::IO, @nospecialize(job::CompilerJob);
+                     raw::Bool=false, dump_module::Bool=false)
+    reflection_job = CompilerJob(job; strip=!raw, only_entry=!dump_module, validate=false)
     asm, meta = JuliaContext() do ctx
-        compile(:asm, job; strip=!raw, only_entry=!dump_module, validate=false)
+        compile(:asm, reflection_job)
     end
     highlight(io, asm, source_code(job.config.target))
 end

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -68,7 +68,7 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method)
     tt = Base.to_tuple_type(method.types)
     source = generic_methodinstance(f, tt)
-    new_mod, meta = codegen(:llvm, CompilerJob(source, config))
+    new_mod, meta = compile_unhooked(:llvm, CompilerJob(source, config))
     ft = function_type(meta.entry)
     expected_ft = convert(LLVM.FunctionType, method)
     if return_type(ft) != return_type(expected_ft)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -68,7 +68,7 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method)
     tt = Base.to_tuple_type(method.types)
     source = generic_methodinstance(f, tt)
-    new_mod, meta = codegen(:llvm, CompilerJob(source, config; toplevel=false))
+    new_mod, meta = codegen(:llvm, CompilerJob(source, config))
     ft = function_type(meta.entry)
     expected_ft = convert(LLVM.FunctionType, method)
     if return_type(ft) != return_type(expected_ft)
@@ -99,7 +99,7 @@ function build_runtime(@nospecialize(job::CompilerJob))
 
     # the compiler job passed into here is identifies the job that requires the runtime.
     # derive a job that represents the runtime itself (notably with kernel=false).
-    config = CompilerConfig(job.config; kernel=false)
+    config = CompilerConfig(job.config; kernel=false, toplevel=false)
 
     for method in values(Runtime.methods)
         def = if isa(method.def, Symbol)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -68,7 +68,7 @@ end
 function emit_function!(mod, config::CompilerConfig, f, method)
     tt = Base.to_tuple_type(method.types)
     source = generic_methodinstance(f, tt)
-    new_mod, meta = codegen(:llvm, CompilerJob(source, config); toplevel=false)
+    new_mod, meta = codegen(:llvm, CompilerJob(source, config; toplevel=false))
     ft = function_type(meta.entry)
     expected_ft = convert(LLVM.FunctionType, method)
     if return_type(ft) != return_type(expected_ft)

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -184,9 +184,9 @@ end
 
 # reimplementation that uses `spirv-dis`, giving much more pleasant output
 function code_native(io::IO, job::CompilerJob{SPIRVCompilerTarget}; raw::Bool=false, dump_module::Bool=false)
-    reflection_job = CompilerJob(job; strip=!raw, only_entry=!dump_module, validate=false)
+    config = CompilerConfig(job.config; strip=!raw, only_entry=!dump_module, validate=false)
     obj, _ = JuliaContext() do ctx
-        compile(:obj, reflection_job)
+        compile(:obj, CompilerJob(job; config))
     end
     mktemp() do input_path, input_io
         write(input_io, obj)

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -184,8 +184,9 @@ end
 
 # reimplementation that uses `spirv-dis`, giving much more pleasant output
 function code_native(io::IO, job::CompilerJob{SPIRVCompilerTarget}; raw::Bool=false, dump_module::Bool=false)
+    reflection_job = CompilerJob(job; strip=!raw, only_entry=!dump_module, validate=false)
     obj, _ = JuliaContext() do ctx
-        compile(:obj, job; strip=!raw, only_entry=!dump_module, validate=false)
+        compile(:obj, reflection_job)
     end
     mktemp() do input_path, input_io
         write(input_io, obj)

--- a/test/helpers/bpf.jl
+++ b/test/helpers/bpf.jl
@@ -7,13 +7,12 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
-    config_kwargs, job_kwargs, kwargs =
-        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = BPFCompilerTarget()
     params = CompilerParams()
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config; job_kwargs...), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/bpf.jl
+++ b/test/helpers/bpf.jl
@@ -6,13 +6,14 @@ import ..TestRuntime
 struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
-function create_job(@nospecialize(func), @nospecialize(types);
-                    kernel::Bool=false, always_inline=false, kwargs...)
+function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
+    config_kwargs, job_kwargs, kwargs =
+        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = BPFCompilerTarget()
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config; job_kwargs...), kwargs
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/gcn.jl
+++ b/test/helpers/gcn.jl
@@ -7,13 +7,12 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
-    config_kwargs, job_kwargs, kwargs =
-        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = CompilerParams()
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config; job_kwargs...), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/gcn.jl
+++ b/test/helpers/gcn.jl
@@ -6,13 +6,14 @@ import ..TestRuntime
 struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
-function create_job(@nospecialize(func), @nospecialize(types);
-                 kernel::Bool=false, always_inline=false, kwargs...)
+function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
+    config_kwargs, job_kwargs, kwargs =
+        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = GCNCompilerTarget(dev_isa="gfx900")
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config; job_kwargs...), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/metal.jl
+++ b/test/helpers/metal.jl
@@ -6,13 +6,14 @@ import ..TestRuntime
 struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
-function create_job(@nospecialize(func), @nospecialize(types);
-                    kernel::Bool=false, always_inline=false, kwargs...)
+function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
+    config_kwargs, job_kwargs, kwargs =
+        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config; job_kwargs...), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/metal.jl
+++ b/test/helpers/metal.jl
@@ -7,13 +7,12 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
-    config_kwargs, job_kwargs, kwargs =
-        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
     params = CompilerParams()
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config; job_kwargs...), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/native.jl
+++ b/test/helpers/native.jl
@@ -22,13 +22,12 @@ GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.config.pa
 
 function create_job(@nospecialize(func), @nospecialize(types);
                     entry_safepoint::Bool=false, method_table=test_method_table, kwargs...)
-    config_kwargs, job_kwargs, kwargs =
-        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = NativeCompilerTarget()
     params = CompilerParams(entry_safepoint, method_table)
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config; job_kwargs...), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/native.jl
+++ b/test/helpers/native.jl
@@ -20,14 +20,15 @@ GPUCompiler.runtime_module(::NativeCompilerJob) = TestRuntime
 GPUCompiler.method_table(@nospecialize(job::NativeCompilerJob)) = job.config.params.method_table
 GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.config.params.entry_safepoint
 
-function create_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
-                    entry_abi=:specfunc, entry_safepoint::Bool=false, always_inline=false,
-                    method_table=test_method_table, kwargs...)
+function create_job(@nospecialize(func), @nospecialize(types);
+                    entry_safepoint::Bool=false, method_table=test_method_table, kwargs...)
+    config_kwargs, job_kwargs, kwargs =
+        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = NativeCompilerTarget()
     params = CompilerParams(entry_safepoint, method_table)
-    config = CompilerConfig(target, params; kernel, entry_abi, always_inline)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config; job_kwargs...), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
@@ -71,7 +72,7 @@ const runtime_cache = Dict{Any, Any}()
 
 function compiler(job)
     JuliaContext() do ctx
-        GPUCompiler.compile(:asm, job, validate=false)
+        GPUCompiler.compile(:asm, job)
     end
 end
 
@@ -81,8 +82,9 @@ end
 
 # simulates cached codegen
 function cached_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.cached_compilation(runtime_cache, job.source, job.config, compiler, linker)
+    job, kwargs = create_job(func, types)
+    GPUCompiler.cached_compilation(runtime_cache, job.source, job.config, compiler, linker;
+                                   validate=false, kwargs...)
 end
 
 end

--- a/test/helpers/native.jl
+++ b/test/helpers/native.jl
@@ -82,9 +82,8 @@ end
 
 # simulates cached codegen
 function cached_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types)
-    GPUCompiler.cached_compilation(runtime_cache, job.source, job.config, compiler, linker;
-                                   validate=false, kwargs...)
+    job, kwargs = create_job(func, types; validate=false, kwargs...)
+    GPUCompiler.cached_compilation(runtime_cache, job.source, job.config, compiler, linker)
 end
 
 end

--- a/test/helpers/ptx.jl
+++ b/test/helpers/ptx.jl
@@ -35,16 +35,17 @@ module PTXTestRuntime
 end
 GPUCompiler.runtime_module(::PTXCompilerJob) = PTXTestRuntime
 
-function create_job(@nospecialize(func), @nospecialize(types); kernel::Bool=false,
-                    minthreads=nothing, maxthreads=nothing, blocks_per_sm=nothing,
-                    maxregs=nothing, always_inline=false, kwargs...)
+function create_job(@nospecialize(func), @nospecialize(types);
+                    minthreads=nothing, maxthreads=nothing,
+                    blocks_per_sm=nothing, maxregs=nothing,
+                    kwargs...)
+    config_kwargs, job_kwargs, kwargs =
+        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = PTXCompilerTarget(;cap=v"7.0",
-                               minthreads, maxthreads,
-                               blocks_per_sm, maxregs)
+    target = PTXCompilerTarget(; cap=v"7.0", minthreads, maxthreads, blocks_per_sm, maxregs)
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config; job_kwargs...), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/ptx.jl
+++ b/test/helpers/ptx.jl
@@ -39,13 +39,12 @@ function create_job(@nospecialize(func), @nospecialize(types);
                     minthreads=nothing, maxthreads=nothing,
                     blocks_per_sm=nothing, maxregs=nothing,
                     kwargs...)
-    config_kwargs, job_kwargs, kwargs =
-        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = PTXCompilerTarget(; cap=v"7.0", minthreads, maxthreads, blocks_per_sm, maxregs)
     params = CompilerParams()
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config; job_kwargs...), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/spirv.jl
+++ b/test/helpers/spirv.jl
@@ -9,14 +9,13 @@ GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 function create_job(@nospecialize(func), @nospecialize(types);
                    supports_fp16=true, supports_fp64=true, backend::Symbol,
                    kwargs...)
-    config_kwargs, job_kwargs, kwargs =
-        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = SPIRVCompilerTarget(; backend, validate=true, optimize=true,
                                    supports_fp16, supports_fp64)
     params = CompilerParams()
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config; job_kwargs...), kwargs
+    CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/helpers/spirv.jl
+++ b/test/helpers/spirv.jl
@@ -7,15 +7,16 @@ struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types);
-                   kernel::Bool=false, always_inline=false,
-                   supports_fp16=true, supports_fp64=true,
-                   backend::Symbol, kwargs...)
+                   supports_fp16=true, supports_fp64=true, backend::Symbol,
+                   kwargs...)
+    config_kwargs, job_kwargs, kwargs =
+        split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS, GPUCompiler.JOB_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = SPIRVCompilerTarget(; backend, validate=true, optimize=true,
                                    supports_fp16, supports_fp64)
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel, always_inline)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config; job_kwargs...), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -114,7 +114,7 @@ end
         return
     end
 
-    @test_throws_message(InvalidIRError, Metal.code_llvm(devnull, kernel2, Tuple{Core.LLVMPtr{Float64,1}}; validate=true)) do msg
+    @test_throws_message(InvalidIRError, Metal.code_execution(kernel2, Tuple{Core.LLVMPtr{Float64,1}})) do msg
         occursin("unsupported use of double value", msg)
     end
 end

--- a/test/native.jl
+++ b/test/native.jl
@@ -50,10 +50,10 @@ end
         @noinline inner(x) = x+1
         foo(x) = sum(inner, fill(x, 10, 10))
 
-        job, _ = Native.create_job(foo, (Float64,))
+        job, _ = Native.create_job(foo, (Float64,); validate=false)
         JuliaContext() do ctx
             # shouldn't segfault
-            ir, meta = GPUCompiler.compile(:llvm, job; validate=false)
+            ir, meta = GPUCompiler.compile(:llvm, job)
 
             meth = only(methods(foo, (Float64,)))
 

--- a/test/native.jl
+++ b/test/native.jl
@@ -87,8 +87,10 @@ end
         invocations = Ref(0)
         function compiler(job)
             invocations[] += 1
-            ir = sprint(io->GPUCompiler.code_llvm(io, job))
-            return ir
+            JuliaContext() do ctx
+                ir, ir_meta = GPUCompiler.compile(:llvm, job)
+                string(ir)
+            end
         end
         linker(job, compiled) = compiled
         cache = Dict()

--- a/test/native/precompile.jl
+++ b/test/native/precompile.jl
@@ -56,7 +56,7 @@ precompile_test_harness("Inference caching") do load_path
         GPUCompiler.enable_disk_cache!()
         @test GPUCompiler.disk_cache_enabled() == true
 
-        job, _ = NativeCompiler.Native.create_job(NativeBackend.kernel, (Vector{Int}, Int))
+        job, _ = NativeCompiler.Native.create_job(NativeBackend.kernel, (Vector{Int}, Int); validate=false)
         @assert job.source == kernel_mi
         ci = GPUCompiler.ci_cache_lookup(GPUCompiler.ci_cache(job), job.source, job.world, job.world)
         @assert ci !== nothing

--- a/test/spirv.jl
+++ b/test/spirv.jl
@@ -48,28 +48,28 @@ end
     end
 
     ir = sprint(io->SPIRV.code_llvm(io, mod.kernel, Tuple{Ptr{Float16}, Float16};
-                                    backend, validate=true))
+                                    backend))
     @test occursin("store half", ir)
 
     ir = sprint(io->SPIRV.code_llvm(io, mod.kernel, Tuple{Ptr{Float32}, Float32};
-                                    backend, validate=true))
+                                    backend))
     @test occursin("store float", ir)
 
     ir = sprint(io->SPIRV.code_llvm(io, mod.kernel, Tuple{Ptr{Float64}, Float64};
-                                    backend, validate=true))
+                                    backend))
     @test occursin("store double", ir)
 
     @test_throws_message(InvalidIRError,
-                         SPIRV.code_llvm(devnull, mod.kernel, Tuple{Ptr{Float16}, Float16};
-                                         backend, supports_fp16=false, validate=true)) do msg
+                         SPIRV.code_execution(mod.kernel, Tuple{Ptr{Float16}, Float16};
+                                              backend, supports_fp16=false)) do msg
         occursin("unsupported use of half value", msg) &&
         occursin("[1] unsafe_store!", msg) &&
         occursin("[2] kernel", msg)
     end
 
     @test_throws_message(InvalidIRError,
-                         SPIRV.code_llvm(devnull, mod.kernel, Tuple{Ptr{Float64}, Float64};
-                                         backend, supports_fp64=false, validate=true)) do msg
+                         SPIRV.code_execution(mod.kernel, Tuple{Ptr{Float64}, Float64};
+                                              backend, supports_fp64=false)) do msg
         occursin("unsupported use of double value", msg) &&
         occursin("[1] unsafe_store!", msg) &&
         occursin("[2] kernel", msg)


### PR DESCRIPTION
The idea behind `CompilerConfig` was that it describes how the compiler should behave, so it should include most of the flags we currently pass to `compile`/`codegen` (e.g., `optimize`, `libraries`, etc).

This should also make caching more correct, as we currently were not including e.g. the optimization level in the logic that loads previous compilation results from the in-memory or disk cache.

This is an API change, so will break back-ends.
EDIT: managed to make it non-breaking.