### PR TITLE
Fix some edge cases for mangling

### DIFF
--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -29,7 +29,7 @@ safe_name(x) = safe_name(repr(x))
 # we generate function names that look like C++ functions, because many tools, like NVIDIA's
 # profilers, support them (grouping different instantiations of the same kernel together).
 
-function mangle_param(t, substitutions=Any[], top=false)
+function mangle_param(t, substitutions = Any[], top = false)
     t == Nothing && return "v"
 
     function find_substitution(x)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -56,9 +56,11 @@ end
           "identity(Val<1>, Val<2>, Val<3>, Val<4>, Val<5>, Val<6>, Val<7>, Val<8>, Val<9>, Val<10>, Val<11>, Val<12>, Val<13>, Val<14>, Val<15>, Val<16>, Val<16>)"
 
     # intertwined substitutions
-    @test mangle(identity, Val{1}, Ptr{Tuple{Ptr{Int}}}, Ptr{Int}, Val{1}, Val{2},
-                           Tuple{Ptr{Int}}, Tuple{Int8}, Int64, Int8) ==
-          "identity(Val<1>, Tuple<Int64*>*, Int64*, Val<1>, Val<2>, Tuple<Int64*>, Tuple<Int8>, Int64, Int8)"
+    @test mangle(
+        identity, Val{1}, Ptr{Tuple{Ptr{Int}}}, Ptr{Int}, Val{1}, Val{2},
+        Tuple{Ptr{Int}}, Tuple{Int8}, Int64, Int8
+    ) ==
+        "identity(Val<1>, Tuple<Int64*>*, Int64*, Val<1>, Val<2>, Tuple<Int64*>, Tuple<Int8>, Int64, Int8)"
 
     # problematic examples
     @test mangle(identity, String, Matrix{Float32}, Broadcast.Broadcasted{Broadcast.ArrayStyle{Matrix{Float32}}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}, typeof(Base.literal_pow), Tuple{Base.RefValue{typeof(sin)}, Broadcast.Extruded{Matrix{Float32}, Tuple{Bool, Bool}, Tuple{Int64, Int64}}}}) == "identity(String, Array<Float32, 2>, Broadcasted<ArrayStyle<Array<Float32, 2>>, Tuple<OneTo<Int64>, OneTo<Int64>>, literal_pow, Tuple<RefValue<sin>, Extruded<Array<Float32, 2>, Tuple<Bool, Bool>, Tuple<Int64, Int64>>>>)"


### PR DESCRIPTION
Fixes #671, and adds some tests for each edge-case I found.

I checked some of the logic with the [Itanium ABI specs](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling) (e.g. `Ptr`), and when possible, if a similarly-defined C++ function would be mangled in the same way.

There might still be some more obscure edge-cases remaining however.