### PR TITLE
Allow for nested targets

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -222,7 +222,7 @@ const __llvm_initialized = Ref(false)
             for dyn_job in keys(worklist)
                 # cached compilation
                 dyn_entry_fn = get!(jobs, dyn_job) do
-                    config = CompilerConfig(dyn_job.config; toplevel=false)
+                    config = CompilerConfig(dyn_job.config; toplevel=false, target = nest_target(dyn_job.target, job.target))
                     dyn_ir, dyn_meta = codegen(:llvm, CompilerJob(dyn_job; config))
                     dyn_entry_fn = LLVM.name(dyn_meta.entry)
                     merge!(compiled, dyn_meta.compiled)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -48,6 +48,9 @@ have_fma(@nospecialize(target::AbstractCompilerTarget), T::Type) = false
 
 dwarf_version(target::AbstractCompilerTarget) = Int32(4) # It seems every target supports v4 bar cuda
 
+# If your target performs nested compilation, this function should reconstruct your target with a new inner target
+nest_target(target::AbstractCompilerTarget, parent::AbstractCompilerTarget) = target
+
 ## params
 
 export AbstractCompilerParams


### PR DESCRIPTION
The idea here is to explicitly allow for the nesting of targets to support Enzyme deferred codegen needs.

x-ref: https://github.com/JuliaGPU/GPUCompiler.jl/pull/668#discussion_r2116258542
x-ref: https://github.com/EnzymeAD/Enzyme.jl/pull/2424
