### PR TITLE
Fix erase! use in gcn.jl

### DIFF
--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -87,7 +87,7 @@ function lower_throw_extra!(mod::LLVM.Module)
                     # remove the call
                     nargs = length(parameters(f))
                     call_args = arguments(call)
-                    erase!(LLVM.parent(call), call)
+                    erase!(call)
 
                     # HACK: kill the exceptions' unused arguments
                     for arg in call_args


### PR DESCRIPTION
This was probably a typo when LLVM.jl moved to using erase! using find and replace