### PR TITLE
Convert the kernel state back to a reference when needed.

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -267,7 +267,7 @@ runtime_slug(@nospecialize(job::CompilerJob)) = error("Not implemented")
 kernel_state_type(@nospecialize(job::CompilerJob)) = Nothing
 
 # Does the target need to pass kernel arguments by value?
-needs_byval(@nospecialize(job::CompilerJob)) = true
+pass_by_value(@nospecialize(job::CompilerJob)) = true
 
 # whether pointer is a valid call target
 valid_function_pointer(@nospecialize(job::CompilerJob), ptr::Ptr{Cvoid}) = false


### PR DESCRIPTION
We're currently passing the kernel state object by value, disregarding the typical Julia calling convention, because there's known issues with `byval` lowering on NVPTX.

For compatibility with back-ends that do not support passing kernel arguments by actual values, provide a pass that's conceptually the inverse of `lower_byval`, instead rewriting the kernel state object to be passed by reference, and loading from it at the beginning of the kernel.

Possible alternatives include:
- always passing the object by reference, and relying on `lower_byval` to avoid the back-end's codegen issues. This is tricky because that function now only operates on the outermost kernel function, and making it so that it lowers byval everywhere (which is necessary to avoid `alloca`'s on cases where the state is passed down, which is almost everywhere) is nontrivial
- customizing the kernel state lowering to use a reference for the kernel, and a value for child functions

cc @simeonschaub 