### PR TITLE
add support for additional hidden kernel args

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -265,6 +265,7 @@ runtime_slug(@nospecialize(job::CompilerJob)) = error("Not implemented")
 # argument to each kernel, and pass that object to every function that accesses the kernel
 # state (possibly indirectly) via the `kernel_state_pointer` function.
 kernel_state_type(@nospecialize(job::CompilerJob)) = Nothing
+additional_arg_types(@nospecialize(job::CompilerJob)) = (;)
 
 # Does the target need to pass kernel arguments by value?
 pass_by_value(@nospecialize(job::CompilerJob)) = true

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -528,8 +528,8 @@ function add_kernel_state!(mod::LLVM.Module)
     state_intr = kernel_state_intr(mod, T_state)
     state_intr_ft = LLVM.FunctionType(T_state)
 
-    # additional arguments to pass to every function
-    additional_args = additional_arg_types(job)
+    # additional arguments to pass to every function, but only if they are required
+    additional_args = haskey(functions(mod), "julia.gpu.additional_arg_getter") ? additional_arg_types(job) : (;)
     T_additional_args = convert.(LLVMType, values(additional_args))
     names_additional_args = String.(keys(additional_args))
 


### PR DESCRIPTION
For device-side RNG in OpenCL we need to allocate local memory depending on the number of subgroups in a workgroup and AFAICT, the only way to do that is to pass the local memory as an argument to the kernel. This adds functionality to add such additional hidden arguments to a kernel and feed them through functions that require them based on the existing kernel state passes.