### PR TITLE
unwrap ExceptionStack in code_ handling

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -25,6 +25,19 @@ end
 Base.show(io::IO, err::KernelError) = showerror(io, err)
 
 
+"""
+    unwrap_error(err)
+
+Unwrap a compiler exception from container exceptions such as the REPL's `err` global
+(a `Base.ExceptionStack`) or the `LoadError` thrown by `include`, so that it can be
+passed to reflection functions like `code_typed`. Other exceptions are returned as-is.
+"""
+unwrap_error(err) = err
+unwrap_error(err::Base.ExceptionStack) =
+    isempty(err.stack) ? err : unwrap_error(last(err.stack).exception)
+unwrap_error(err::LoadError) = unwrap_error(err.error)
+
+
 struct InternalCompilerError <: Exception
     job::CompilerJob
     message::String

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -164,6 +164,12 @@ InteractiveUtils.code_lowered(err::KernelError; kwargs...) = code_lowered(err.jo
 InteractiveUtils.code_typed(err::KernelError; kwargs...) = code_typed(err.job; kwargs...)
 InteractiveUtils.code_warntype(err::KernelError; kwargs...) = code_warntype(err.job; kwargs...)
 
+# Technically type-pirarcy
+InteractiveUtils.code_lowered(err::Base.ExceptionStack; kwargs...) = InteractiveUtils.code_lowered(only(err.stack).exception; kwargs...)
+InteractiveUtils.code_typed(err::Base.ExceptionStack; kwargs...) = InteractiveUtils.code_typed(only(err.stack).exception; kwargs...)
+InteractiveUtils.code_warntype(err::Base.ExceptionStack; kwargs...) = InteractiveUtils.code_warntype(only(err.stack).exception; kwargs...)
+
+
 struct jl_llvmf_dump
     TSM::LLVM.API.LLVMOrcThreadSafeModuleRef
     F::LLVM.API.LLVMValueRef

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -153,7 +153,8 @@ function Base.showerror(io::IO, err::InvalidIRError)
     printstyled(io, "Hint"; bold = true, color = :cyan)
     printstyled(
         io,
-        ": catch this exception as `err` and call `code_typed(err; interactive = true)` to",
+        ": catch this exception as `err` and call",
+        " `code_typed(GPUCompiler.unwrap_error(err); interactive = true)` to",
         " introspect the erroneous code with Cthulhu.jl";
         color = :cyan,
     )

--- a/test/native.jl
+++ b/test/native.jl
@@ -1,3 +1,5 @@
+using InteractiveUtils
+
 @testset "reflection" begin
     job, _ = Native.create_job(identity, (Int,))
 
@@ -620,6 +622,25 @@ end
         occursin("[1] println", msg) &&
         occursin("[2] foobar", msg)
     end
+end
+
+@testset "unwrap_error" begin
+    mod = @eval module $(gensym())
+        foobar(i) = println(i)
+    end
+
+    stack = try
+        Native.code_execution(mod.foobar, Tuple{Int})
+        nothing
+    catch
+        current_exceptions()
+    end
+    @test stack isa Base.ExceptionStack
+    err = GPUCompiler.unwrap_error(stack)
+    @test err isa GPUCompiler.InvalidIRError
+    @test GPUCompiler.unwrap_error(err) === err
+    @test GPUCompiler.unwrap_error(LoadError("foo.jl", 1, err)) === err
+    @test only(code_typed(GPUCompiler.unwrap_error(stack))) isa Pair
 end
 
 @testset "invalid LLVM IR (ccall)" begin


### PR DESCRIPTION
We inform users to use:

```
Catch this exception as `err` and call `code_typed(err; interactive = true)`
```

But in the REPL this is often not useful advice since the exception of interest is actually wrapped...
This biggest issue with this PR is that we are technically committing type-piracy, but this improves the UX for working with compiler errors from GPUCompiler a lot.

I think there is a second error type that we can get which is when the error happens in a file that is being `include`'d
