### PR TITLE
More robust error message on method compilation failure

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -630,9 +630,7 @@ function ci_cache_populate(interp, cache, mi, min_world, max_world)
         # inference should have populated our cache
         wvc = WorldView(cache, min_world, max_world)
 
-        if !CC.haskey(wvc, mi)
-            throw(AssertionError("GPUCompiler: Failed to compile method for $mi, between worlds $min_world and $max_world"))
-        end
+        @assert CC.haskey(wvc, mi) "GPUCompiler: Failed to compile method for $mi, between worlds $min_world and $max_world"
         ci = CC.getindex(wvc, mi)
 
         # if ci is rettype_const, the inference result won't have been cached


### PR DESCRIPTION
If the method compiling a generated function fails, it will throw a vanilla unhelpful assertion.

By adding more information to the assertion error itself, its easier to figure out what went wrong and why