### PR TITLE
[CI] set 10 minute timeout for GH actions jobs

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -15,6 +15,7 @@ jobs:
   release_test:
     name: Julia ${{ matrix.version }} ${{ matrix.llvm_args }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The Julia 1.10 MacOS Intel runners seem to hang fairly frequently, so kill hanging jobs early