### PR TITLE
use `CC.MAX_INLINE_COST` instead of `typemax(Int)`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -324,7 +324,7 @@ function optimization_params(@nospecialize(job::CompilerJob))
     kwargs = NamedTuple()
 
     if job.config.always_inline
-        kwargs = (kwargs..., inline_cost_threshold=typemax(Int))
+        kwargs = (kwargs..., inline_cost_threshold=Int(CC.MAX_INLINE_COST))
     end
 
     return CC.OptimizationParams(;kwargs...)

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -37,6 +37,13 @@ end
     end
 end
 
+@testset "https://github.com/JuliaGPU/AMDGPU.jl/issues/846" begin
+    ir, rt = GCN.code_typed((Tuple{Tuple{Val{4}}, Tuple{Float32}},); always_inline=true) do t
+        t[1]
+    end |> only
+    @test rt == Tuple{Val{4}}
+end
+
 end
 
 ############################################################################################


### PR DESCRIPTION
as cost threshold for `always_inline` to avoid integer overflow

fix JuliaGPU/AMDGPU.jl#846

alternative to JuliaLang/julia#60121
