### PR TITLE
Imaging-mode PLT codegen and relocatable TLS

### DIFF
--- a/examples/kernel.jl
+++ b/examples/kernel.jl
@@ -11,7 +11,7 @@ module TestRuntime
 end
 
 struct TestCompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,TestCompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::CompilerJob{<:Any, TestCompilerParams}) = TestRuntime
 
 kernel() = nothing
 
@@ -26,7 +26,7 @@ function main()
         GPUCompiler.compile(:asm, job)
     end
 
-    println(output[1])
+    return println(output[1])
 end
 
 isinteractive() || main()

--- a/src/GPUCompiler.jl
+++ b/src/GPUCompiler.jl
@@ -66,7 +66,7 @@ function __init__()
     global compile_cache = dir
 
     Tracy.@register_tracepoints()
-    register_deferred_codegen()
+    return register_deferred_codegen()
 end
 
 end # module

--- a/src/bpf.jl
+++ b/src/bpf.jl
@@ -5,7 +5,7 @@
 export BPFCompilerTarget
 
 Base.@kwdef struct BPFCompilerTarget <: AbstractCompilerTarget
-    function_pointers::UnitRange{Int}=1:1000 # set of valid function "pointers"
+    function_pointers::UnitRange{Int} = 1:1000 # set of valid function "pointers"
 end
 
 llvm_triple(::BPFCompilerTarget) = "bpf-bpf-bpf"
@@ -13,7 +13,7 @@ llvm_datalayout(::BPFCompilerTarget) = "e-m:e-p:64:64-i64:64-n32:64-S128"
 
 function llvm_machine(target::BPFCompilerTarget)
     triple = llvm_triple(target)
-    t = Target(;triple=triple)
+    t = Target(; triple = triple)
 
     cpu = ""
     feat = ""

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -19,7 +19,7 @@ function backtrace(inst::LLVM.Instruction, bt = StackTraces.StackFrame[])
             while loc !== nothing
                 scope = LLVM.scope(loc)
                 if scope !== nothing
-                    name = replace(LLVM.name(scope), r";$"=>"")
+                    name = replace(LLVM.name(scope), r";$" => "")
                     file = LLVM.file(scope)
                     path = joinpath(LLVM.directory(file), LLVM.filename(file))
                     line = LLVM.line(loc)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -27,7 +27,7 @@ llvm_triple(@nospecialize(target::AbstractCompilerTarget)) = error("Not implemen
 function llvm_machine(@nospecialize(target::AbstractCompilerTarget))
     triple = llvm_triple(target)
 
-    t = Target(triple=triple)
+    t = Target(triple = triple)
 
     tm = TargetMachine(t, triple)
     asm_verbosity!(tm, true)
@@ -41,7 +41,7 @@ llvm_datalayout(target::AbstractCompilerTarget) = DataLayout(llvm_machine(target
 function julia_datalayout(@nospecialize(target::AbstractCompilerTarget))
     dl = llvm_datalayout(target)
     dl === nothing && return nothing
-    DataLayout(string(dl) * "-ni:10:11:12:13")
+    return DataLayout(string(dl) * "-ni:10:11:12:13")
 end
 
 have_fma(@nospecialize(target::AbstractCompilerTarget), T::Type) = false
@@ -68,8 +68,10 @@ export CompilerConfig
 
 # the configuration of the compiler
 
-const CONFIG_KWARGS = [:kernel, :name, :entry_abi, :always_inline, :opt_level,
-                       :libraries, :optimize, :cleanup, :validate, :strip]
+const CONFIG_KWARGS = [
+    :kernel, :name, :entry_abi, :always_inline, :opt_level,
+    :libraries, :optimize, :cleanup, :validate, :strip,
+]
 
 """
     CompilerConfig(target, params; kernel=true, entry_abi=:specfunc, name=nothing,
@@ -102,12 +104,12 @@ Several keyword arguments can be used to customize the compilation process:
 - `validate`: enable optional validation of input and outputs (default: true)
 - `strip`: strip non-functional metadata and debug information (default: false)
 """
-struct CompilerConfig{T,P}
+struct CompilerConfig{T, P}
     target::T
     params::P
 
     kernel::Bool
-    name::Union{Nothing,String}
+    name::Union{Nothing, String}
     entry_abi::Symbol
     always_inline::Bool
     opt_level::Int
@@ -121,27 +123,33 @@ struct CompilerConfig{T,P}
     toplevel::Bool
     only_entry::Bool
 
-    function CompilerConfig(target::AbstractCompilerTarget, params::AbstractCompilerParams;
-                            kernel=true, name=nothing, entry_abi=:specfunc, toplevel=true,
-                            always_inline=false, opt_level=2, optimize=toplevel,
-                            libraries=toplevel, cleanup=toplevel, validate=toplevel,
-                            strip=false, only_entry=false)
+    function CompilerConfig(
+            target::AbstractCompilerTarget, params::AbstractCompilerParams;
+            kernel = true, name = nothing, entry_abi = :specfunc, toplevel = true,
+            always_inline = false, opt_level = 2, optimize = toplevel,
+            libraries = toplevel, cleanup = toplevel, validate = toplevel,
+            strip = false, only_entry = false
+        )
         if entry_abi ∉ (:specfunc, :func)
             error("Unknown entry_abi=$entry_abi")
         end
-        new{typeof(target), typeof(params)}(target, params, kernel, name, entry_abi,
-                                            always_inline, opt_level, libraries, optimize,
-                                            cleanup, validate, strip, toplevel, only_entry)
+        return new{typeof(target), typeof(params)}(
+            target, params, kernel, name, entry_abi,
+            always_inline, opt_level, libraries, optimize,
+            cleanup, validate, strip, toplevel, only_entry
+        )
     end
 end
 
 # copy constructor
-function CompilerConfig(cfg::CompilerConfig; target=cfg.target, params=cfg.params,
-                        kernel=cfg.kernel, name=cfg.name, entry_abi=cfg.entry_abi,
-                        always_inline=cfg.always_inline, opt_level=cfg.opt_level,
-                        libraries=cfg.libraries, optimize=cfg.optimize, cleanup=cfg.cleanup,
-                        validate=cfg.validate, strip=cfg.strip, toplevel=cfg.toplevel,
-                        only_entry=cfg.only_entry)
+function CompilerConfig(
+        cfg::CompilerConfig; target = cfg.target, params = cfg.params,
+        kernel = cfg.kernel, name = cfg.name, entry_abi = cfg.entry_abi,
+        always_inline = cfg.always_inline, opt_level = cfg.opt_level,
+        libraries = cfg.libraries, optimize = cfg.optimize, cleanup = cfg.cleanup,
+        validate = cfg.validate, strip = cfg.strip, toplevel = cfg.toplevel,
+        only_entry = cfg.only_entry
+    )
     # deriving a non-toplevel job disables certain features
     # XXX: should we keep track if any of these were set explicitly in the first place?
     #      see how PkgEval does that.
@@ -151,12 +159,14 @@ function CompilerConfig(cfg::CompilerConfig; target=cfg.target, params=cfg.param
         cleanup = false
         validate = false
     end
-    CompilerConfig(target, params; kernel, entry_abi, name, always_inline, opt_level,
-                   libraries, optimize, cleanup, validate, strip, toplevel, only_entry)
+    return CompilerConfig(
+        target, params; kernel, entry_abi, name, always_inline, opt_level,
+        libraries, optimize, cleanup, validate, strip, toplevel, only_entry
+    )
 end
 
 function Base.show(io::IO, @nospecialize(cfg::CompilerConfig{T})) where {T}
-    print(io, "CompilerConfig for ", T)
+    return print(io, "CompilerConfig for ", T)
 end
 
 function Base.hash(cfg::CompilerConfig, h::UInt)
@@ -194,18 +204,20 @@ using Core: MethodInstance
 Construct a `CompilerJob` that will be used to drive compilation for the given `source` and
 `config` in a given `world`.
 """
-struct CompilerJob{T,P}
+struct CompilerJob{T, P}
     source::MethodInstance
-    config::CompilerConfig{T,P}
+    config::CompilerConfig{T, P}
     world::UInt
 
-    CompilerJob(source::MethodInstance, config::CompilerConfig{T,P},
-                world=tls_world_age()) where {T,P} =
-        new{T,P}(source, config, world)
+    CompilerJob(
+        source::MethodInstance, config::CompilerConfig{T, P},
+        world = tls_world_age()
+    ) where {T, P} =
+        new{T, P}(source, config, world)
 end
 
 # copy constructor
-CompilerJob(job::CompilerJob; source=job.source, config=job.config, world=job.world) =
+CompilerJob(job::CompilerJob; source = job.source, config = job.config, world = job.world) =
     CompilerJob(source, config, world)
 
 function Base.hash(job::CompilerJob, h::UInt)
@@ -242,15 +254,19 @@ isintrinsic(@nospecialize(job::CompilerJob), fn::String) = false
 
 # provide a specific interpreter to use.
 if VERSION >= v"1.11.0-DEV.1552"
-get_interpreter(@nospecialize(job::CompilerJob)) =
-    GPUInterpreter(job.world; method_table_view=maybe_cached(method_table_view(job)),
-                   token=ci_cache_token(job), inf_params=inference_params(job),
-                   opt_params=optimization_params(job))
+    get_interpreter(@nospecialize(job::CompilerJob)) =
+        GPUInterpreter(
+        job.world; method_table_view = maybe_cached(method_table_view(job)),
+        token = ci_cache_token(job), inf_params = inference_params(job),
+        opt_params = optimization_params(job)
+    )
 else
-get_interpreter(@nospecialize(job::CompilerJob)) =
-    GPUInterpreter(job.world; method_table_view=maybe_cached(method_table_view(job)),
-                   code_cache=ci_cache(job), inf_params=inference_params(job),
-                   opt_params=optimization_params(job))
+    get_interpreter(@nospecialize(job::CompilerJob)) =
+        GPUInterpreter(
+        job.world; method_table_view = maybe_cached(method_table_view(job)),
+        code_cache = ci_cache(job), inf_params = inference_params(job),
+        opt_params = optimization_params(job)
+    )
 end
 
 # does this target support throwing Julia exceptions with jl_throw?
@@ -299,14 +315,14 @@ if VERSION >= v"1.11.0-DEV.1552"
     # Soft deprecated user should use `CC.code_cache(get_interpreter(job))`
     ci_cache(@nospecialize(job::CompilerJob)) = CC.code_cache(get_interpreter(job))
 else
-function ci_cache(@nospecialize(job::CompilerJob))
-    lock(GLOBAL_CI_CACHES_LOCK) do
-        cache = get!(GLOBAL_CI_CACHES, job.config) do
-            CodeCache()
+    function ci_cache(@nospecialize(job::CompilerJob))
+        return lock(GLOBAL_CI_CACHES_LOCK) do
+            cache = get!(GLOBAL_CI_CACHES, job.config) do
+                CodeCache()
+            end
+            return cache
         end
-        return cache
     end
-end
 end
 
 # the method table to use
@@ -316,10 +332,10 @@ method_table_view(@nospecialize(job::CompilerJob)) = get_method_table_view(job.w
 
 # the inference parameters to use when constructing the GPUInterpreter
 function inference_params(@nospecialize(job::CompilerJob))
-    if VERSION >= v"1.12.0-DEV.1017"
+    return if VERSION >= v"1.12.0-DEV.1017"
         CC.InferenceParams()
     else
-        CC.InferenceParams(; unoptimize_throw_blocks=false)
+        CC.InferenceParams(; unoptimize_throw_blocks = false)
     end
 end
 
@@ -328,15 +344,15 @@ function optimization_params(@nospecialize(job::CompilerJob))
     kwargs = NamedTuple()
 
     if job.config.always_inline
-        kwargs = (kwargs..., inline_cost_threshold=Int(CC.MAX_INLINE_COST))
+        kwargs = (kwargs..., inline_cost_threshold = Int(CC.MAX_INLINE_COST))
     end
 
-    return CC.OptimizationParams(;kwargs...)
+    return CC.OptimizationParams(; kwargs...)
 end
 
 # how much debuginfo to emit
 function llvm_debug_info(@nospecialize(job::CompilerJob))
-    if Base.JLOptions().debug_level == 0
+    return if Base.JLOptions().debug_level == 0
         LLVM.API.LLVMDebugEmissionKindNoDebug
     elseif Base.JLOptions().debug_level == 1
         LLVM.API.LLVMDebugEmissionKindLineTablesOnly
@@ -354,8 +370,10 @@ prepare_job!(@nospecialize(job::CompilerJob)) = return
 
 # early extension point used to link-in external bitcode files.
 # this is typically used by downstream packages to link vendor libraries.
-link_libraries!(@nospecialize(job::CompilerJob), mod::LLVM.Module,
-                undefined_fns::Vector{String}) = return
+link_libraries!(
+    @nospecialize(job::CompilerJob), mod::LLVM.Module,
+    undefined_fns::Vector{String}
+) = return
 
 # finalization of the module, before deferred codegen and optimization
 finish_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry::LLVM.Function) =

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -24,7 +24,7 @@ end
 # create a MethodError from a function type
 # TODO: fix upstream
 function unsafe_function_from_type(ft::Type)
-    if isdefined(ft, :instance)
+    return if isdefined(ft, :instance)
         ft.instance
     else
         # HACK: dealing with a closure or something... let's do somthing really invalid,
@@ -33,14 +33,14 @@ function unsafe_function_from_type(ft::Type)
     end
 end
 global MethodError
-function MethodError(ft::Type{<:Function}, tt::Type, world::Integer=typemax(UInt))
-    Base.MethodError(unsafe_function_from_type(ft), tt, world)
+function MethodError(ft::Type{<:Function}, tt::Type, world::Integer = typemax(UInt))
+    return Base.MethodError(unsafe_function_from_type(ft), tt, world)
 end
-MethodError(ft, tt, world=typemax(UInt)) = Base.MethodError(ft, tt, world)
+MethodError(ft, tt, world = typemax(UInt)) = Base.MethodError(ft, tt, world)
 
 # generate a LineInfoNode for the current source code location
 macro LineInfoNode(method)
-    Core.LineInfoNode(__module__, method, __source__.file, Int32(__source__.line), Int32(0))
+    return Core.LineInfoNode(__module__, method, __source__.file, Int32(__source__.line), Int32(0))
 end
 
 """
@@ -60,8 +60,10 @@ pass at run time. For non-concrete signatures, use `generic_methodinstance` inst
 """
 methodinstance
 
-function generic_methodinstance(@nospecialize(ft::Type), @nospecialize(tt::Type),
-                                world::Integer=tls_world_age())
+function generic_methodinstance(
+        @nospecialize(ft::Type), @nospecialize(tt::Type),
+        world::Integer = tls_world_age()
+    )
     sig = signature_type_by_tt(ft, tt)
 
     match, _ = CC._findsup(sig, nothing, world)
@@ -76,85 +78,93 @@ end
 # Julia's cached method lookup to simply look up method instances at run time.
 @static if VERSION >= v"1.11.0-DEV.1552"
 
-# XXX: version of Base.method_instance that uses a function type
-@inline function methodinstance(@nospecialize(ft::Type), @nospecialize(tt::Type),
-                                world::Integer=tls_world_age())
-    sig = signature_type_by_tt(ft, tt)
-    @assert Base.isdispatchtuple(sig)   # JuliaLang/julia#52233
+    # XXX: version of Base.method_instance that uses a function type
+    @inline function methodinstance(
+            @nospecialize(ft::Type), @nospecialize(tt::Type),
+            world::Integer = tls_world_age()
+        )
+        sig = signature_type_by_tt(ft, tt)
+        @assert Base.isdispatchtuple(sig)   # JuliaLang/julia#52233
 
-    mi = ccall(:jl_method_lookup_by_tt, Any,
-               (Any, Csize_t, Any),
-               sig, world, #=method_table=# nothing)
-    mi === nothing && throw(MethodError(ft, tt, world))
-    mi = mi::MethodInstance
+        mi = ccall(
+            :jl_method_lookup_by_tt, Any,
+            (Any, Csize_t, Any),
+            sig, world, #=method_table=# nothing
+        )
+        mi === nothing && throw(MethodError(ft, tt, world))
+        mi = mi::MethodInstance
 
-    # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
-    if !Base.isdispatchtuple(mi.specTypes)
-        mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)::MethodInstance
+        # `jl_method_lookup_by_tt` and `jl_method_lookup` can return a unspecialized mi
+        if !Base.isdispatchtuple(mi.specTypes)
+            mi = CC.specialize_method(mi.def, sig, mi.sparam_vals)::MethodInstance
+        end
+
+        return mi
     end
 
-    return mi
-end
-
-# on older versions of Julia, we always need to use the generic lookup
+    # on older versions of Julia, we always need to use the generic lookup
 else
 
-const methodinstance = generic_methodinstance
+    const methodinstance = generic_methodinstance
 
-function methodinstance_generator(world::UInt, source, self, ft::Type, tt::Type)
-    @nospecialize
-    @assert CC.isType(ft) && CC.isType(tt)
-    ft = ft.parameters[1]
-    tt = tt.parameters[1]
+    function methodinstance_generator(world::UInt, source, self, ft::Type, tt::Type)
+        @nospecialize
+        @assert CC.isType(ft) && CC.isType(tt)
+        ft = ft.parameters[1]
+        tt = tt.parameters[1]
 
-    stub = Core.GeneratedFunctionStub(identity, Core.svec(:methodinstance, :ft, :tt), Core.svec())
+        stub = Core.GeneratedFunctionStub(identity, Core.svec(:methodinstance, :ft, :tt), Core.svec())
 
-    # look up the method match
-    method_error = :(throw(MethodError(ft, tt, $world)))
-    sig = Tuple{ft, tt.parameters...}
-    min_world = Ref{UInt}(typemin(UInt))
-    max_world = Ref{UInt}(typemax(UInt))
-    match = ccall(:jl_gf_invoke_lookup_worlds, Any,
-                  (Any, Any, Csize_t, Ref{Csize_t}, Ref{Csize_t}),
-                  sig, #=mt=# nothing, world, min_world, max_world)
-    match === nothing && return stub(world, source, method_error)
+        # look up the method match
+        method_error = :(throw(MethodError(ft, tt, $world)))
+        sig = Tuple{ft, tt.parameters...}
+        min_world = Ref{UInt}(typemin(UInt))
+        max_world = Ref{UInt}(typemax(UInt))
+        match = ccall(
+            :jl_gf_invoke_lookup_worlds, Any,
+            (Any, Any, Csize_t, Ref{Csize_t}, Ref{Csize_t}),
+            sig, #=mt=# nothing, world, min_world, max_world
+        )
+        match === nothing && return stub(world, source, method_error)
 
-    # look up the method and code instance
-    mi = ccall(:jl_specializations_get_linfo, Ref{MethodInstance},
-               (Any, Any, Any), match.method, match.spec_types, match.sparams)
-    ci = CC.retrieve_code_info(mi, world)
+        # look up the method and code instance
+        mi = ccall(
+            :jl_specializations_get_linfo, Ref{MethodInstance},
+            (Any, Any, Any), match.method, match.spec_types, match.sparams
+        )
+        ci = CC.retrieve_code_info(mi, world)
 
-    # prepare a new code info
-    new_ci = copy(ci)
-    empty!(new_ci.code)
-    empty!(new_ci.codelocs)
-    empty!(new_ci.linetable)
-    empty!(new_ci.ssaflags)
-    new_ci.ssavaluetypes = 0
+        # prepare a new code info
+        new_ci = copy(ci)
+        empty!(new_ci.code)
+        empty!(new_ci.codelocs)
+        empty!(new_ci.linetable)
+        empty!(new_ci.ssaflags)
+        new_ci.ssavaluetypes = 0
 
-    # propagate edge metadata
-    new_ci.min_world = min_world[]
-    new_ci.max_world = max_world[]
-    new_ci.edges = MethodInstance[mi]
+        # propagate edge metadata
+        new_ci.min_world = min_world[]
+        new_ci.max_world = max_world[]
+        new_ci.edges = MethodInstance[mi]
 
-    # prepare the slots
-    new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
-    new_ci.slotflags = UInt8[0x00 for i = 1:3]
+        # prepare the slots
+        new_ci.slotnames = Symbol[Symbol("#self#"), :ft, :tt]
+        new_ci.slotflags = UInt8[0x00 for i in 1:3]
 
-    # return the method instance
-    push!(new_ci.code, CC.ReturnNode(mi))
-    push!(new_ci.ssaflags, 0x00)
-    push!(new_ci.linetable, @LineInfoNode(methodinstance))
-    push!(new_ci.codelocs, 1)
-    new_ci.ssavaluetypes += 1
+        # return the method instance
+        push!(new_ci.code, CC.ReturnNode(mi))
+        push!(new_ci.ssaflags, 0x00)
+        push!(new_ci.linetable, @LineInfoNode(methodinstance))
+        push!(new_ci.codelocs, 1)
+        new_ci.ssavaluetypes += 1
 
-    return new_ci
-end
+        return new_ci
+    end
 
-@eval function methodinstance(ft, tt)
-    $(Expr(:meta, :generated_only))
-    $(Expr(:meta, :generated, methodinstance_generator))
-end
+    @eval function methodinstance(ft, tt)
+        $(Expr(:meta, :generated_only))
+        $(Expr(:meta, :generated, methodinstance_generator))
+    end
 
 end
 
@@ -163,133 +173,135 @@ end
 const HAS_INTEGRATED_CACHE = VERSION >= v"1.11.0-DEV.1552"
 
 if !HAS_INTEGRATED_CACHE
-struct CodeCache
-    dict::IdDict{MethodInstance,Vector{CodeInstance}}
+    struct CodeCache
+        dict::IdDict{MethodInstance, Vector{CodeInstance}}
 
-    CodeCache() = new(IdDict{MethodInstance,Vector{CodeInstance}}())
-end
+        CodeCache() = new(IdDict{MethodInstance, Vector{CodeInstance}}())
+    end
 
-function Base.show(io::IO, ::MIME"text/plain", cc::CodeCache)
-    print(io, "CodeCache with $(mapreduce(length, +, values(cc.dict); init=0)) entries")
-    if !isempty(cc.dict)
-        print(io, ": ")
-        for (mi, cis) in cc.dict
-            println(io)
-            print(io, "  ")
-            show(io, mi)
+    function Base.show(io::IO, ::MIME"text/plain", cc::CodeCache)
+        print(io, "CodeCache with $(mapreduce(length, +, values(cc.dict); init = 0)) entries")
+        return if !isempty(cc.dict)
+            print(io, ": ")
+            for (mi, cis) in cc.dict
+                println(io)
+                print(io, "  ")
+                show(io, mi)
 
-            function worldstr(min_world, max_world)
-                if min_world == typemax(UInt)
-                    "empty world range"
-                elseif max_world == typemax(UInt)
-                    "worlds $(Int(min_world))+"
-                else
-                    "worlds $(Int(min_world)) to $(Int(max_world))"
+                function worldstr(min_world, max_world)
+                    return if min_world == typemax(UInt)
+                        "empty world range"
+                    elseif max_world == typemax(UInt)
+                        "worlds $(Int(min_world))+"
+                    else
+                        "worlds $(Int(min_world)) to $(Int(max_world))"
+                    end
+                end
+
+                for (i, ci) in enumerate(cis)
+                    println(io)
+                    print(io, "    CodeInstance for ", worldstr(ci.min_world, ci.max_world))
                 end
             end
+        end
+    end
 
-            for (i,ci) in enumerate(cis)
-                println(io)
-                print(io, "    CodeInstance for ", worldstr(ci.min_world, ci.max_world))
+    Base.empty!(cc::CodeCache) = empty!(cc.dict)
+
+    const GLOBAL_CI_CACHES = Dict{CompilerConfig, CodeCache}()
+    const GLOBAL_CI_CACHES_LOCK = ReentrantLock()
+
+
+    ## method invalidations
+
+    function CC.setindex!(cache::CodeCache, ci::CodeInstance, mi::MethodInstance)
+        # make sure the invalidation callback is attached to the method instance
+        add_codecache_callback!(cache, mi)
+        cis = get!(cache.dict, mi, CodeInstance[])
+        return push!(cis, ci)
+    end
+
+    # invalidation (like invalidate_method_instance, but for our cache)
+    struct CodeCacheCallback
+        cache::CodeCache
+    end
+
+    @static if VERSION ≥ v"1.11.0-DEV.798"
+
+        function add_codecache_callback!(cache::CodeCache, mi::MethodInstance)
+            callback = CodeCacheCallback(cache)
+            CC.add_invalidation_callback!(callback, mi)
+        end
+        function (callback::CodeCacheCallback)(replaced::MethodInstance, max_world::UInt32)
+            cis = get(callback.cache.dict, replaced, nothing)
+            if cis === nothing
+                return
             end
-        end
-    end
-end
-
-Base.empty!(cc::CodeCache) = empty!(cc.dict)
-
-const GLOBAL_CI_CACHES = Dict{CompilerConfig, CodeCache}()
-const GLOBAL_CI_CACHES_LOCK = ReentrantLock()
-
-
-## method invalidations
-
-function CC.setindex!(cache::CodeCache, ci::CodeInstance, mi::MethodInstance)
-    # make sure the invalidation callback is attached to the method instance
-    add_codecache_callback!(cache, mi)
-    cis = get!(cache.dict, mi, CodeInstance[])
-    push!(cis, ci)
-end
-
-# invalidation (like invalidate_method_instance, but for our cache)
-struct CodeCacheCallback
-    cache::CodeCache
-end
-
-@static if VERSION ≥ v"1.11.0-DEV.798"
-
-function add_codecache_callback!(cache::CodeCache, mi::MethodInstance)
-    callback = CodeCacheCallback(cache)
-    CC.add_invalidation_callback!(callback, mi)
-end
-function (callback::CodeCacheCallback)(replaced::MethodInstance, max_world::UInt32)
-    cis = get(callback.cache.dict, replaced, nothing)
-    if cis === nothing
-        return
-    end
-    for ci in cis
-        if ci.max_world == ~0 % Csize_t
-            @assert ci.min_world - 1 <= max_world "attempting to set illogical constraints"
-@static if VERSION >= v"1.11.0-DEV.1390"
-            @atomic ci.max_world = max_world
-else
-            ci.max_world = max_world
-end
-        end
-        @assert ci.max_world <= max_world
-    end
-end
-
-else
-
-function add_codecache_callback!(cache::CodeCache, mi::MethodInstance)
-    callback = CodeCacheCallback(cache)
-    if !isdefined(mi, :callbacks)
-        mi.callbacks = Any[callback]
-    elseif !in(callback, mi.callbacks)
-        push!(mi.callbacks, callback)
-    end
-end
-function (callback::CodeCacheCallback)(replaced::MethodInstance, max_world::UInt32,
-                                       seen::Set{MethodInstance}=Set{MethodInstance}())
-    push!(seen, replaced)
-
-    cis = get(callback.cache.dict, replaced, nothing)
-    if cis === nothing
-        return
-    end
-    for ci in cis
-        if ci.max_world == ~0 % Csize_t
-            @assert ci.min_world - 1 <= max_world "attempting to set illogical constraints"
-            ci.max_world = max_world
-        end
-        @assert ci.max_world <= max_world
-    end
-
-    # recurse to all backedges to update their valid range also
-    if isdefined(replaced, :backedges)
-        backedges = filter(replaced.backedges) do @nospecialize(mi)
-            if mi isa MethodInstance
-                mi ∉ seen
-            elseif mi isa Type
-                # an `invoke` call, which is a `(sig, MethodInstance)` pair.
-                # let's ignore the `sig` and process the `MethodInstance` next.
-                false
-            else
-                error("invalid backedge")
+            for ci in cis
+                if ci.max_world == ~0 % Csize_t
+                    @assert ci.min_world - 1 <= max_world "attempting to set illogical constraints"
+                    @static if VERSION >= v"1.11.0-DEV.1390"
+                        @atomic ci.max_world = max_world
+                    else
+                        ci.max_world = max_world
+                    end
+                end
+                @assert ci.max_world <= max_world
             end
         end
 
-        # Don't touch/empty backedges `invalidate_method_instance` in C will do that later
-        # replaced.backedges = Any[]
+    else
 
-        for mi in backedges
-            callback(mi::MethodInstance, max_world, seen)
+        function add_codecache_callback!(cache::CodeCache, mi::MethodInstance)
+            callback = CodeCacheCallback(cache)
+            if !isdefined(mi, :callbacks)
+                mi.callbacks = Any[callback]
+            elseif !in(callback, mi.callbacks)
+                push!(mi.callbacks, callback)
+            end
         end
-    end
-end
+        function (callback::CodeCacheCallback)(
+                replaced::MethodInstance, max_world::UInt32,
+                seen::Set{MethodInstance} = Set{MethodInstance}()
+            )
+            push!(seen, replaced)
 
-end
+            cis = get(callback.cache.dict, replaced, nothing)
+            if cis === nothing
+                return
+            end
+            for ci in cis
+                if ci.max_world == ~0 % Csize_t
+                    @assert ci.min_world - 1 <= max_world "attempting to set illogical constraints"
+                    ci.max_world = max_world
+                end
+                @assert ci.max_world <= max_world
+            end
+
+            # recurse to all backedges to update their valid range also
+            if isdefined(replaced, :backedges)
+                backedges = filter(replaced.backedges) do @nospecialize(mi)
+                    if mi isa MethodInstance
+                        mi ∉ seen
+                    elseif mi isa Type
+                        # an `invoke` call, which is a `(sig, MethodInstance)` pair.
+                        # let's ignore the `sig` and process the `MethodInstance` next.
+                        false
+                    else
+                        error("invalid backedge")
+                    end
+                end
+
+                # Don't touch/empty backedges `invalidate_method_instance` in C will do that later
+                # replaced.backedges = Any[]
+
+                for mi in backedges
+                    callback(mi::MethodInstance, max_world, seen)
+                end
+            end
+        end
+
+    end
 end # !HAS_INTEGRATED_CACHE
 
 
@@ -300,7 +312,7 @@ Base.Experimental.@MethodTable(GLOBAL_METHOD_TABLE)
 # Implements a priority lookup for method tables, where the first match in the stack get's returned.
 # An alternative to this would be to use a "Union" where we would query the parent method table and
 # do a most-specific match.
-struct StackedMethodTable{MTV<:CC.MethodTableView} <: CC.MethodTableView
+struct StackedMethodTable{MTV <: CC.MethodTableView} <: CC.MethodTableView
     world::UInt
     mt::Core.MethodTable
     parent::MTV
@@ -313,7 +325,7 @@ CC.isoverlayed(::StackedMethodTable) = true
 @static if VERSION >= v"1.11.0-DEV.363"
     # https://github.com/JuliaLang/julia/pull/51078
     # same API as before but without returning isoverlayed flag
-    function CC.findall(@nospecialize(sig::Type), table::StackedMethodTable; limit::Int=-1)
+    function CC.findall(@nospecialize(sig::Type), table::StackedMethodTable; limit::Int = -1)
         result = CC._findall(sig, table.mt, table.world, limit)
         result === nothing && return nothing # to many matches
         nr = CC.length(result)
@@ -330,8 +342,10 @@ CC.isoverlayed(::StackedMethodTable) = true
             CC.vcat(result.matches, parent_result.matches),
             CC.WorldRange(
                 CC.max(result.valid_worlds.min_world, parent_result.valid_worlds.min_world),
-                CC.min(result.valid_worlds.max_world, parent_result.valid_worlds.max_world)),
-            result.ambig | parent_result.ambig)
+                CC.min(result.valid_worlds.max_world, parent_result.valid_worlds.max_world)
+            ),
+            result.ambig | parent_result.ambig
+        )
     end
 
     function CC.findsup(@nospecialize(sig::Type), table::StackedMethodTable)
@@ -342,11 +356,12 @@ CC.isoverlayed(::StackedMethodTable) = true
             parent_match,
             CC.WorldRange(
                 max(valid_worlds.min_world, parent_valid_worlds.min_world),
-                min(valid_worlds.max_world, parent_valid_worlds.max_world))
-            )
+                min(valid_worlds.max_world, parent_valid_worlds.max_world)
+            ),
+        )
     end
 else
-    function CC.findall(@nospecialize(sig::Type), table::StackedMethodTable; limit::Int=-1)
+    function CC.findall(@nospecialize(sig::Type), table::StackedMethodTable; limit::Int = -1)
         result = CC._findall(sig, table.mt, table.world, limit)
         result === nothing && return nothing # to many matches
         nr = CC.length(result)
@@ -363,13 +378,16 @@ else
 
         # merge the parent match results with the internal method table
         return CC.MethodMatchResult(
-        CC.MethodLookupResult(
-            CC.vcat(result.matches, parent_result.matches),
-            CC.WorldRange(
-                CC.max(result.valid_worlds.min_world, parent_result.valid_worlds.min_world),
-                CC.min(result.valid_worlds.max_world, parent_result.valid_worlds.max_world)),
-            result.ambig | parent_result.ambig),
-        overlayed)
+            CC.MethodLookupResult(
+                CC.vcat(result.matches, parent_result.matches),
+                CC.WorldRange(
+                    CC.max(result.valid_worlds.min_world, parent_result.valid_worlds.min_world),
+                    CC.min(result.valid_worlds.max_world, parent_result.valid_worlds.max_world)
+                ),
+                result.ambig | parent_result.ambig
+            ),
+            overlayed
+        )
     end
 
     function CC.findsup(@nospecialize(sig::Type), table::StackedMethodTable)
@@ -380,8 +398,10 @@ else
             parent_match,
             CC.WorldRange(
                 max(valid_worlds.min_world, parent_valid_worlds.min_world),
-                min(valid_worlds.max_world, parent_valid_worlds.max_world)),
-            overlayed)
+                min(valid_worlds.max_world, parent_valid_worlds.max_world)
+            ),
+            overlayed,
+        )
     end
 end
 
@@ -404,15 +424,15 @@ end
 
 get_method_table_view(world::UInt, mt::CC.MethodTable) = CC.OverlayMethodTable(world, mt)
 
-struct GPUInterpreter{MTV<:CC.MethodTableView} <: CC.AbstractInterpreter
+struct GPUInterpreter{MTV <: CC.MethodTableView} <: CC.AbstractInterpreter
     world::UInt
     method_table_view::MTV
 
-@static if HAS_INTEGRATED_CACHE
-    token::Any
-else
-    code_cache::CodeCache
-end
+    @static if HAS_INTEGRATED_CACHE
+        token::Any
+    else
+        code_cache::CodeCache
+    end
     inf_cache::Vector{CC.InferenceResult}
 
     inf_params::CC.InferenceParams
@@ -420,59 +440,75 @@ end
 end
 
 @static if HAS_INTEGRATED_CACHE
-function GPUInterpreter(world::UInt=Base.get_world_counter();
-                        method_table_view::CC.MethodTableView,
-                        token::Any,
-                        inf_params::CC.InferenceParams,
-                        opt_params::CC.OptimizationParams)
-    @assert world <= Base.get_world_counter()
+    function GPUInterpreter(
+            world::UInt = Base.get_world_counter();
+            method_table_view::CC.MethodTableView,
+            token::Any,
+            inf_params::CC.InferenceParams,
+            opt_params::CC.OptimizationParams
+        )
+        @assert world <= Base.get_world_counter()
 
-    inf_cache = Vector{CC.InferenceResult}()
+        inf_cache = Vector{CC.InferenceResult}()
 
-    return GPUInterpreter(world, method_table_view,
-                          token, inf_cache,
-                          inf_params, opt_params)
-end
+        return GPUInterpreter(
+            world, method_table_view,
+            token, inf_cache,
+            inf_params, opt_params
+        )
+    end
 
-function GPUInterpreter(interp::GPUInterpreter;
-                        world::UInt=interp.world,
-                        method_table_view::CC.MethodTableView=interp.method_table_view,
-                        token::Any=interp.token,
-                        inf_cache::Vector{CC.InferenceResult}=interp.inf_cache,
-                        inf_params::CC.InferenceParams=interp.inf_params,
-                        opt_params::CC.OptimizationParams=interp.opt_params)
-    return GPUInterpreter(world, method_table_view,
-                          token, inf_cache,
-                          inf_params, opt_params)
-end
+    function GPUInterpreter(
+            interp::GPUInterpreter;
+            world::UInt = interp.world,
+            method_table_view::CC.MethodTableView = interp.method_table_view,
+            token::Any = interp.token,
+            inf_cache::Vector{CC.InferenceResult} = interp.inf_cache,
+            inf_params::CC.InferenceParams = interp.inf_params,
+            opt_params::CC.OptimizationParams = interp.opt_params
+        )
+        return GPUInterpreter(
+            world, method_table_view,
+            token, inf_cache,
+            inf_params, opt_params
+        )
+    end
 
 else
 
-function GPUInterpreter(world::UInt=Base.get_world_counter();
-                        method_table_view::CC.MethodTableView,
-                        code_cache::CodeCache,
-                        inf_params::CC.InferenceParams,
-                        opt_params::CC.OptimizationParams)
-    @assert world <= Base.get_world_counter()
+    function GPUInterpreter(
+            world::UInt = Base.get_world_counter();
+            method_table_view::CC.MethodTableView,
+            code_cache::CodeCache,
+            inf_params::CC.InferenceParams,
+            opt_params::CC.OptimizationParams
+        )
+        @assert world <= Base.get_world_counter()
 
-    inf_cache = Vector{CC.InferenceResult}()
+        inf_cache = Vector{CC.InferenceResult}()
 
-    return GPUInterpreter(world, method_table_view,
-                          code_cache, inf_cache,
-                          inf_params, opt_params)
-end
+        return GPUInterpreter(
+            world, method_table_view,
+            code_cache, inf_cache,
+            inf_params, opt_params
+        )
+    end
 
-function GPUInterpreter(interp::GPUInterpreter;
-                        world::UInt=interp.world,
-                        method_table_view::CC.MethodTableView=interp.method_table_view,
-                        code_cache::CodeCache=interp.code_cache,
-                        inf_cache::Vector{CC.InferenceResult}=interp.inf_cache,
-                        inf_params::CC.InferenceParams=interp.inf_params,
-                        opt_params::CC.OptimizationParams=interp.opt_params)
-    return GPUInterpreter(world, method_table_view,
-                          code_cache, inf_cache,
-                          inf_params, opt_params)
-end
+    function GPUInterpreter(
+            interp::GPUInterpreter;
+            world::UInt = interp.world,
+            method_table_view::CC.MethodTableView = interp.method_table_view,
+            code_cache::CodeCache = interp.code_cache,
+            inf_cache::Vector{CC.InferenceResult} = interp.inf_cache,
+            inf_params::CC.InferenceParams = interp.inf_params,
+            opt_params::CC.OptimizationParams = interp.opt_params
+        )
+        return GPUInterpreter(
+            world, method_table_view,
+            code_cache, inf_cache,
+            inf_params, opt_params
+        )
+    end
 end # HAS_INTEGRATED_CACHE
 
 CC.InferenceParams(interp::GPUInterpreter) = interp.inf_params
@@ -490,33 +526,41 @@ CC.lock_mi_inference(interp::GPUInterpreter, mi::MethodInstance) = nothing
 CC.unlock_mi_inference(interp::GPUInterpreter, mi::MethodInstance) = nothing
 
 function CC.add_remark!(interp::GPUInterpreter, sv::CC.InferenceState, msg)
-    @safe_debug "Inference remark during GPU compilation of $(sv.linfo): $msg"
+    return @safe_debug "Inference remark during GPU compilation of $(sv.linfo): $msg"
 end
 
 CC.may_optimize(interp::GPUInterpreter) = true
 CC.may_compress(interp::GPUInterpreter) = true
 CC.may_discard_trees(interp::GPUInterpreter) = true
 @static if VERSION <= v"1.12.0-DEV.1531"
-CC.verbose_stmt_info(interp::GPUInterpreter) = false
+    CC.verbose_stmt_info(interp::GPUInterpreter) = false
 end
 CC.method_table(interp::GPUInterpreter) = interp.method_table_view
 
 # semi-concrete interepretation is broken with overlays (JuliaLang/julia#47349)
-function CC.concrete_eval_eligible(interp::GPUInterpreter,
-    @nospecialize(f), result::CC.MethodCallResult, arginfo::CC.ArgInfo, sv::CC.InferenceState)
+function CC.concrete_eval_eligible(
+        interp::GPUInterpreter,
+        @nospecialize(f), result::CC.MethodCallResult, arginfo::CC.ArgInfo, sv::CC.InferenceState
+    )
     # NOTE it's fine to skip overloading with `sv::IRInterpretationState` since we disables
     #      semi-concrete interpretation anyway.
-    ret = @invoke CC.concrete_eval_eligible(interp::CC.AbstractInterpreter,
-        f::Any, result::CC.MethodCallResult, arginfo::CC.ArgInfo, sv::CC.InferenceState)
+    ret = @invoke CC.concrete_eval_eligible(
+        interp::CC.AbstractInterpreter,
+        f::Any, result::CC.MethodCallResult, arginfo::CC.ArgInfo, sv::CC.InferenceState
+    )
     if ret === :semi_concrete_eval
         return :none
     end
     return ret
 end
-function CC.concrete_eval_eligible(interp::GPUInterpreter,
-    @nospecialize(f), result::CC.MethodCallResult, arginfo::CC.ArgInfo)
-    ret = @invoke CC.concrete_eval_eligible(interp::CC.AbstractInterpreter,
-        f::Any, result::CC.MethodCallResult, arginfo::CC.ArgInfo)
+function CC.concrete_eval_eligible(
+        interp::GPUInterpreter,
+        @nospecialize(f), result::CC.MethodCallResult, arginfo::CC.ArgInfo
+    )
+    ret = @invoke CC.concrete_eval_eligible(
+        interp::CC.AbstractInterpreter,
+        f::Any, result::CC.MethodCallResult, arginfo::CC.ArgInfo
+    )
     ret === false && return nothing
     return ret
 end
@@ -527,37 +571,39 @@ using Core.Compiler: WorldView
 
 if !HAS_INTEGRATED_CACHE
 
-function CC.haskey(wvc::WorldView{CodeCache}, mi::MethodInstance)
-    CC.get(wvc, mi, nothing) !== nothing
-end
-
-function CC.get(wvc::WorldView{CodeCache}, mi::MethodInstance, default)
-    # check the cache
-    for ci in get!(wvc.cache.dict, mi, CodeInstance[])
-        if ci.min_world <= wvc.worlds.min_world && wvc.worlds.max_world <= ci.max_world
-            # TODO: if (code && (code == jl_nothing || jl_ir_flag_inferred((jl_array_t*)code)))
-            src = if ci.inferred isa Vector{UInt8}
-                ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any),
-                       mi.def, C_NULL, ci.inferred)
-            else
-                ci.inferred
-            end
-            return ci
-        end
+    function CC.haskey(wvc::WorldView{CodeCache}, mi::MethodInstance)
+        return CC.get(wvc, mi, nothing) !== nothing
     end
 
-    return default
-end
+    function CC.get(wvc::WorldView{CodeCache}, mi::MethodInstance, default)
+        # check the cache
+        for ci in get!(wvc.cache.dict, mi, CodeInstance[])
+            if ci.min_world <= wvc.worlds.min_world && wvc.worlds.max_world <= ci.max_world
+                # TODO: if (code && (code == jl_nothing || jl_ir_flag_inferred((jl_array_t*)code)))
+                src = if ci.inferred isa Vector{UInt8}
+                    ccall(
+                        :jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any),
+                        mi.def, C_NULL, ci.inferred
+                    )
+                else
+                    ci.inferred
+                end
+                return ci
+            end
+        end
 
-function CC.getindex(wvc::WorldView{CodeCache}, mi::MethodInstance)
-    r = CC.get(wvc, mi, nothing)
-    r === nothing && throw(KeyError(mi))
-    return r::CodeInstance
-end
+        return default
+    end
 
-function CC.setindex!(wvc::WorldView{CodeCache}, ci::CodeInstance, mi::MethodInstance)
-    CC.setindex!(wvc.cache, ci, mi)
-end
+    function CC.getindex(wvc::WorldView{CodeCache}, mi::MethodInstance)
+        r = CC.get(wvc, mi, nothing)
+        r === nothing && throw(KeyError(mi))
+        return r::CodeInstance
+    end
+
+    function CC.setindex!(wvc::WorldView{CodeCache}, ci::CodeInstance, mi::MethodInstance)
+        return CC.setindex!(wvc.cache, ci, mi)
+    end
 
 end # HAS_INTEGRATED_CACHE
 
@@ -664,7 +710,7 @@ const _method_instances = Ref{Any}()
 const _cache = Ref{Any}()
 function _lookup_fun(mi, min_world, max_world)
     push!(_method_instances[], mi)
-    ci_cache_lookup(_cache[], mi, min_world, max_world)
+    return ci_cache_lookup(_cache[], mi, min_world, max_world)
 end
 
 @enum CompilationPolicy::Cint begin
@@ -706,7 +752,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
     if Sys.ARCH == :x86 || Sys.ARCH == :x86_64
         function lookup_fun(mi, min_world, max_world)
             push!(method_instances, mi)
-            ci_cache_lookup(cache, mi, min_world, max_world)
+            return ci_cache_lookup(cache, mi, min_world, max_world)
         end
         lookup_cb = @cfunction($lookup_fun, Any, (Any, UInt, UInt))
     else
@@ -720,21 +766,22 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
     imaging = imaging_mode(job)
 
     cgparams = (;
-        track_allocations  = false,
-        code_coverage      = false,
-        prefer_specsig     = true,
-        gnu_pubnames       = false,
-        debug_info_kind    = Cint(debug_info_kind),
+        track_allocations = false,
+        code_coverage = false,
+        prefer_specsig = true,
+        gnu_pubnames = false,
+        debug_info_kind = Cint(debug_info_kind),
         safepoint_on_entry = can_safepoint(job),
-        gcstack_arg        = false)
+        gcstack_arg = false,
+    )
     if :use_jlplt in fieldnames(Base.CodegenParams)
         cgparams = (; cgparams..., use_jlplt = imaging)
     end
     if VERSION < v"1.12.0-DEV.1667"
-        cgparams = (; lookup = Base.unsafe_convert(Ptr{Nothing}, lookup_cb), cgparams... )
+        cgparams = (; lookup = Base.unsafe_convert(Ptr{Nothing}, lookup_cb), cgparams...)
     end
     if v"1.12.0-DEV.2126" <= VERSION < v"1.13-" || VERSION >= v"1.13.0-DEV.285"
-        cgparams = (; force_emit_all = true , cgparams...)
+        cgparams = (; force_emit_all = true, cgparams...)
     end
     params = Base.CodegenParams(; cgparams...)
 
@@ -765,19 +812,25 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
             end
             @ccall jl_emit_native(codeinfos::Vector{Any}, ts_mod::LLVM.API.LLVMOrcThreadSafeModuleRef, Ref(params)::Ptr{Base.CodegenParams}, #=extern linkage=# false::Cint)::Ptr{Cvoid}
         elseif VERSION >= v"1.12.0-DEV.1667"
-            ccall(:jl_create_native, Ptr{Cvoid},
+            ccall(
+                :jl_create_native, Ptr{Cvoid},
                 (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint, Cint, Csize_t, Ptr{Cvoid}),
-                [job.source], ts_mod, Ref(params), CompilationPolicyExtern, imaging_flag, #=external linkage=# 0, job.world, Base.unsafe_convert(Ptr{Nothing}, lookup_cb))
+                [job.source], ts_mod, Ref(params), CompilationPolicyExtern, imaging_flag, #=external linkage=# 0, job.world, Base.unsafe_convert(Ptr{Nothing}, lookup_cb)
+            )
         else
-            ccall(:jl_create_native, Ptr{Cvoid},
+            ccall(
+                :jl_create_native, Ptr{Cvoid},
                 (Vector{MethodInstance}, LLVM.API.LLVMOrcThreadSafeModuleRef, Ptr{Base.CodegenParams}, Cint, Cint, Cint, Csize_t),
-                [job.source], ts_mod, Ref(params), CompilationPolicyExtern, imaging_flag, #=external linkage=# 0, job.world)
+                [job.source], ts_mod, Ref(params), CompilationPolicyExtern, imaging_flag, #=external linkage=# 0, job.world
+            )
         end
         @assert native_code != C_NULL
 
         llvm_mod_ref =
-            ccall(:jl_get_llvm_module, LLVM.API.LLVMOrcThreadSafeModuleRef,
-                  (Ptr{Cvoid},), native_code)
+            ccall(
+            :jl_get_llvm_module, LLVM.API.LLVMOrcThreadSafeModuleRef,
+            (Ptr{Cvoid},), native_code
+        )
         @assert llvm_mod_ref != C_NULL
 
         # XXX: this is wrong; we can't expose the underlying LLVM module, but should
@@ -797,14 +850,20 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
         # Since Julia 1.13, the caller is responsible for initializing global variables that
         # point to global values or bindings with their address in memory.
         num_gvars = Ref{Csize_t}(0)
-        @ccall jl_get_llvm_gvs(native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
-                               C_NULL::Ptr{Cvoid})::Nothing
+        @ccall jl_get_llvm_gvs(
+            native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
+            C_NULL::Ptr{Cvoid}
+        )::Nothing
         gvs = Vector{Ptr{LLVM.API.LLVMOpaqueValue}}(undef, num_gvars[])
-        @ccall jl_get_llvm_gvs(native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
-                               gvs::Ptr{LLVM.API.LLVMOpaqueValue})::Nothing
+        @ccall jl_get_llvm_gvs(
+            native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
+            gvs::Ptr{LLVM.API.LLVMOpaqueValue}
+        )::Nothing
         inits = Vector{Ptr{Cvoid}}(undef, num_gvars[])
-        @ccall jl_get_llvm_gv_inits(native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
-                                    inits::Ptr{Cvoid})::Nothing
+        @ccall jl_get_llvm_gv_inits(
+            native_code::Ptr{Cvoid}, num_gvars::Ptr{Csize_t},
+            inits::Ptr{Cvoid}
+        )::Nothing
 
         for (gv_ref, init) in zip(gvs, inits)
             gv = GlobalVariable(gv_ref)
@@ -819,11 +878,15 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
         # lookup function (used to populate method_instances) isn't always called then.
 
         num_cis = Ref{Csize_t}(0)
-        @ccall jl_get_llvm_cis(native_code::Ptr{Cvoid}, num_cis::Ptr{Csize_t},
-                               C_NULL::Ptr{Cvoid})::Nothing
+        @ccall jl_get_llvm_cis(
+            native_code::Ptr{Cvoid}, num_cis::Ptr{Csize_t},
+            C_NULL::Ptr{Cvoid}
+        )::Nothing
         resize!(method_instances, num_cis[])
-        @ccall jl_get_llvm_cis(native_code::Ptr{Cvoid}, num_cis::Ptr{Csize_t},
-                               method_instances::Ptr{Cvoid})::Nothing
+        @ccall jl_get_llvm_cis(
+            native_code::Ptr{Cvoid}, num_cis::Ptr{Csize_t},
+            method_instances::Ptr{Cvoid}
+        )::Nothing
 
         for (i, ci) in enumerate(method_instances)
             method_instances[i] = ci.def::MethodInstance
@@ -833,11 +896,15 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
         # slightly older versions of Julia used MIs directly
 
         num_mis = Ref{Csize_t}(0)
-        @ccall jl_get_llvm_mis(native_code::Ptr{Cvoid}, num_mis::Ptr{Csize_t},
-                               C_NULL::Ptr{Cvoid})::Nothing
+        @ccall jl_get_llvm_mis(
+            native_code::Ptr{Cvoid}, num_mis::Ptr{Csize_t},
+            C_NULL::Ptr{Cvoid}
+        )::Nothing
         resize!(method_instances, num_mis[])
-        @ccall jl_get_llvm_mis(native_code::Ptr{Cvoid}, num_mis::Ptr{Csize_t},
-                               method_instances::Ptr{Cvoid})::Nothing
+        @ccall jl_get_llvm_mis(
+            native_code::Ptr{Cvoid}, num_mis::Ptr{Csize_t},
+            method_instances::Ptr{Cvoid}
+        )::Nothing
     end
 
     # process all compiled method instances
@@ -849,15 +916,19 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
         # get the function index
         llvm_func_idx = Ref{Int32}(-1)
         llvm_specfunc_idx = Ref{Int32}(-1)
-        ccall(:jl_get_function_id, Nothing,
-              (Ptr{Cvoid}, Any, Ptr{Int32}, Ptr{Int32}),
-              native_code, ci, llvm_func_idx, llvm_specfunc_idx)
+        ccall(
+            :jl_get_function_id, Nothing,
+            (Ptr{Cvoid}, Any, Ptr{Int32}, Ptr{Int32}),
+            native_code, ci, llvm_func_idx, llvm_specfunc_idx
+        )
         @assert llvm_func_idx[] != -1 || llvm_specfunc_idx[] != -1 "Static compilation failed"
 
         # get the function
         llvm_func = if llvm_func_idx[] >= 1
-            llvm_func_ref = ccall(:jl_get_llvm_function, LLVM.API.LLVMValueRef,
-                                  (Ptr{Cvoid}, UInt32), native_code, llvm_func_idx[]-1)
+            llvm_func_ref = ccall(
+                :jl_get_llvm_function, LLVM.API.LLVMValueRef,
+                (Ptr{Cvoid}, UInt32), native_code, llvm_func_idx[] - 1
+            )
             @assert llvm_func_ref != C_NULL
             LLVM.name(LLVM.Function(llvm_func_ref))
         else
@@ -865,8 +936,10 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
         end
 
         llvm_specfunc = if llvm_specfunc_idx[] >= 1
-            llvm_specfunc_ref = ccall(:jl_get_llvm_function, LLVM.API.LLVMValueRef,
-                                      (Ptr{Cvoid}, UInt32), native_code, llvm_specfunc_idx[]-1)
+            llvm_specfunc_ref = ccall(
+                :jl_get_llvm_function, LLVM.API.LLVMValueRef,
+                (Ptr{Cvoid}, UInt32), native_code, llvm_specfunc_idx[] - 1
+            )
             @assert llvm_specfunc_ref != C_NULL
             LLVM.name(LLVM.Function(llvm_specfunc_ref))
         else
@@ -875,7 +948,7 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
 
         # NOTE: it's not safe to store raw LLVM functions here, since those may get
         #       removed or renamed during optimization, so we store their name instead.
-        compiled[mi] = (; ci, func=llvm_func, specfunc=llvm_specfunc)
+        compiled[mi] = (; ci, func = llvm_func, specfunc = llvm_specfunc)
     end
 
     # ensure that the requested method instance was compiled
@@ -886,15 +959,15 @@ end
 
 # partially revert JuliaLangjulia#49391
 @static if v"1.11.0-DEV.1603" <= VERSION < v"1.12.0-DEV.347" && # reverted on master
-           !(v"1.11-beta2" <= VERSION < v"1.12")                # reverted on 1.11-beta2
-function CC.typeinf(interp::GPUInterpreter, frame::CC.InferenceState)
-    if CC.__measure_typeinf__[]
-        CC.Timings.enter_new_timer(frame)
-        v = CC._typeinf(interp, frame)
-        CC.Timings.exit_current_timer(frame)
-        return v
-    else
-        return CC._typeinf(interp, frame)
+        !(v"1.11-beta2" <= VERSION < v"1.12")                # reverted on 1.11-beta2
+    function CC.typeinf(interp::GPUInterpreter, frame::CC.InferenceState)
+        if CC.__measure_typeinf__[]
+            CC.Timings.enter_new_timer(frame)
+            v = CC._typeinf(interp, frame)
+            CC.Timings.exit_current_timer(frame)
+            return v
+        else
+            return CC._typeinf(interp, frame)
+        end
     end
-end
 end

--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -5,7 +5,7 @@
 # LLVM doesn't like names with special characters, so we need to sanitize them.
 # note that we are stricter than LLVM, because of `ptxas`.
 
-safe_name(fn::String) = replace(fn, r"[^A-Za-z0-9]"=>"_")
+safe_name(fn::String) = replace(fn, r"[^A-Za-z0-9]" => "_")
 
 safe_name(t::DataType) = safe_name(String(nameof(t)))
 function safe_name(t::Type{<:Function})
@@ -21,7 +21,7 @@ function safe_name(t::Type{<:Function})
             mt.name
         end
     end
-    safe_name(string(fn))
+    return safe_name(string(fn))
 end
 safe_name(::Type{Union{}}) = "Bottom"
 
@@ -43,7 +43,7 @@ function mangle_param(t, substitutions = Any[], top = false)
         elseif sub == 1
             "S_"
         else
-            seq_id = uppercase(string(sub-2; base=36))
+            seq_id = uppercase(string(sub - 2; base = 36))
             "S$(seq_id)_"
         end
         return res
@@ -55,7 +55,7 @@ function mangle_param(t, substitutions = Any[], top = false)
         return str
     end
 
-    if isa(t, DataType) && t <: Ptr
+    return if isa(t, DataType) && t <: Ptr
         tn = mangle_param(eltype(t), substitutions)
         push!(substitutions, t)
         "P$tn"
@@ -129,34 +129,34 @@ function mangle_param(t, substitutions = Any[], top = false)
     elseif isa(t, Char)
         mangle_param(UInt32(t), substitutions)
     elseif isa(t, Union{Bool, Cchar, Cuchar, Cshort, Cushort, Cint, Cuint, Clong, Culong, Clonglong, Culonglong, Int128, UInt128})
-        ts = t isa Bool       ? 'b' : # bool
-             t isa Cchar      ? 'a' : # signed char
-             t isa Cuchar     ? 'h' : # unsigned char
-             t isa Cshort     ? 's' : # short
-             t isa Cushort    ? 't' : # unsigned short
-             t isa Cint       ? 'i' : # int
-             t isa Cuint      ? 'j' : # unsigned int
-             t isa Clong      ? 'l' : # long
-             t isa Culong     ? 'm' : # unsigned long
-             t isa Clonglong  ? 'x' : # long long, __int64
-             t isa Culonglong ? 'y' : # unsigned long long, __int64
-             t isa Int128     ? 'n' : # __int128
-             t isa UInt128    ? 'o' : # unsigned __int128
-             error("Invalid type")
-        tn = string(abs(t), base=10)
+        ts = t isa Bool ? 'b' : # bool
+            t isa Cchar ? 'a' : # signed char
+            t isa Cuchar ? 'h' : # unsigned char
+            t isa Cshort ? 's' : # short
+            t isa Cushort ? 't' : # unsigned short
+            t isa Cint ? 'i' : # int
+            t isa Cuint ? 'j' : # unsigned int
+            t isa Clong ? 'l' : # long
+            t isa Culong ? 'm' : # unsigned long
+            t isa Clonglong ? 'x' : # long long, __int64
+            t isa Culonglong ? 'y' : # unsigned long long, __int64
+            t isa Int128 ? 'n' : # __int128
+            t isa UInt128 ? 'o' : # unsigned __int128
+            error("Invalid type")
+        tn = string(abs(t), base = 10)
         # for legibility, encode Julia-native integers as C-native integers, if possible
         if t isa Int && typemin(Cint) <= t <= typemax(Cint)
             ts = 'i'
         end
         if t < 0
-            tn = 'n'*tn
+            tn = 'n' * tn
         end
         "L$(ts)$(tn)E"
     elseif t isa Float32
-        bits = string(reinterpret(UInt32, t); base=16)
+        bits = string(reinterpret(UInt32, t); base = 16)
         "Lf$(bits)E"
     elseif t isa Float64
-        bits = string(reinterpret(UInt64, t); base=16)
+        bits = string(reinterpret(UInt64, t); base = 16)
         "Ld$(bits)E"
     else
         tn = safe_name(t)   # TODO: actually does support digits...

--- a/src/mcgen.jl
+++ b/src/mcgen.jl
@@ -6,7 +6,7 @@ function prepare_execution!(@nospecialize(job::CompilerJob), mod::LLVM.Module)
     global current_job
     current_job = job
 
-    @dispose pb=NewPMPassBuilder() begin
+    @dispose pb = NewPMPassBuilder() begin
         register!(pb, ResolveCPUReferencesPass())
 
         add!(pb, RecomputeGlobalsAAPass())
@@ -56,7 +56,7 @@ function resolve_cpu_references!(mod::LLVM.Module)
                         changed = true
                     end
                 end
-                changed
+                return changed
             end
 
             changed |= replace_bindings!(f)
@@ -69,7 +69,7 @@ ResolveCPUReferencesPass() =
     NewPMModulePass("ResolveCPUReferences", resolve_cpu_references!)
 
 
-function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
+function mcgen(@nospecialize(job::CompilerJob), mod::LLVM.Module, format = LLVM.API.LLVMAssemblyFile)
     tm = llvm_machine(job.config.target)
 
     return String(emit(tm, mod, format))

--- a/src/native.jl
+++ b/src/native.jl
@@ -5,17 +5,17 @@
 export NativeCompilerTarget
 
 Base.@kwdef struct NativeCompilerTarget <: AbstractCompilerTarget
-    cpu::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
-    features::String=(LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
-    llvm_always_inline::Bool=false # will mark the job function as always inline
-    jlruntime::Bool=false # Use Julia runtime for throwing errors, instead of the GPUCompiler support
+    cpu::String = (LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUName())
+    features::String = (LLVM.version() < v"8") ? "" : unsafe_string(LLVM.API.LLVMGetHostCPUFeatures())
+    llvm_always_inline::Bool = false # will mark the job function as always inline
+    jlruntime::Bool = false # Use Julia runtime for throwing errors, instead of the GPUCompiler support
 end
 llvm_triple(::NativeCompilerTarget) = Sys.MACHINE
 
 function llvm_machine(target::NativeCompilerTarget)
     triple = llvm_triple(target)
 
-    t = Target(triple=triple)
+    t = Target(triple = triple)
 
     tm = TargetMachine(t, triple, target.cpu, target.features)
     asm_verbosity!(tm, true)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -2,22 +2,22 @@ using PrecompileTools: @setup_workload, @compile_workload
 
 @setup_workload begin
     precompile_module = @eval module $(gensym())
-        using ..GPUCompiler
+    using ..GPUCompiler
 
-        module DummyRuntime
-            # dummy methods
-            signal_exception() = return
-            malloc(sz) = C_NULL
-            report_oom(sz) = return
-            report_exception(ex) = return
-            report_exception_name(ex) = return
-            report_exception_frame(idx, func, file, line) = return
-        end
+    module DummyRuntime
+        # dummy methods
+        signal_exception() = return
+        malloc(sz) = C_NULL
+        report_oom(sz) = return
+        report_exception(ex) = return
+        report_exception_name(ex) = return
+        report_exception_frame(idx, func, file, line) = return
+    end
 
-        struct DummyCompilerParams <: AbstractCompilerParams end
-        const DummyCompilerJob = CompilerJob{NativeCompilerTarget, DummyCompilerParams}
+    struct DummyCompilerParams <: AbstractCompilerParams end
+    const DummyCompilerJob = CompilerJob{NativeCompilerTarget, DummyCompilerParams}
 
-        GPUCompiler.runtime_module(::DummyCompilerJob) = DummyRuntime
+    GPUCompiler.runtime_module(::DummyCompilerJob) = DummyRuntime
     end
 
     kernel() = nothing
@@ -28,7 +28,7 @@ using PrecompileTools: @setup_workload, @compile_workload
         params = precompile_module.DummyCompilerParams()
         # XXX: on Windows, compiling the GPU runtime leaks GPU code in the native cache,
         #      so prevent building the runtime library (see JuliaGPU/GPUCompiler.jl#601)
-        config = CompilerConfig(target, params; libraries=false)
+        config = CompilerConfig(target, params; libraries = false)
         job = CompilerJob(source, config)
 
         JuliaContext() do ctx

--- a/src/reflection_compat.jl
+++ b/src/reflection_compat.jl
@@ -3,11 +3,11 @@
 using InteractiveUtils: highlighting
 using Base: hasgenerator
 
-function method_instances(@nospecialize(tt::Type), world::UInt=Base.get_world_counter())
+function method_instances(@nospecialize(tt::Type), world::UInt = Base.get_world_counter())
     return map(Core.Compiler.specialize_method, method_matches(tt; world))
 end
 
-function code_lowered_by_type(@nospecialize(tt); generated::Bool=true, debuginfo::Symbol=:default)
+function code_lowered_by_type(@nospecialize(tt); generated::Bool = true, debuginfo::Symbol = :default)
 
     debuginfo = Base.IRShow.debuginfo(debuginfo)
     if debuginfo !== :source && debuginfo !== :none
@@ -18,9 +18,11 @@ function code_lowered_by_type(@nospecialize(tt); generated::Bool=true, debuginfo
             if Base.may_invoke_generator(m)
                 return ccall(:jl_code_for_staged, Any, (Any,), m)::CodeInfo
             else
-                error("Could not expand generator for `@generated` method ", m, ". ",
-                      "This can happen if the provided argument types (", t, ") are ",
-                      "not leaf types, but the `generated` argument is `true`.")
+                error(
+                    "Could not expand generator for `@generated` method ", m, ". ",
+                    "This can happen if the provided argument types (", t, ") are ",
+                    "not leaf types, but the `generated` argument is `true`."
+                )
             end
         end
         code = Base.uncompressed_ir(m.def::Method)
@@ -29,8 +31,10 @@ function code_lowered_by_type(@nospecialize(tt); generated::Bool=true, debuginfo
     end
 end
 
-function code_warntype_by_type(io::IO, @nospecialize(tt);
-                       debuginfo::Symbol=:default, optimize::Bool=false, kwargs...)
+function code_warntype_by_type(
+        io::IO, @nospecialize(tt);
+        debuginfo::Symbol = :default, optimize::Bool = false, kwargs...
+    )
     debuginfo = Base.IRShow.debuginfo(debuginfo)
     lineprinter = Base.IRShow.__debuginfo[debuginfo]
     for (src, rettype) in Base.code_typed_by_type(tt; optimize, kwargs...)
@@ -51,16 +55,16 @@ function code_warntype_by_type(io::IO, @nospecialize(tt);
                 println(io, "Static Parameters")
                 sig = p.def.sig
                 warn_color = Base.warn_color() # more mild user notification
-                for i = 1:length(p.sparam_vals)
+                for i in 1:length(p.sparam_vals)
                     sig = sig::UnionAll
                     name = sig.var.name
                     val = p.sparam_vals[i]
                     print_highlighted(io::IO, v::String, color::Symbol) =
-                        if highlighting[:warntype]
-                            Base.printstyled(io, v; color)
-                        else
-                            Base.print(io, v)
-                        end
+                    if highlighting[:warntype]
+                        Base.printstyled(io, v; color)
+                    else
+                        Base.print(io, v)
+                    end
                     if val isa TypeVar
                         if val.lb === Union{}
                             print(io, "  ", name, " <: ")
@@ -91,24 +95,24 @@ function code_warntype_by_type(io::IO, @nospecialize(tt);
             lambda_io = IOContext(lambda_io, :SOURCE_SLOTNAMES => slotnames)
             slottypes = src.slottypes
             nargs > 0 && println(io, "Arguments")
-            for i = 1:length(slotnames)
+            for i in 1:length(slotnames)
                 if i == nargs + 1
                     println(io, "Locals")
                 end
                 print(io, "  ", slotnames[i])
                 if isa(slottypes, Vector{Any})
-                    InteractiveUtils.warntype_type_printer(io; type=slottypes[i], used=true)
+                    InteractiveUtils.warntype_type_printer(io; type = slottypes[i], used = true)
                 end
                 println(io)
             end
         end
         print(io, "Body")
-        InteractiveUtils.warntype_type_printer(io; type=rettype, used=true)
+        InteractiveUtils.warntype_type_printer(io; type = rettype, used = true)
         println(io)
 
         irshow_config = Base.IRShow.IRShowConfig(lineprinter(src), InteractiveUtils.warntype_type_printer)
         Base.IRShow.show_ir(lambda_io, src, irshow_config)
         println(io)
     end
-    nothing
+    return nothing
 end

--- a/test/bpf.jl
+++ b/test/bpf.jl
@@ -1,6 +1,6 @@
 @testset "No-op" begin
     mod = @eval module $(gensym())
-        kernel() = 0
+    kernel() = 0
     end
 
     @test @filecheck begin
@@ -12,7 +12,7 @@
 end
 @testset "Return argument" begin
     mod = @eval module $(gensym())
-        kernel(x) = x
+    kernel(x) = x
     end
 
     @test @filecheck begin
@@ -24,7 +24,7 @@ end
 end
 @testset "Addition" begin
     mod = @eval module $(gensym())
-        kernel(x) = x+1
+    kernel(x) = x + 1
     end
 
     @test @filecheck begin
@@ -37,7 +37,7 @@ end
 end
 @testset "Errors" begin
     mod = @eval module $(gensym())
-        kernel(x) = fakefunc(x)
+    kernel(x) = fakefunc(x)
     end
 
     @test_throws GPUCompiler.InvalidIRError BPF.code_execution(mod.kernel, (UInt64,))
@@ -45,8 +45,8 @@ end
 @testset "Function Pointers" begin
     @testset "valid" begin
         mod = @eval module $(gensym())
-            goodcall(x) = Base.llvmcall("%2 = call i64 inttoptr (i64 3 to i64 (i64)*)(i64 %0)\nret i64 %2", Int, Tuple{Int}, x)
-            kernel(x) = goodcall(x)
+        goodcall(x) = Base.llvmcall("%2 = call i64 inttoptr (i64 3 to i64 (i64)*)(i64 %0)\nret i64 %2", Int, Tuple{Int}, x)
+        kernel(x) = goodcall(x)
         end
 
         @test @filecheck begin
@@ -59,8 +59,8 @@ end
 
     @testset "invalid" begin
         mod = @eval module $(gensym())
-            badcall(x) = Base.llvmcall("%2 = call i64 inttoptr (i64 3000 to i64 (i64)*)(i64 %0)\nret i64 %2", Int, Tuple{Int}, x)
-            kernel(x) = badcall(x)
+        badcall(x) = Base.llvmcall("%2 = call i64 inttoptr (i64 3000 to i64 (i64)*)(i64 %0)\nret i64 %2", Int, Tuple{Int}, x)
+        kernel(x) = badcall(x)
         end
 
         @test_throws GPUCompiler.InvalidIRError BPF.code_execution(mod.kernel, (Int,))

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,4 +1,4 @@
-function find_sources(path::String, sources=String[])
+function find_sources(path::String, sources = String[])
     if isdir(path)
         for entry in readdir(path)
             find_sources(joinpath(path, entry), sources)
@@ -6,7 +6,7 @@ function find_sources(path::String, sources=String[])
     elseif endswith(path, ".jl")
         push!(sources, path)
     end
-    sources
+    return sources
 end
 
 dir = joinpath(@__DIR__, "..", "examples")
@@ -18,6 +18,6 @@ cd(dir) do
     examples = relpath.(files, Ref(dir))
     @testset for example in examples
         cmd = `$(Base.julia_cmd()) --project=$(Base.active_project())`
-        @test success(pipeline(`$cmd $example`, stderr=stderr))
+        @test success(pipeline(`$cmd $example`, stderr = stderr))
     end
 end

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -1,286 +1,286 @@
 if :AMDGPU in LLVM.backends()
 
-# XXX: generic `sink` generates an instruction selection error
-sink_gcn(i) = sink(i, Val(5))
+    # XXX: generic `sink` generates an instruction selection error
+    sink_gcn(i) = sink(i, Val(5))
 
-@testset "IR" begin
+    @testset "IR" begin
 
-@testset "kernel calling convention" begin
-    mod = @eval module $(gensym())
-        kernel() = return
-    end
-
-    @test @filecheck begin
-        check"CHECK-NOT: amdgpu_kernel"
-        GCN.code_llvm(mod.kernel, Tuple{}; dump_module=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK: amdgpu_kernel"
-        GCN.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true)
-    end
-end
-
-@testset "bounds errors" begin
-    mod = @eval module $(gensym())
-        function kernel()
-            Base.throw_boundserror(1, 2)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-NOT: {{julia_throw_boundserror_[0-9]+}}"
-        check"CHECK: @gpu_report_exception"
-        check"CHECK: @gpu_signal_exception"
-        GCN.code_llvm(mod.kernel, Tuple{})
-    end
-end
-
-@testset "https://github.com/JuliaGPU/AMDGPU.jl/issues/846" begin
-    ir, rt = GCN.code_typed((Tuple{Tuple{Val{4}}, Tuple{Float32}},); always_inline=true) do t
-        t[1]
-    end |> only
-    @test rt == Tuple{Val{4}}
-end
-
-end
-
-############################################################################################
-@testset "assembly" begin
-
-@testset "skip scalar trap" begin
-    mod = @eval module $(gensym())
-        workitem_idx_x() = ccall("llvm.amdgcn.workitem.id.x", llvmcall, Int32, ())
-        trap() = ccall("llvm.trap", llvmcall, Nothing, ())
-
-        function kernel()
-            if workitem_idx_x() > 1
-                trap()
+        @testset "kernel calling convention" begin
+            mod = @eval module $(gensym())
+            kernel() = return
             end
-            return
-        end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: {{(julia|j)_kernel_[0-9]+}}:"
-        check"CHECK: s_cbranch_exec"
-        check"CHECK: s_trap 2"
-        GCN.code_native(mod.kernel, Tuple{})
-    end
-end
+            @test @filecheck begin
+                check"CHECK-NOT: amdgpu_kernel"
+                GCN.code_llvm(mod.kernel, Tuple{}; dump_module = true)
+            end
 
-@testset "child functions" begin
-    # we often test using @noinline child functions, so test whether these survive
-    # (despite not having side-effects)
-    mod = @eval module $(gensym())
-        import ..sink_gcn
-        @noinline child(i) = sink_gcn(i)
-        function parent(i)
-            child(i)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: {{(julia|j)_parent_[0-9]+}}:"
-        check"CHECK: s_add_u32 {{.+}} {{(julia|j)_child_[0-9]+}}@rel32@"
-        check"CHECK: s_addc_u32 {{.+}} {{(julia|j)_child_[0-9]+}}@rel32@"
-        GCN.code_native(mod.parent, Tuple{Int64}; dump_module=true)
-    end
-end
-
-@testset "kernel functions" begin
-    mod = @eval module $(gensym())
-        import ..sink_gcn
-        @noinline nonentry(i) = sink_gcn(i)
-        function entry(i)
-            nonentry(i)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-NOT: .amdhsa_kernel {{(julia|j)_nonentry_[0-9]+}}"
-        check"CHECK: .type {{(julia|j)_nonentry_[0-9]+}},@function"
-        check"CHECK: .amdhsa_kernel _Z5entry5Int64"
-        GCN.code_native(mod.entry, Tuple{Int64}; dump_module=true, kernel=true)
-    end
-end
-
-@testset "child function reuse" begin
-    # bug: depending on a child function from multiple parents resulted in
-    #      the child only being present once
-
-    mod = @eval module $(gensym())
-        import ..sink_gcn
-        @noinline child(i) = sink_gcn(i)
-        function parent1(i)
-            child(i)
-            return
-        end
-        function parent2(i)
-            child(i+1)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK: .type {{(julia|j)_child_[0-9]+}},@function"
-        GCN.code_native(mod.parent1, Tuple{Int}; dump_module=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK: .type {{(julia|j)_child_[0-9]+}},@function"
-        GCN.code_native(mod.parent2, Tuple{Int}; dump_module=true)
-    end
-end
-
-@testset "child function reuse bis" begin
-    # bug: similar, but slightly different issue as above
-    #      in the case of two child functions
-
-    mod = @eval module $(gensym())
-        import ..sink_gcn
-        @noinline child1(i) = sink_gcn(i)
-        @noinline child2(i) = sink_gcn(i+1)
-        function parent1(i)
-            child1(i) + child2(i)
-            return
-        end
-        function parent2(i)
-            child1(i+1) + child2(i+1)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-DAG: .type {{(julia|j)_child1_[0-9]+}},@function"
-        check"CHECK-DAG: .type {{(julia|j)_child2_[0-9]+}},@function"
-        GCN.code_native(mod.parent1, Tuple{Int}; dump_module=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK-DAG: .type {{(julia|j)_child1_[0-9]+}},@function"
-        check"CHECK-DAG: .type {{(julia|j)_child2_[0-9]+}},@function"
-        GCN.code_native(mod.parent2, Tuple{Int}; dump_module=true)
-    end
-end
-
-@testset "indirect sysimg function use" begin
-    # issue #9: re-using sysimg functions should force recompilation
-    #           (host fldmod1->mod1 throws, so the GCN code shouldn't contain a throw)
-
-    # NOTE: Int32 to test for #49
-
-    mod = @eval module $(gensym())
-        function kernel(out)
-            wid, lane = fldmod1(unsafe_load(out), Int32(32))
-            unsafe_store!(out, wid)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: {{(julia|j)_kernel_[0-9]+}}:"
-        check"CHECK-NOT: jl_throw"
-        check"CHECK-NOT: jl_invoke"
-        GCN.code_native(mod.kernel, Tuple{Ptr{Int32}})
-    end
-end
-
-@testset "LLVM intrinsics" begin
-    # issue #13 (a): cannot select trunc
-    mod = @eval module $(gensym())
-        function kernel(x)
-            unsafe_trunc(Int, x)
-            return
-        end
-    end
-    GCN.code_native(devnull, mod.kernel, Tuple{Float64})
-    @test "We did not crash!" != ""
-end
-
-# FIXME: _ZNK4llvm14TargetLowering20scalarizeVectorStoreEPNS_11StoreSDNodeERNS_12SelectionDAGE
-false && @testset "exception arguments" begin
-    mod = @eval module $(gensym())
-        function kernel(a)
-            unsafe_store!(a, trunc(Int, unsafe_load(a)))
-            return
-        end
-    end
-
-    GCN.code_native(devnull, mod.kernel, Tuple{Ptr{Float64}})
-end
-
-# FIXME: in function julia_inner_18528 void (%jl_value_t addrspace(10)*): invalid addrspacecast
-false && @testset "GC and TLS lowering" begin
-    mod = @eval module $(gensym())
-        import ..sink_gcn
-        mutable struct PleaseAllocate
-            y::Csize_t
+            @test @filecheck begin
+                check"CHECK: amdgpu_kernel"
+                GCN.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true)
+            end
         end
 
-        # common pattern in Julia 0.7: outlined throw to avoid a GC frame in the calling code
-        @noinline function inner(x)
-            sink_gcn(x.y)
-            nothing
+        @testset "bounds errors" begin
+            mod = @eval module $(gensym())
+            function kernel()
+                Base.throw_boundserror(1, 2)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-NOT: {{julia_throw_boundserror_[0-9]+}}"
+                check"CHECK: @gpu_report_exception"
+                check"CHECK: @gpu_signal_exception"
+                GCN.code_llvm(mod.kernel, Tuple{})
+            end
         end
 
-        function kernel(i)
-            inner(PleaseAllocate(Csize_t(42)))
-            nothing
+        @testset "https://github.com/JuliaGPU/AMDGPU.jl/issues/846" begin
+            ir, rt = GCN.code_typed((Tuple{Tuple{Val{4}}, Tuple{Float32}},); always_inline = true) do t
+                t[1]
+            end |> only
+            @test rt == Tuple{Val{4}}
         end
+
     end
 
-    @test @filecheck begin
-        check"CHECK-NOT: jl_push_gc_frame"
-        check"CHECK-NOT: jl_pop_gc_frame"
-        check"CHECK-NOT: jl_get_gc_frame_slot"
-        check"CHECK-NOT: jl_new_gc_frame"
-        check"CHECK: gpu_gc_pool_alloc"
-        GCN.code_native(mod.kernel, Tuple{Int})
-    end
+    ############################################################################################
+    @testset "assembly" begin
 
-    # make sure that we can still ellide allocations
-    function ref_kernel(ptr, i)
-        data = Ref{Int64}()
-        data[] = 0
-        if i > 1
-            data[] = 1
-        else
-            data[] = 2
+        @testset "skip scalar trap" begin
+            mod = @eval module $(gensym())
+            workitem_idx_x() = ccall("llvm.amdgcn.workitem.id.x", llvmcall, Int32, ())
+            trap() = ccall("llvm.trap", llvmcall, Nothing, ())
+
+            function kernel()
+                if workitem_idx_x() > 1
+                    trap()
+                end
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: {{(julia|j)_kernel_[0-9]+}}:"
+                check"CHECK: s_cbranch_exec"
+                check"CHECK: s_trap 2"
+                GCN.code_native(mod.kernel, Tuple{})
+            end
         end
-        unsafe_store!(ptr, data[], i)
-        return nothing
-    end
 
-    @test @filecheck begin
-        check"CHECK-NOT: gpu_gc_pool_alloc"
-        GCN.code_native(ref_kernel, Tuple{Ptr{Int64}, Int})
-    end
-end
+        @testset "child functions" begin
+            # we often test using @noinline child functions, so test whether these survive
+            # (despite not having side-effects)
+            mod = @eval module $(gensym())
+            import ..sink_gcn
+            @noinline child(i) = sink_gcn(i)
+            function parent(i)
+                child(i)
+                return
+            end
+            end
 
-@testset "float boxes" begin
-    mod = @eval module $(gensym())
-        function kernel(a,b)
-            c = Int32(a)
-            # the conversion to Int32 may fail, in which case the input Float32 is boxed in order to
-            # pass it to the @nospecialize exception constructor. we should really avoid that (eg.
-            # by avoiding @nospecialize, or optimize the unused arguments away), but for now the box
-            # should just work.
-            unsafe_store!(b, c)
-            return
+            @test @filecheck begin
+                check"CHECK-LABEL: {{(julia|j)_parent_[0-9]+}}:"
+                check"CHECK: s_add_u32 {{.+}} {{(julia|j)_child_[0-9]+}}@rel32@"
+                check"CHECK: s_addc_u32 {{.+}} {{(julia|j)_child_[0-9]+}}@rel32@"
+                GCN.code_native(mod.parent, Tuple{Int64}; dump_module = true)
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK: jl_box_float32"
-        GCN.code_llvm(mod.kernel, Tuple{Float32,Ptr{Float32}})
-    end
-    GCN.code_native(devnull, mod.kernel, Tuple{Float32,Ptr{Float32}})
-end
+        @testset "kernel functions" begin
+            mod = @eval module $(gensym())
+            import ..sink_gcn
+            @noinline nonentry(i) = sink_gcn(i)
+            function entry(i)
+                nonentry(i)
+                return
+            end
+            end
 
-end
+            @test @filecheck begin
+                check"CHECK-NOT: .amdhsa_kernel {{(julia|j)_nonentry_[0-9]+}}"
+                check"CHECK: .type {{(julia|j)_nonentry_[0-9]+}},@function"
+                check"CHECK: .amdhsa_kernel _Z5entry5Int64"
+                GCN.code_native(mod.entry, Tuple{Int64}; dump_module = true, kernel = true)
+            end
+        end
+
+        @testset "child function reuse" begin
+            # bug: depending on a child function from multiple parents resulted in
+            #      the child only being present once
+
+            mod = @eval module $(gensym())
+            import ..sink_gcn
+            @noinline child(i) = sink_gcn(i)
+            function parent1(i)
+                child(i)
+                return
+            end
+            function parent2(i)
+                child(i + 1)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK: .type {{(julia|j)_child_[0-9]+}},@function"
+                GCN.code_native(mod.parent1, Tuple{Int}; dump_module = true)
+            end
+
+            @test @filecheck begin
+                check"CHECK: .type {{(julia|j)_child_[0-9]+}},@function"
+                GCN.code_native(mod.parent2, Tuple{Int}; dump_module = true)
+            end
+        end
+
+        @testset "child function reuse bis" begin
+            # bug: similar, but slightly different issue as above
+            #      in the case of two child functions
+
+            mod = @eval module $(gensym())
+            import ..sink_gcn
+            @noinline child1(i) = sink_gcn(i)
+            @noinline child2(i) = sink_gcn(i + 1)
+            function parent1(i)
+                child1(i) + child2(i)
+                return
+            end
+            function parent2(i)
+                child1(i + 1) + child2(i + 1)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-DAG: .type {{(julia|j)_child1_[0-9]+}},@function"
+                check"CHECK-DAG: .type {{(julia|j)_child2_[0-9]+}},@function"
+                GCN.code_native(mod.parent1, Tuple{Int}; dump_module = true)
+            end
+
+            @test @filecheck begin
+                check"CHECK-DAG: .type {{(julia|j)_child1_[0-9]+}},@function"
+                check"CHECK-DAG: .type {{(julia|j)_child2_[0-9]+}},@function"
+                GCN.code_native(mod.parent2, Tuple{Int}; dump_module = true)
+            end
+        end
+
+        @testset "indirect sysimg function use" begin
+            # issue #9: re-using sysimg functions should force recompilation
+            #           (host fldmod1->mod1 throws, so the GCN code shouldn't contain a throw)
+
+            # NOTE: Int32 to test for #49
+
+            mod = @eval module $(gensym())
+            function kernel(out)
+                wid, lane = fldmod1(unsafe_load(out), Int32(32))
+                unsafe_store!(out, wid)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: {{(julia|j)_kernel_[0-9]+}}:"
+                check"CHECK-NOT: jl_throw"
+                check"CHECK-NOT: jl_invoke"
+                GCN.code_native(mod.kernel, Tuple{Ptr{Int32}})
+            end
+        end
+
+        @testset "LLVM intrinsics" begin
+            # issue #13 (a): cannot select trunc
+            mod = @eval module $(gensym())
+            function kernel(x)
+                unsafe_trunc(Int, x)
+                return
+            end
+            end
+            GCN.code_native(devnull, mod.kernel, Tuple{Float64})
+            @test "We did not crash!" != ""
+        end
+
+        # FIXME: _ZNK4llvm14TargetLowering20scalarizeVectorStoreEPNS_11StoreSDNodeERNS_12SelectionDAGE
+        false && @testset "exception arguments" begin
+            mod = @eval module $(gensym())
+            function kernel(a)
+                unsafe_store!(a, trunc(Int, unsafe_load(a)))
+                return
+            end
+            end
+
+            GCN.code_native(devnull, mod.kernel, Tuple{Ptr{Float64}})
+        end
+
+        # FIXME: in function julia_inner_18528 void (%jl_value_t addrspace(10)*): invalid addrspacecast
+        false && @testset "GC and TLS lowering" begin
+            mod = @eval module $(gensym())
+            import ..sink_gcn
+            mutable struct PleaseAllocate
+                y::Csize_t
+            end
+
+            # common pattern in Julia 0.7: outlined throw to avoid a GC frame in the calling code
+            @noinline function inner(x)
+                sink_gcn(x.y)
+                nothing
+            end
+
+            function kernel(i)
+                inner(PleaseAllocate(Csize_t(42)))
+                nothing
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-NOT: jl_push_gc_frame"
+                check"CHECK-NOT: jl_pop_gc_frame"
+                check"CHECK-NOT: jl_get_gc_frame_slot"
+                check"CHECK-NOT: jl_new_gc_frame"
+                check"CHECK: gpu_gc_pool_alloc"
+                GCN.code_native(mod.kernel, Tuple{Int})
+            end
+
+            # make sure that we can still ellide allocations
+            function ref_kernel(ptr, i)
+                data = Ref{Int64}()
+                data[] = 0
+                if i > 1
+                    data[] = 1
+                else
+                    data[] = 2
+                end
+                unsafe_store!(ptr, data[], i)
+                return nothing
+            end
+
+            @test @filecheck begin
+                check"CHECK-NOT: gpu_gc_pool_alloc"
+                GCN.code_native(ref_kernel, Tuple{Ptr{Int64}, Int})
+            end
+        end
+
+        @testset "float boxes" begin
+            mod = @eval module $(gensym())
+            function kernel(a, b)
+                c = Int32(a)
+                # the conversion to Int32 may fail, in which case the input Float32 is boxed in order to
+                # pass it to the @nospecialize exception constructor. we should really avoid that (eg.
+                # by avoiding @nospecialize, or optimize the unused arguments away), but for now the box
+                # should just work.
+                unsafe_store!(b, c)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK: jl_box_float32"
+                GCN.code_llvm(mod.kernel, Tuple{Float32, Ptr{Float32}})
+            end
+            GCN.code_native(devnull, mod.kernel, Tuple{Float32, Ptr{Float32}})
+        end
+
+    end
 end # :AMDGPU in LLVM.backends()

--- a/test/helpers/bpf.jl
+++ b/test/helpers/bpf.jl
@@ -4,25 +4,25 @@ using ..GPUCompiler
 import ..TestRuntime
 
 struct CompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::CompilerJob{<:Any, CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = BPFCompilerTarget()
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel = false, config_kwargs...)
+    return CompilerJob(source, config), kwargs
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_llvm(io, job; kwargs...)
+    return GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_native(io, job; kwargs...)
+    return GPUCompiler.code_native(io, job; kwargs...)
 end
 
 # aliases without ::IO argument
@@ -37,7 +37,7 @@ end
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    JuliaContext() do ctx
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job; kwargs...)
     end
 end

--- a/test/helpers/gcn.jl
+++ b/test/helpers/gcn.jl
@@ -4,35 +4,35 @@ using ..GPUCompiler
 import ..TestRuntime
 
 struct CompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::CompilerJob{<:Any, CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = GCNCompilerTarget(dev_isa="gfx900")
+    target = GCNCompilerTarget(dev_isa = "gfx900")
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel = false, config_kwargs...)
+    return CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_typed(job; kwargs...)
+    return GPUCompiler.code_typed(job; kwargs...)
 end
 
 function code_warntype(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_warntype(io, job; kwargs...)
+    return GPUCompiler.code_warntype(io, job; kwargs...)
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_llvm(io, job; kwargs...)
+    return GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_native(io, job; kwargs...)
+    return GPUCompiler.code_native(io, job; kwargs...)
 end
 
 # aliases without ::IO argument
@@ -46,8 +46,8 @@ end
 
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; kernel=true, kwargs...)
-    JuliaContext() do ctx
+    job, kwargs = create_job(func, types; kernel = true, kwargs...)
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job; kwargs...)
     end
 end

--- a/test/helpers/metal.jl
+++ b/test/helpers/metal.jl
@@ -4,35 +4,35 @@ using ..GPUCompiler
 import ..TestRuntime
 
 struct CompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::CompilerJob{<:Any, CompilerParams}) = TestRuntime
 
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
+    target = MetalCompilerTarget(; macos = v"12.2", metal = v"3.0", air = v"3.0")
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel = false, config_kwargs...)
+    return CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_typed(job; kwargs...)
+    return GPUCompiler.code_typed(job; kwargs...)
 end
 
 function code_warntype(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_warntype(io, job; kwargs...)
+    return GPUCompiler.code_warntype(io, job; kwargs...)
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_llvm(io, job; kwargs...)
+    return GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_native(io, job; kwargs...)
+    return GPUCompiler.code_native(io, job; kwargs...)
 end
 
 # aliases without ::IO argument
@@ -46,8 +46,8 @@ end
 
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; kernel=true, kwargs...)
-    JuliaContext() do ctx
+    job, kwargs = create_job(func, types; kernel = true, kwargs...)
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job; kwargs...)
     end
 end

--- a/test/helpers/native.jl
+++ b/test/helpers/native.jl
@@ -10,44 +10,46 @@ struct CompilerParams <: AbstractCompilerParams
     entry_safepoint::Bool
     method_table
 
-    CompilerParams(entry_safepoint::Bool=false, method_table=test_method_table) =
+    CompilerParams(entry_safepoint::Bool = false, method_table = test_method_table) =
         new(entry_safepoint, method_table)
 end
 
-NativeCompilerJob = CompilerJob{NativeCompilerTarget,CompilerParams}
+NativeCompilerJob = CompilerJob{NativeCompilerTarget, CompilerParams}
 GPUCompiler.runtime_module(::NativeCompilerJob) = TestRuntime
 
 GPUCompiler.method_table(@nospecialize(job::NativeCompilerJob)) = job.config.params.method_table
 GPUCompiler.can_safepoint(@nospecialize(job::NativeCompilerJob)) = job.config.params.entry_safepoint
 
-function create_job(@nospecialize(func), @nospecialize(types);
-                    entry_safepoint::Bool=false, method_table=test_method_table, kwargs...)
+function create_job(
+        @nospecialize(func), @nospecialize(types);
+        entry_safepoint::Bool = false, method_table = test_method_table, kwargs...
+    )
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = NativeCompilerTarget()
     params = CompilerParams(entry_safepoint, method_table)
-    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel = false, config_kwargs...)
+    return CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_typed(job; kwargs...)
+    return GPUCompiler.code_typed(job; kwargs...)
 end
 
 function code_warntype(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_warntype(io, job; kwargs...)
+    return GPUCompiler.code_warntype(io, job; kwargs...)
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_llvm(io, job; kwargs...)
+    return GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_native(io, job; kwargs...)
+    return GPUCompiler.code_native(io, job; kwargs...)
 end
 
 # aliases without ::IO argument
@@ -61,8 +63,8 @@ end
 
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; kernel=true, kwargs...)
-    JuliaContext() do ctx
+    job, kwargs = create_job(func, types; kernel = true, kwargs...)
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job; kwargs...)
     end
 end
@@ -70,19 +72,19 @@ end
 const runtime_cache = Dict{Any, Any}()
 
 function compiler(job)
-    JuliaContext() do ctx
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job)
     end
 end
 
 function linker(job, asm)
-    asm
+    return asm
 end
 
 # simulates cached codegen
 function cached_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; validate=false, kwargs...)
-    GPUCompiler.cached_compilation(runtime_cache, job.source, job.config, compiler, linker)
+    job, kwargs = create_job(func, types; validate = false, kwargs...)
+    return GPUCompiler.cached_compilation(runtime_cache, job.source, job.config, compiler, linker)
 end
 
 end

--- a/test/helpers/precompile.jl
+++ b/test/helpers/precompile.jl
@@ -1,5 +1,5 @@
 function precompile_test_harness(@nospecialize(f), testset::String)
-    @testset "$testset" begin
+    return @testset "$testset" begin
         precompile_test_harness(f, true)
     end
 end
@@ -7,8 +7,8 @@ function precompile_test_harness(@nospecialize(f), separate::Bool)
     # XXX: clean-up may fail on Windows, because opened files are not deletable.
     #      fix this by running the harness in a separate process, such that the
     #      compilation cache files are not opened?
-    load_path = mktempdir(cleanup=true)
-    load_cache_path = separate ? mktempdir(cleanup=true) : load_path
+    load_path = mktempdir(cleanup = true)
+    load_cache_path = separate ? mktempdir(cleanup = true) : load_path
     try
         pushfirst!(LOAD_PATH, load_path)
         pushfirst!(DEPOT_PATH, load_cache_path)
@@ -17,7 +17,7 @@ function precompile_test_harness(@nospecialize(f), separate::Bool)
         popfirst!(DEPOT_PATH)
         popfirst!(LOAD_PATH)
     end
-    nothing
+    return nothing
 end
 
 function check_presence(mi, token)
@@ -47,5 +47,5 @@ function create_standalone(load_path, name::String, file)
 
     # Write out the test setup as a micro package
     write(joinpath(load_path, "$name.jl"), string(code))
-    Base.compilecache(Base.PkgId(name))
+    return Base.compilecache(Base.PkgId(name))
 end

--- a/test/helpers/ptx.jl
+++ b/test/helpers/ptx.jl
@@ -5,7 +5,7 @@ import ..TestRuntime
 
 struct CompilerParams <: AbstractCompilerParams end
 
-PTXCompilerJob = CompilerJob{PTXCompilerTarget,CompilerParams}
+PTXCompilerJob = CompilerJob{PTXCompilerTarget, CompilerParams}
 
 struct PTXKernelState
     data::Int64
@@ -35,36 +35,38 @@ module PTXTestRuntime
 end
 GPUCompiler.runtime_module(::PTXCompilerJob) = PTXTestRuntime
 
-function create_job(@nospecialize(func), @nospecialize(types);
-                    minthreads=nothing, maxthreads=nothing,
-                    blocks_per_sm=nothing, maxregs=nothing,
-                    kwargs...)
+function create_job(
+        @nospecialize(func), @nospecialize(types);
+        minthreads = nothing, maxthreads = nothing,
+        blocks_per_sm = nothing, maxregs = nothing,
+        kwargs...
+    )
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = PTXCompilerTarget(; cap=v"7.0", minthreads, maxthreads, blocks_per_sm, maxregs)
+    target = PTXCompilerTarget(; cap = v"7.0", minthreads, maxthreads, blocks_per_sm, maxregs)
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel = false, config_kwargs...)
+    return CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_typed(job; kwargs...)
+    return GPUCompiler.code_typed(job; kwargs...)
 end
 
 function code_warntype(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_warntype(io, job; kwargs...)
+    return GPUCompiler.code_warntype(io, job; kwargs...)
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_llvm(io, job; kwargs...)
+    return GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_native(io, job; kwargs...)
+    return GPUCompiler.code_native(io, job; kwargs...)
 end
 
 # aliases without ::IO argument
@@ -78,8 +80,8 @@ end
 
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; kernel=true, kwargs...)
-    JuliaContext() do ctx
+    job, kwargs = create_job(func, types; kernel = true, kwargs...)
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job; kwargs...)
     end
 end

--- a/test/helpers/runtime.jl
+++ b/test/helpers/runtime.jl
@@ -1,9 +1,9 @@
 module TestRuntime
-    # dummy methods
-    signal_exception() = return
-    malloc(sz) = C_NULL
-    report_oom(sz) = return
-    report_exception(ex) = return
-    report_exception_name(ex) = return
-    report_exception_frame(idx, func, file, line) = return
+# dummy methods
+signal_exception() = return
+malloc(sz) = C_NULL
+report_oom(sz) = return
+report_exception(ex) = return
+report_exception_name(ex) = return
+report_exception_frame(idx, func, file, line) = return
 end

--- a/test/helpers/spirv.jl
+++ b/test/helpers/spirv.jl
@@ -4,38 +4,42 @@ using ..GPUCompiler
 import ..TestRuntime
 
 struct CompilerParams <: AbstractCompilerParams end
-GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
+GPUCompiler.runtime_module(::CompilerJob{<:Any, CompilerParams}) = TestRuntime
 
-function create_job(@nospecialize(func), @nospecialize(types);
-                   supports_fp16=true, supports_fp64=true, backend::Symbol,
-                   kwargs...)
+function create_job(
+        @nospecialize(func), @nospecialize(types);
+        supports_fp16 = true, supports_fp64 = true, backend::Symbol,
+        kwargs...
+    )
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = SPIRVCompilerTarget(; backend, validate=true, optimize=true,
-                                   supports_fp16, supports_fp64)
+    target = SPIRVCompilerTarget(;
+        backend, validate = true, optimize = true,
+        supports_fp16, supports_fp64
+    )
     params = CompilerParams()
-    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
-    CompilerJob(source, config), kwargs
+    config = CompilerConfig(target, params; kernel = false, config_kwargs...)
+    return CompilerJob(source, config), kwargs
 end
 
 function code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_typed(job; kwargs...)
+    return GPUCompiler.code_typed(job; kwargs...)
 end
 
 function code_warntype(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_warntype(io, job; kwargs...)
+    return GPUCompiler.code_warntype(io, job; kwargs...)
 end
 
 function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_llvm(io, job; kwargs...)
+    return GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
-    GPUCompiler.code_native(io, job; kwargs...)
+    return GPUCompiler.code_native(io, job; kwargs...)
 end
 
 # aliases without ::IO argument
@@ -49,8 +53,8 @@ end
 
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)
-    job, kwargs = create_job(func, types; kernel=true, kwargs...)
-    JuliaContext() do ctx
+    job, kwargs = create_job(func, types; kernel = true, kwargs...)
+    return JuliaContext() do ctx
         GPUCompiler.compile(:asm, job; kwargs...)
     end
 end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -1,186 +1,200 @@
 @testset "IR" begin
 
-@testset "kernel functions" begin
-@testset "byref aggregates" begin
-    mod = @eval module $(gensym())
-        kernel(x) = return
-    end
+    @testset "kernel functions" begin
+        @testset "byref aggregates" begin
+            mod = @eval module $(gensym())
+            kernel(x) = return
+            end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"TYPED-SAME: ({{(\{ i64 \}|\[1 x i64\])}}*"
-        check"OPAQUE-SAME: (ptr"
-        Metal.code_llvm(mod.kernel, Tuple{Tuple{Int}})
-    end
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"TYPED-SAME: ({{(\{ i64 \}|\[1 x i64\])}}*"
+                check"OPAQUE-SAME: (ptr"
+                Metal.code_llvm(mod.kernel, Tuple{Tuple{Int}})
+            end
 
-    # for kernels, every pointer argument needs to take an address space
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @_Z6kernel5TupleI5Int64E"
-        check"TYPED-SAME: ({{(\{ i64 \}|\[1 x i64\])}} addrspace(1)*"
-        check"OPAQUE-SAME: (ptr addrspace(1)"
-        Metal.code_llvm(mod.kernel, Tuple{Tuple{Int}}; kernel=true)
-    end
-end
-
-@testset "byref primitives" begin
-    mod = @eval module $(gensym())
-        kernel(x) = return
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK-SAME: (i64"
-        Metal.code_llvm(mod.kernel, Tuple{Int})
-    end
-
-    # for kernels, every pointer argument needs to take an address space
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @_Z6kernel5Int64"
-        check"TYPED-SAME: (i64 addrspace(1)*"
-        check"OPAQUE-SAME: (ptr addrspace(1)"
-        Metal.code_llvm(mod.kernel, Tuple{Int}; kernel=true)
-    end
-end
-
-@testset "module metadata" begin
-    mod = @eval module $(gensym())
-        kernel() = return
-    end
-
-    @test @filecheck begin
-        check"CHECK: air.version"
-        check"CHECK: air.language_version"
-        check"CHECK: air.max_device_buffers"
-        Metal.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true)
-    end
-end
-
-@testset "argument metadata" begin
-    mod = @eval module $(gensym())
-        kernel(x) = return
-    end
-
-    @test @filecheck begin
-        check"CHECK: air.buffer"
-        Metal.code_llvm(mod.kernel, Tuple{Int}; dump_module=true, kernel=true)
-    end
-
-    # XXX: perform more exhaustive testing of argument passing metadata here,
-    #      or just defer to execution testing in Metal.jl?
-end
-
-@testset "input arguments" begin
-    mod = @eval module $(gensym())
-        function kernel(ptr)
-            idx = ccall("extern julia.air.thread_position_in_threadgroup.i32",
-                        llvmcall, UInt32, ()) + 1
-            unsafe_store!(ptr, 42, idx)
-            return
+            # for kernels, every pointer argument needs to take an address space
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @_Z6kernel5TupleI5Int64E"
+                check"TYPED-SAME: ({{(\{ i64 \}|\[1 x i64\])}} addrspace(1)*"
+                check"OPAQUE-SAME: (ptr addrspace(1)"
+                Metal.code_llvm(mod.kernel, Tuple{Tuple{Int}}; kernel = true)
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"TYPED-SAME: ({{.+}} addrspace(1)* %{{.+}})"
-        check"OPAQUE-SAME: (ptr addrspace(1) %{{.+}})"
-        check"CHECK: call i32 @julia.air.thread_position_in_threadgroup.i32"
-        Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Int,1}})
-    end
+        @testset "byref primitives" begin
+            mod = @eval module $(gensym())
+            kernel(x) = return
+            end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @_Z6kernel7LLVMPtrI5Int64Li1EE"
-        check"TYPED-SAME: ({{.+}} addrspace(1)* %{{.+}}, i32 %thread_position_in_threadgroup)"
-        check"OPAQUE-SAME: (ptr addrspace(1) %{{.+}}, i32 %thread_position_in_threadgroup)"
-        check"CHECK-NOT: call i32 @julia.air.thread_position_in_threadgroup.i32"
-        Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Int,1}}; kernel=true)
-    end
-end
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK-SAME: (i64"
+                Metal.code_llvm(mod.kernel, Tuple{Int})
+            end
 
-@testset "vector intrinsics" begin
-    mod = @eval module $(gensym())
-        foo(x, y) = ccall("llvm.smax.v2i64", llvmcall, NTuple{2, VecElement{Int64}},
-                          (NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}}), x, y)
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: define <2 x i64> @{{(julia|j)_foo_[0-9]+}}"
-        check"CHECK: air.max.s.v2i64"
-        Metal.code_llvm(mod.foo, (NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}}))
-    end
-end
-
-@testset "unsupported type detection" begin
-    mod = @eval module $(gensym())
-        function kernel(ptr)
-            buf = reinterpret(Ptr{Float32}, ptr)
-            val = unsafe_load(buf)
-            dval = Cdouble(val)
-            # ccall("extern metal_os_log", llvmcall, Nothing, (Float64,), dval)
-            Base.llvmcall(("""
-                declare void @llvm.va_start(i8*)
-                declare void @llvm.va_end(i8*)
-                declare void @air.os_log(i8*, i64)
-
-                define void @metal_os_log(...) {
-                    %1 = alloca i8*
-                    %2 = bitcast i8** %1 to i8*
-                    call void @llvm.va_start(i8* %2)
-                    %3 = load i8*, i8** %1
-                    call void @air.os_log(i8* %3, i64 8)
-                    call void @llvm.va_end(i8* %2)
-                    ret void
-                }
-
-                define void @entry(double %val) #0 {
-                    call void (...) @metal_os_log(double %val)
-                    ret void
-                }
-
-                attributes #0 = { alwaysinline }""", "entry"),
-                Nothing, Tuple{Float64}, dval)
-            return
+            # for kernels, every pointer argument needs to take an address space
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @_Z6kernel5Int64"
+                check"TYPED-SAME: (i64 addrspace(1)*"
+                check"OPAQUE-SAME: (ptr addrspace(1)"
+                Metal.code_llvm(mod.kernel, Tuple{Int}; kernel = true)
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK: @metal_os_log"
-        Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Float32,1}}; validate=true)
-    end
+        @testset "module metadata" begin
+            mod = @eval module $(gensym())
+            kernel() = return
+            end
 
-    function kernel2(ptr)
-        val = unsafe_load(ptr)
-        res = val * val
-        unsafe_store!(ptr, res)
-        return
-    end
-
-    @test_throws_message(InvalidIRError,
-                         Metal.code_execution(kernel2,
-                                              Tuple{Core.LLVMPtr{Float64,1}})) do msg
-        occursin("unsupported use of double value", msg)
-    end
-end
-
-@testset "constant globals" begin
-    mod = @eval module $(gensym())
-        const xs = (1.0f0, 2f0)
-
-        function kernel(ptr, i)
-            unsafe_store!(ptr, xs[i])
-
-            return
+            @test @filecheck begin
+                check"CHECK: air.version"
+                check"CHECK: air.language_version"
+                check"CHECK: air.max_device_buffers"
+                Metal.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true)
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK: @{{.+}} ={{.*}} addrspace(2) constant [2 x float]"
-        check"CHECK: define void @_Z6kernel7LLVMPtrI7Float32Li1EE5Int64"
-        Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Float32,1}, Int};
-                        dump_module=true, kernel=true)
-    end
-end
+        @testset "argument metadata" begin
+            mod = @eval module $(gensym())
+            kernel(x) = return
+            end
 
-end
+            @test @filecheck begin
+                check"CHECK: air.buffer"
+                Metal.code_llvm(mod.kernel, Tuple{Int}; dump_module = true, kernel = true)
+            end
+
+            # XXX: perform more exhaustive testing of argument passing metadata here,
+            #      or just defer to execution testing in Metal.jl?
+        end
+
+        @testset "input arguments" begin
+            mod = @eval module $(gensym())
+            function kernel(ptr)
+                idx = ccall(
+                    "extern julia.air.thread_position_in_threadgroup.i32",
+                    llvmcall, UInt32, ()
+                ) + 1
+                unsafe_store!(ptr, 42, idx)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"TYPED-SAME: ({{.+}} addrspace(1)* %{{.+}})"
+                check"OPAQUE-SAME: (ptr addrspace(1) %{{.+}})"
+                check"CHECK: call i32 @julia.air.thread_position_in_threadgroup.i32"
+                Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Int, 1}})
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @_Z6kernel7LLVMPtrI5Int64Li1EE"
+                check"TYPED-SAME: ({{.+}} addrspace(1)* %{{.+}}, i32 %thread_position_in_threadgroup)"
+                check"OPAQUE-SAME: (ptr addrspace(1) %{{.+}}, i32 %thread_position_in_threadgroup)"
+                check"CHECK-NOT: call i32 @julia.air.thread_position_in_threadgroup.i32"
+                Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Int, 1}}; kernel = true)
+            end
+        end
+
+        @testset "vector intrinsics" begin
+            mod = @eval module $(gensym())
+            foo(x, y) = ccall(
+                "llvm.smax.v2i64", llvmcall, NTuple{2, VecElement{Int64}},
+                (NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}}), x, y
+            )
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: define <2 x i64> @{{(julia|j)_foo_[0-9]+}}"
+                check"CHECK: air.max.s.v2i64"
+                Metal.code_llvm(mod.foo, (NTuple{2, VecElement{Int64}}, NTuple{2, VecElement{Int64}}))
+            end
+        end
+
+        @testset "unsupported type detection" begin
+            mod = @eval module $(gensym())
+            function kernel(ptr)
+                buf = reinterpret(Ptr{Float32}, ptr)
+                val = unsafe_load(buf)
+                dval = Cdouble(val)
+                # ccall("extern metal_os_log", llvmcall, Nothing, (Float64,), dval)
+                Base.llvmcall(
+                    (
+                        """
+                        declare void @llvm.va_start(i8*)
+                        declare void @llvm.va_end(i8*)
+                        declare void @air.os_log(i8*, i64)
+
+                        define void @metal_os_log(...) {
+                            %1 = alloca i8*
+                            %2 = bitcast i8** %1 to i8*
+                            call void @llvm.va_start(i8* %2)
+                            %3 = load i8*, i8** %1
+                            call void @air.os_log(i8* %3, i64 8)
+                            call void @llvm.va_end(i8* %2)
+                            ret void
+                        }
+
+                        define void @entry(double %val) #0 {
+                            call void (...) @metal_os_log(double %val)
+                            ret void
+                        }
+
+                        attributes #0 = { alwaysinline }""", "entry",
+                    ),
+                    Nothing, Tuple{Float64}, dval
+                )
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK: @metal_os_log"
+                Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Float32, 1}}; validate = true)
+            end
+
+            function kernel2(ptr)
+                val = unsafe_load(ptr)
+                res = val * val
+                unsafe_store!(ptr, res)
+                return
+            end
+
+            @test_throws_message(
+                InvalidIRError,
+                Metal.code_execution(
+                    kernel2,
+                    Tuple{Core.LLVMPtr{Float64, 1}}
+                )
+            ) do msg
+                occursin("unsupported use of double value", msg)
+            end
+        end
+
+        @testset "constant globals" begin
+            mod = @eval module $(gensym())
+            const xs = (1.0f0, 2.0f0)
+
+            function kernel(ptr, i)
+                unsafe_store!(ptr, xs[i])
+
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK: @{{.+}} ={{.*}} addrspace(2) constant [2 x float]"
+                check"CHECK: define void @_Z6kernel7LLVMPtrI7Float32Li1EE5Int64"
+                Metal.code_llvm(
+                    mod.kernel, Tuple{Core.LLVMPtr{Float32, 1}, Int};
+                    dump_module = true, kernel = true
+                )
+            end
+        end
+
+    end
 
 end

--- a/test/native.jl
+++ b/test/native.jl
@@ -25,20 +25,20 @@ end
 @testset "compilation" begin
     @testset "callable structs" begin
         mod = @eval module $(gensym())
-            struct MyCallable end
-            (::MyCallable)(a, b) = a+b
+        struct MyCallable end
+        (::MyCallable)(a, b) = a + b
         end
 
-        (ci, rt) = Native.code_typed(mod.MyCallable(), (Int, Int), kernel=false)[1]
+        (ci, rt) = Native.code_typed(mod.MyCallable(), (Int, Int), kernel = false)[1]
         @test ci.slottypes[1] == Core.Compiler.Const(mod.MyCallable())
     end
 
     @testset "compilation database" begin
         mod = @eval module $(gensym())
-            @noinline inner(x) = x+1
-            function outer(x)
-                return inner(x)
-            end
+        @noinline inner(x) = x + 1
+        function outer(x)
+            return inner(x)
+        end
         end
 
         job, _ = Native.create_job(mod.outer, (Int,))
@@ -47,10 +47,10 @@ end
 
             meth = only(methods(mod.outer, (Int,)))
 
-            mis = filter(mi->mi.def == meth, keys(meta.compiled))
+            mis = filter(mi -> mi.def == meth, keys(meta.compiled))
             @test length(mis) == 1
 
-            other_mis = filter(mi->mi.def != meth, keys(meta.compiled))
+            other_mis = filter(mi -> mi.def != meth, keys(meta.compiled))
             @test length(other_mis) == 1
             @test only(other_mis).def in methods(mod.inner)
         end
@@ -58,23 +58,23 @@ end
 
     @testset "advanced database" begin
         mod = @eval module $(gensym())
-            @noinline inner(x) = x+1
-            foo(x) = sum(inner, fill(x, 10, 10))
+        @noinline inner(x) = x + 1
+        foo(x) = sum(inner, fill(x, 10, 10))
         end
 
-        job, _ = Native.create_job(mod.foo, (Float64,); validate=false)
+        job, _ = Native.create_job(mod.foo, (Float64,); validate = false)
         JuliaContext() do ctx
             # shouldn't segfault
             ir, meta = GPUCompiler.compile(:llvm, job)
 
             meth = only(methods(mod.foo, (Float64,)))
 
-            mis = filter(mi->mi.def == meth, keys(meta.compiled))
+            mis = filter(mi -> mi.def == meth, keys(meta.compiled))
             @test length(mis) == 1
 
             inner_methods = filter(keys(meta.compiled)) do mi
                 mi.def in methods(mod.inner) &&
-                mi.specTypes == Tuple{typeof(mod.inner), Float64}
+                    mi.specTypes == Tuple{typeof(mod.inner), Float64}
             end
             @test length(inner_methods) == 1
         end
@@ -82,8 +82,8 @@ end
 
     @testset "cached compilation" begin
         mod = @eval module $(gensym())
-            @noinline child(i) = i
-            kernel(i) = child(i)+1
+        @noinline child(i) = i
+        kernel(i) = child(i) + 1
         end
 
         # smoke test
@@ -95,7 +95,7 @@ end
         end
 
         # basic redefinition
-        @eval mod kernel(i) = child(i)+2
+        @eval mod kernel(i) = child(i) + 2
         job, _ = Native.create_job(mod.kernel, (Int64,))
         @test @filecheck begin
             check"CHECK-LABEL: define i64 @{{(julia|j)_kernel_[0-9]+}}"
@@ -135,7 +135,7 @@ end
         @test invocations[] == 1
 
         # redefinition
-        @eval mod kernel(i) = child(i)+3
+        @eval mod kernel(i) = child(i) + 3
         source = methodinstance(ft, tt, Base.get_world_counter())
         @test @filecheck begin
             check"CHECK-LABEL: define i64 @{{(julia|j)_kernel_[0-9]+}}"
@@ -158,7 +158,7 @@ end
         @test invocations[] == 2
 
         # redefining child functions
-        @eval mod @noinline child(i) = i+1
+        @eval mod @noinline child(i) = i + 1
         Base.invokelatest(GPUCompiler.cached_compilation, cache, source, job.config, compiler, linker)
         @test invocations[] == 3
 
@@ -167,7 +167,7 @@ end
         @test invocations[] == 3
 
         # change in configuration
-        config = CompilerConfig(job.config; name="foobar")
+        config = CompilerConfig(job.config; name = "foobar")
         @test @filecheck begin
             check"CHECK: define i64 @foobar"
             Base.invokelatest(GPUCompiler.cached_compilation, cache, source, config, compiler, linker)
@@ -184,7 +184,7 @@ end
         end
         t = @async Base.invokelatest(background, job)
         wait(c1)        # make sure the task has started
-        @eval mod kernel(i) = child(i)+4
+        @eval mod kernel(i) = child(i) + 4
         source = methodinstance(ft, tt, Base.get_world_counter())
         ir = Base.invokelatest(GPUCompiler.cached_compilation, cache, source, job.config, compiler, linker)
         @test contains(ir, r"add i64 %\d+, 4")
@@ -199,7 +199,7 @@ end
     @testset "allowed mutable types" begin
         # when types have no fields, we should always allow them
         mod = @eval module $(gensym())
-            struct Empty end
+        struct Empty end
         end
 
         Native.code_execution(Returns(nothing), (mod.Empty,))
@@ -213,140 +213,140 @@ end
 
 @testset "IR" begin
 
-@testset "basic reflection" begin
-    mod = @eval module $(gensym())
+    @testset "basic reflection" begin
+        mod = @eval module $(gensym())
         valid_kernel() = return
         invalid_kernel() = 1
+        end
+
+        @test @filecheck begin
+            # module should contain our function + a generic call wrapper
+            check"CHECK: @{{(julia|j)_valid_kernel_[0-9]+}}"
+            Native.code_llvm(mod.valid_kernel, Tuple{}; optimize = false, dump_module = true)
+        end
+
+        @test Native.code_llvm(devnull, mod.invalid_kernel, Tuple{}) == nothing
+        @test_throws KernelError Native.code_llvm(devnull, mod.invalid_kernel, Tuple{}; kernel = true) == nothing
     end
 
-    @test @filecheck begin
-        # module should contain our function + a generic call wrapper
-        check"CHECK: @{{(julia|j)_valid_kernel_[0-9]+}}"
-        Native.code_llvm(mod.valid_kernel, Tuple{}; optimize=false, dump_module=true)
-    end
-
-    @test Native.code_llvm(devnull, mod.invalid_kernel, Tuple{}) == nothing
-    @test_throws KernelError Native.code_llvm(devnull, mod.invalid_kernel, Tuple{}; kernel=true) == nothing
-end
-
-@testset "unbound typevars" begin
-    mod = @eval module $(gensym())
+    @testset "unbound typevars" begin
+        mod = @eval module $(gensym())
         invalid_kernel() where {unbound} = return
+        end
+        @test_throws KernelError Native.code_llvm(devnull, mod.invalid_kernel, Tuple{})
     end
-    @test_throws KernelError Native.code_llvm(devnull, mod.invalid_kernel, Tuple{})
-end
 
-@testset "child functions" begin
-    # we often test using `@noinline sink` child functions, so test whether these survive
-    mod = @eval module $(gensym())
+    @testset "child functions" begin
+        # we often test using `@noinline sink` child functions, so test whether these survive
+        mod = @eval module $(gensym())
         import ..sink
         @noinline child(i) = sink(i)
         parent(i) = child(i)
-    end
+        end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define i64 @{{(julia|j)_parent_[0-9]+}}"
-        check"CHECK: call{{.*}} i64 @{{(julia|j)_child_[0-9]+}}"
-        Native.code_llvm(mod.parent, Tuple{Int})
-    end
-end
-
-@testset "sysimg" begin
-    # bug: use a system image function
-    mod = @eval module $(gensym())
-        function foobar(a,i)
-            Base.pointerset(a, 0, mod1(i,10), 8)
+        @test @filecheck begin
+            check"CHECK-LABEL: define i64 @{{(julia|j)_parent_[0-9]+}}"
+            check"CHECK: call{{.*}} i64 @{{(julia|j)_child_[0-9]+}}"
+            Native.code_llvm(mod.parent, Tuple{Int})
         end
     end
 
-    @test @filecheck begin
-        check"CHECK-NOT: jlsys_"
-        Native.code_llvm(mod.foobar, Tuple{Ptr{Int},Int})
-    end
-end
+    @testset "sysimg" begin
+        # bug: use a system image function
+        mod = @eval module $(gensym())
+        function foobar(a, i)
+            Base.pointerset(a, 0, mod1(i, 10), 8)
+        end
+        end
 
-@testset "tracked pointers" begin
-    mod = @eval module $(gensym())
+        @test @filecheck begin
+            check"CHECK-NOT: jlsys_"
+            Native.code_llvm(mod.foobar, Tuple{Ptr{Int}, Int})
+        end
+    end
+
+    @testset "tracked pointers" begin
+        mod = @eval module $(gensym())
         function kernel(a)
             a[1] = 1
             return
         end
+        end
+
+        # this used to throw an LLVM assertion (#223)
+        Native.code_llvm(devnull, mod.kernel, Tuple{Vector{Int}}; kernel = true)
+        @test "We did not crash!" != ""
     end
 
-    # this used to throw an LLVM assertion (#223)
-    Native.code_llvm(devnull, mod.kernel, Tuple{Vector{Int}}; kernel=true)
-    @test "We did not crash!" != ""
-end
+    @testset "CUDA.jl#278" begin
+        # codegen idempotency
+        # NOTE: this isn't fixed, but surfaces here due to bad inference of checked_sub
+        # NOTE: with the fix to print_to_string this doesn't error anymore,
+        #       but still have a test to make sure it doesn't regress
+        Native.code_llvm(devnull, Base.checked_sub, Tuple{Int, Int}; optimize = false)
+        Native.code_llvm(devnull, Base.checked_sub, Tuple{Int, Int}; optimize = false)
 
-@testset "CUDA.jl#278" begin
-    # codegen idempotency
-    # NOTE: this isn't fixed, but surfaces here due to bad inference of checked_sub
-    # NOTE: with the fix to print_to_string this doesn't error anymore,
-    #       but still have a test to make sure it doesn't regress
-    Native.code_llvm(devnull, Base.checked_sub, Tuple{Int,Int}; optimize=false)
-    Native.code_llvm(devnull, Base.checked_sub, Tuple{Int,Int}; optimize=false)
+        # breaking recursion in print_to_string makes it possible to compile
+        # even in the presence of the above bug
+        Native.code_llvm(devnull, Base.print_to_string, Tuple{Int, Int}; optimize = false)
 
-    # breaking recursion in print_to_string makes it possible to compile
-    # even in the presence of the above bug
-    Native.code_llvm(devnull, Base.print_to_string, Tuple{Int,Int}; optimize=false)
+        @test "We did not crash!" != ""
+    end
 
-    @test "We did not crash!" != ""
-end
-
-@testset "LLVM D32593" begin
-    mod = @eval module $(gensym())
+    @testset "LLVM D32593" begin
+        mod = @eval module $(gensym())
         struct D32593_struct
             foo::Float32
             bar::Float32
         end
 
         D32593(ptr) = unsafe_load(ptr).foo
+        end
+
+        Native.code_llvm(devnull, mod.D32593, Tuple{Ptr{mod.D32593_struct}})
+        @test "We did not crash!" != ""
     end
 
-    Native.code_llvm(devnull, mod.D32593, Tuple{Ptr{mod.D32593_struct}})
-    @test "We did not crash!" != ""
-end
-
-@testset "slow abi" begin
-    mod = @eval module $(gensym())
+    @testset "slow abi" begin
+        mod = @eval module $(gensym())
         x = 2
-        f = () -> x+1
-    end
-    @test @filecheck begin
-        check"CHECK: define {{.+}} @julia"
-        check"TYPED: define nonnull {}* @jfptr"
-        check"OPAQUE: define nonnull ptr @jfptr"
-        check"CHECK: call {{.+}} @julia"
-        Native.code_llvm(mod.f, Tuple{}; entry_abi=:func, dump_module=true)
-    end
-end
-
-@testset "function entry safepoint emission" begin
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_identity_[0-9]+}}"
-        check"CHECK-NOT: %safepoint"
-        Native.code_llvm(identity, Tuple{Nothing}; entry_safepoint=false, optimize=false, dump_module=true)
-    end
-
-    # XXX: broken by JuliaLang/julia#57010,
-    #      see https://github.com/JuliaLang/julia/pull/57010/files#r2079576894
-    if VERSION < v"1.13.0-DEV.533"
+        f = () -> x + 1
+        end
         @test @filecheck begin
-            check"CHECK-LABEL: define void @{{(julia|j)_identity_[0-9]+}}"
-            check"CHECK: %safepoint"
-            Native.code_llvm(identity, Tuple{Nothing}; entry_safepoint=true, optimize=false, dump_module=true)
+            check"CHECK: define {{.+}} @julia"
+            check"TYPED: define nonnull {}* @jfptr"
+            check"OPAQUE: define nonnull ptr @jfptr"
+            check"CHECK: call {{.+}} @julia"
+            Native.code_llvm(mod.f, Tuple{}; entry_abi = :func, dump_module = true)
         end
     end
-end
 
-@testset "always_inline" begin
-    # XXX: broken by JuliaLang/julia#51599, see JuliaGPU/GPUCompiler.jl#527.
-    #      yet somehow this works on 1.12?
-    broken = VERSION >= v"1.13-"
+    @testset "function entry safepoint emission" begin
+        @test @filecheck begin
+            check"CHECK-LABEL: define void @{{(julia|j)_identity_[0-9]+}}"
+            check"CHECK-NOT: %safepoint"
+            Native.code_llvm(identity, Tuple{Nothing}; entry_safepoint = false, optimize = false, dump_module = true)
+        end
 
-    mod = @eval module $(gensym())
+        # XXX: broken by JuliaLang/julia#57010,
+        #      see https://github.com/JuliaLang/julia/pull/57010/files#r2079576894
+        if VERSION < v"1.13.0-DEV.533"
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_identity_[0-9]+}}"
+                check"CHECK: %safepoint"
+                Native.code_llvm(identity, Tuple{Nothing}; entry_safepoint = true, optimize = false, dump_module = true)
+            end
+        end
+    end
+
+    @testset "always_inline" begin
+        # XXX: broken by JuliaLang/julia#51599, see JuliaGPU/GPUCompiler.jl#527.
+        #      yet somehow this works on 1.12?
+        broken = VERSION >= v"1.13-"
+
+        mod = @eval module $(gensym())
         import ..sink
-        expensive(x) = $(foldl((e, _) -> :($sink($e) + $sink(x)), 1:100; init=:x))
+        expensive(x) = $(foldl((e, _) -> :($sink($e) + $sink(x)), 1:100; init = :x))
         function g(x)
             expensive(x)
             return
@@ -355,51 +355,59 @@ end
             expensive(x)
             return
         end
+        end
+
+        @test @filecheck begin
+            check"CHECK: @{{(julia|j)_expensive_[0-9]+}}"
+            Native.code_llvm(mod.g, Tuple{Int64}; dump_module = true, kernel = true)
+        end
+
+        @test @filecheck(
+            begin
+                check"CHECK-NOT: @{{(julia|j)_expensive_[0-9]+}}"
+                Native.code_llvm(mod.g, Tuple{Int64}; dump_module = true, kernel = true, always_inline = true)
+            end
+        ) broken = broken
+
+        @test @filecheck begin
+            check"CHECK: @{{(julia|j)_expensive_[0-9]+}}"
+            Native.code_llvm(mod.h, Tuple{Int64}; dump_module = true, kernel = true)
+        end
+
+        @test @filecheck(
+            begin
+                check"CHECK-NOT: @{{(julia|j)_expensive_[0-9]+}}"
+                Native.code_llvm(mod.h, Tuple{Int64}; dump_module = true, kernel = true, always_inline = true)
+            end
+        ) broken = broken
     end
 
-    @test @filecheck begin
-        check"CHECK: @{{(julia|j)_expensive_[0-9]+}}"
-        Native.code_llvm(mod.g, Tuple{Int64}; dump_module=true, kernel=true)
-    end
-
-    @test @filecheck(begin
-        check"CHECK-NOT: @{{(julia|j)_expensive_[0-9]+}}"
-        Native.code_llvm(mod.g, Tuple{Int64}; dump_module=true, kernel=true, always_inline=true)
-    end) broken=broken
-
-    @test @filecheck begin
-        check"CHECK: @{{(julia|j)_expensive_[0-9]+}}"
-        Native.code_llvm(mod.h, Tuple{Int64}; dump_module=true, kernel=true)
-    end
-
-    @test @filecheck(begin
-        check"CHECK-NOT: @{{(julia|j)_expensive_[0-9]+}}"
-        Native.code_llvm(mod.h, Tuple{Int64}; dump_module=true, kernel=true, always_inline=true)
-    end) broken=broken
-end
-
-@testset "function attributes" begin
-    mod = @eval module $(gensym())
+    @testset "function attributes" begin
+        mod = @eval module $(gensym())
         @inline function convergent_barrier()
-            Base.llvmcall(("""
-                declare void @barrier() #1
+            Base.llvmcall(
+                (
+                    """
+                    declare void @barrier() #1
 
-                define void @entry() #0 {
-                    call void @barrier()
-                    ret void
-                }
+                    define void @entry() #0 {
+                        call void @barrier()
+                        ret void
+                    }
 
-                attributes #0 = { alwaysinline }
-                attributes #1 = { convergent }""", "entry"),
-            Nothing, Tuple{})
+                    attributes #0 = { alwaysinline }
+                    attributes #1 = { convergent }""", "entry",
+                ),
+                Nothing, Tuple{}
+            )
+        end
+        end
+
+        @test @filecheck begin
+            check"CHECK: attributes #{{.}} = { convergent }"
+            Native.code_llvm(mod.convergent_barrier, Tuple{}; dump_module = true, raw = true)
         end
     end
-
-    @test @filecheck begin
-        check"CHECK: attributes #{{.}} = { convergent }"
-        Native.code_llvm(mod.convergent_barrier, Tuple{}; dump_module=true, raw=true)
-    end
-end
 
 end
 
@@ -407,33 +415,33 @@ end
 
 @testset "assembly" begin
 
-@testset "basic reflection" begin
-    mod = @eval module $(gensym())
+    @testset "basic reflection" begin
+        mod = @eval module $(gensym())
         valid_kernel() = return
         invalid_kernel() = 1
+        end
+
+        @test Native.code_native(devnull, mod.valid_kernel, Tuple{}) == nothing
+        @test Native.code_native(devnull, mod.invalid_kernel, Tuple{}) == nothing
+        @test_throws KernelError Native.code_native(devnull, mod.invalid_kernel, Tuple{}; kernel = true)
     end
 
-    @test Native.code_native(devnull, mod.valid_kernel, Tuple{}) == nothing
-    @test Native.code_native(devnull, mod.invalid_kernel, Tuple{}) == nothing
-    @test_throws KernelError Native.code_native(devnull, mod.invalid_kernel, Tuple{}; kernel=true)
-end
-
-@testset "idempotency" begin
-    # bug: generate code twice for the same kernel (jl_to_ptx wasn't idempotent)
-    mod = @eval module $(gensym())
+    @testset "idempotency" begin
+        # bug: generate code twice for the same kernel (jl_to_ptx wasn't idempotent)
+        mod = @eval module $(gensym())
         kernel() = return
+        end
+        Native.code_native(devnull, mod.kernel, Tuple{})
+        Native.code_native(devnull, mod.kernel, Tuple{})
+
+        @test "We did not crash!" != ""
     end
-    Native.code_native(devnull, mod.kernel, Tuple{})
-    Native.code_native(devnull, mod.kernel, Tuple{})
 
-    @test "We did not crash!" != ""
-end
-
-@testset "compile for host after gpu" begin
-    # issue #11: re-using host functions after GPU compilation
-    mod = @eval module $(gensym())
+    @testset "compile for host after gpu" begin
+        # issue #11: re-using host functions after GPU compilation
+        mod = @eval module $(gensym())
         import ..sink
-        @noinline child(i) = sink(i+1)
+        @noinline child(i) = sink(i + 1)
 
         function fromhost()
             child(10)
@@ -443,11 +451,11 @@ end
             child(10)
             return
         end
-    end
+        end
 
-    Native.code_native(devnull, mod.fromptx, Tuple{})
-    @test mod.fromhost() == 11
-end
+        Native.code_native(devnull, mod.fromptx, Tuple{})
+        @test mod.fromhost() == 11
+    end
 
 end
 
@@ -456,119 +464,137 @@ end
 @testset "errors" begin
 
 
-@testset "non-isbits arguments" begin
-    mod = @eval module $(gensym())
+    @testset "non-isbits arguments" begin
+        mod = @eval module $(gensym())
         import ..sink
-        foobar(i) = (sink(unsafe_trunc(Int,i)); return)
-    end
+        foobar(i) = (sink(unsafe_trunc(Int, i)); return)
+        end
 
-    @test_throws_message(KernelError,
-                         Native.code_execution(mod.foobar, Tuple{BigInt})) do msg
-        occursin("passing non-bitstype argument", msg) &&
-        occursin("BigInt", msg)
-    end
+        @test_throws_message(
+            KernelError,
+            Native.code_execution(mod.foobar, Tuple{BigInt})
+        ) do msg
+            occursin("passing non-bitstype argument", msg) &&
+                occursin("BigInt", msg)
+        end
 
-    # test that we get information about fields and reason why something is not isbits
-    mod = @eval module $(gensym())
+        # test that we get information about fields and reason why something is not isbits
+        mod = @eval module $(gensym())
         struct CleverType{T}
             x::T
         end
         Base.unsafe_trunc(::Type{Int}, x::CleverType) = unsafe_trunc(Int, x.x)
-        foobar(i) = (sink(unsafe_trunc(Int,i)); return)
+        foobar(i) = (sink(unsafe_trunc(Int, i)); return)
+        end
+        @test_throws_message(
+            KernelError,
+            Native.code_execution(mod.foobar, Tuple{mod.CleverType{BigInt}})
+        ) do msg
+            occursin("passing non-bitstype argument", msg) &&
+                occursin("CleverType", msg) &&
+                occursin("BigInt", msg)
+        end
     end
-    @test_throws_message(KernelError,
-                         Native.code_execution(mod.foobar, Tuple{mod.CleverType{BigInt}})) do msg
-        occursin("passing non-bitstype argument", msg) &&
-        occursin("CleverType", msg) &&
-        occursin("BigInt", msg)
-    end
-end
 
-@testset "invalid LLVM IR" begin
-    mod = @eval module $(gensym())
+    @testset "invalid LLVM IR" begin
+        mod = @eval module $(gensym())
         foobar(i) = println(i)
+        end
+
+        @test_throws_message(
+            InvalidIRError,
+            Native.code_execution(mod.foobar, Tuple{Int})
+        ) do msg
+            occursin("invalid LLVM IR", msg) &&
+                (
+                occursin(GPUCompiler.RUNTIME_FUNCTION, msg) ||
+                    occursin(GPUCompiler.UNKNOWN_FUNCTION, msg) ||
+                    occursin(GPUCompiler.DYNAMIC_CALL, msg)
+            ) &&
+                occursin("[1] println", msg) &&
+                occursin("[2] foobar", msg)
+        end
     end
 
-    @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.foobar, Tuple{Int})) do msg
-        occursin("invalid LLVM IR", msg) &&
-        (occursin(GPUCompiler.RUNTIME_FUNCTION, msg) ||
-         occursin(GPUCompiler.UNKNOWN_FUNCTION, msg) ||
-         occursin(GPUCompiler.DYNAMIC_CALL, msg)) &&
-        occursin("[1] println", msg) &&
-        occursin("[2] foobar", msg)
-    end
-end
-
-@testset "invalid LLVM IR (ccall)" begin
-    mod = @eval module $(gensym())
+    @testset "invalid LLVM IR (ccall)" begin
+        mod = @eval module $(gensym())
         function foobar(p)
             unsafe_store!(p, ccall(:time, Cint, ()))
             return
         end
-    end
+        end
 
-    @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.foobar, Tuple{Ptr{Int}})) do msg
-        if VERSION >= v"1.11-"
-            occursin("invalid LLVM IR", msg) &&
-            (occursin(GPUCompiler.LAZY_FUNCTION, msg) ||
-             occursin(GPUCompiler.RUNTIME_FUNCTION, msg)) &&
-            occursin("call to time", msg) &&
-            occursin("[1] foobar", msg)
-        else
-            occursin("invalid LLVM IR", msg) &&
-            occursin(GPUCompiler.POINTER_FUNCTION, msg) &&
-            occursin("[1] foobar", msg)
+        @test_throws_message(
+            InvalidIRError,
+            Native.code_execution(mod.foobar, Tuple{Ptr{Int}})
+        ) do msg
+            if VERSION >= v"1.11-"
+                occursin("invalid LLVM IR", msg) &&
+                    (
+                    occursin(GPUCompiler.LAZY_FUNCTION, msg) ||
+                        occursin(GPUCompiler.RUNTIME_FUNCTION, msg)
+                ) &&
+                    occursin("call to time", msg) &&
+                    occursin("[1] foobar", msg)
+            else
+                occursin("invalid LLVM IR", msg) &&
+                    occursin(GPUCompiler.POINTER_FUNCTION, msg) &&
+                    occursin("[1] foobar", msg)
+            end
         end
     end
-end
 
-@testset "delayed bindings" begin
-    mod = @eval module $(gensym())
+    @testset "delayed bindings" begin
+        mod = @eval module $(gensym())
         function kernel()
             undefined
             return
         end
+        end
+
+        @test_throws_message(
+            InvalidIRError,
+            Native.code_execution(mod.kernel, Tuple{})
+        ) do msg
+            occursin("invalid LLVM IR", msg) &&
+                occursin(GPUCompiler.DELAYED_BINDING, msg) &&
+                occursin(r"use of '.*undefined'", msg) &&
+                occursin("[1] kernel", msg)
+        end
     end
 
-    @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.kernel, Tuple{})) do msg
-        occursin("invalid LLVM IR", msg) &&
-        occursin(GPUCompiler.DELAYED_BINDING, msg) &&
-        occursin(r"use of '.*undefined'", msg) &&
-        occursin("[1] kernel", msg)
-    end
-end
-
-@testset "dynamic call (invoke)" begin
-    mod = @eval module $(gensym())
+    @testset "dynamic call (invoke)" begin
+        mod = @eval module $(gensym())
         @noinline nospecialize_child(@nospecialize(i)) = i
         kernel(a, b) = (unsafe_store!(b, nospecialize_child(a)); return)
+        end
+
+        @test_throws_message(
+            InvalidIRError,
+            Native.code_execution(mod.kernel, Tuple{Int, Ptr{Int}})
+        ) do msg
+            occursin("invalid LLVM IR", msg) &&
+                occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
+                occursin("call to nospecialize_child", msg) &&
+                occursin("[1] kernel", msg)
+        end
     end
 
-    @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.kernel, Tuple{Int,Ptr{Int}})) do msg
-        occursin("invalid LLVM IR", msg) &&
-        occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
-        occursin("call to nospecialize_child", msg) &&
-        occursin("[1] kernel", msg)
-    end
-end
-
-@testset "dynamic call (apply)" begin
-    mod = @eval module $(gensym())
+    @testset "dynamic call (apply)" begin
+        mod = @eval module $(gensym())
         func() = println(1)
-    end
+        end
 
-    @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.func, Tuple{})) do msg
-        occursin("invalid LLVM IR", msg) &&
-        occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
-        occursin("call to print", msg) &&
-        occursin("[2] func", msg)
+        @test_throws_message(
+            InvalidIRError,
+            Native.code_execution(mod.func, Tuple{})
+        ) do msg
+            occursin("invalid LLVM IR", msg) &&
+                occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
+                occursin("call to print", msg) &&
+                occursin("[2] func", msg)
+        end
     end
-end
 
 end
 
@@ -578,8 +604,8 @@ end
     # NOTE: method overrides do not support redefinitions, so we use different kernels
 
     mod = @eval module $(gensym())
-        kernel() = child()
-        @inline child() = 0
+    kernel() = child()
+    @inline child() = 0
     end
 
     @test @filecheck begin
@@ -589,14 +615,14 @@ end
     end
 
     mod = @eval module $(gensym())
-        using ..GPUCompiler
+    using ..GPUCompiler
 
-        Base.Experimental.@MethodTable(method_table)
+    Base.Experimental.@MethodTable(method_table)
 
-        kernel() = child()
-        @inline child() = 0
+    kernel() = child()
+    @inline child() = 0
 
-        Base.Experimental.@overlay method_table child() = 1
+    Base.Experimental.@overlay method_table child() = 1
     end
 
     @test @filecheck begin
@@ -609,26 +635,26 @@ end
 @testset "semi-concrete interpretation + overlay methods" begin
     # issue 366, caused dynamic deispatch
     mod = @eval module $(gensym())
-        using ..GPUCompiler
-        using StaticArrays
+    using ..GPUCompiler
+    using StaticArrays
 
-        function kernel(width, height)
-            xy = SVector{2, Float32}(0.5f0, 0.5f0)
-            res = SVector{2, UInt32}(width, height)
-            floor.(UInt32, max.(0f0, xy) .* res)
-            return
-        end
+    function kernel(width, height)
+        xy = SVector{2, Float32}(0.5f0, 0.5f0)
+        res = SVector{2, UInt32}(width, height)
+        floor.(UInt32, max.(0.0f0, xy) .* res)
+        return
+    end
 
-        Base.Experimental.@MethodTable method_table
-        Base.Experimental.@overlay method_table Base.isnan(x::Float32) =
-            (ccall("extern __nv_isnanf", llvmcall, Int32, (Cfloat,), x)) != 0
+    Base.Experimental.@MethodTable method_table
+    Base.Experimental.@overlay method_table Base.isnan(x::Float32) =
+        (ccall("extern __nv_isnanf", llvmcall, Int32, (Cfloat,), x)) != 0
     end
 
     @test @filecheck begin
         check"CHECK-LABEL: @julia_kernel"
         check"CHECK-NOT: apply_generic"
         check"CHECK: llvm.floor"
-        Native.code_llvm(mod.kernel, Tuple{Int, Int}; debuginfo=:none, mod.method_table)
+        Native.code_llvm(mod.kernel, Tuple{Int, Int}; debuginfo = :none, mod.method_table)
     end
 end
 
@@ -637,14 +663,14 @@ end
     # broken again by JuliaLang/julia#51092, see JuliaGPU/GPUCompiler.jl#506
 
     mod = @eval module $(gensym())
-        child(; kwargs...) = return
-        function parent()
-            child(; a=1f0, b=1.0)
-            return
-        end
+    child(; kwargs...) = return
+    function parent()
+        child(; a = 1.0f0, b = 1.0)
+        return
+    end
 
-        Base.Experimental.@MethodTable method_table
-        Base.Experimental.@overlay method_table @noinline Core.throw_inexacterror(f::Symbol, ::Type{T}, val) where {T} = return
+    Base.Experimental.@MethodTable method_table
+    Base.Experimental.@overlay method_table @noinline Core.throw_inexacterror(f::Symbol, ::Type{T}, val) where {T} = return
     end
 
     @test @filecheck begin
@@ -654,7 +680,7 @@ end
         check"CHECK-NOT: inttoptr"
         check"CHECK-NOT: apply_type"
         check"CHECK: ret void"
-        Native.code_llvm(mod.parent, Tuple{}; debuginfo=:none, mod.method_table)
+        Native.code_llvm(mod.parent, Tuple{}; debuginfo = :none, mod.method_table)
     end
 end
 
@@ -670,7 +696,7 @@ end
         return
     end
 
-    ir = sprint(io->Native.code_llvm(io, dkernel, Tuple{Vector{Float64}}; debuginfo=:none))
+    ir = sprint(io -> Native.code_llvm(io, dkernel, Tuple{Vector{Float64}}; debuginfo = :none))
     @test !occursin("deferred_codegen", ir)
     @test occursin("call void @julia_kernel", ir)
 end

--- a/test/native/precompile.jl
+++ b/test/native/precompile.jl
@@ -1,32 +1,33 @@
-
-
 precompile_test_harness("Inference caching") do load_path
     # Write out the Native test setup as a micro package
     create_standalone(load_path, "NativeCompiler", "native.jl")
 
-    write(joinpath(load_path, "NativeBackend.jl"), :(
-        module NativeBackend
-        import NativeCompiler
-        using PrecompileTools
+    write(
+        joinpath(load_path, "NativeBackend.jl"), :(
+            module NativeBackend
+            import NativeCompiler
+            using PrecompileTools
 
-        function kernel(A, x)
-            A[1] = x
-            return
-        end
+            function kernel(A, x)
+                A[1] = x
+                return
+            end
 
-        let
-            job, _ = NativeCompiler.Native.create_job(kernel, (Vector{Int}, Int))
-            precompile(job)
-        end
-
-        # identity is foreign
-        @setup_workload begin
-            job, _ = NativeCompiler.Native.create_job(identity, (Int,))
-            @compile_workload begin
+            let
+                job, _ = NativeCompiler.Native.create_job(kernel, (Vector{Int}, Int))
                 precompile(job)
             end
-        end
-    end) |> string)
+
+            # identity is foreign
+            @setup_workload begin
+                job, _ = NativeCompiler.Native.create_job(identity, (Int,))
+                @compile_workload begin
+                    precompile(job)
+                end
+            end
+            end
+        ) |> string
+    )
 
     Base.compilecache(Base.PkgId("NativeBackend"))
     @eval let
@@ -48,7 +49,7 @@ precompile_test_harness("Inference caching") do load_path
         @test check_presence(kernel_mi, token)
 
         # check that identity survived
-        @test check_presence(identity_mi, token) broken=VERSION>=v"1.12.0-DEV.1268"
+        @test check_presence(identity_mi, token) broken = VERSION >= v"1.12.0-DEV.1268"
 
         GPUCompiler.clear_disk_cache!()
         @test GPUCompiler.disk_cache_enabled() == false
@@ -56,7 +57,7 @@ precompile_test_harness("Inference caching") do load_path
         GPUCompiler.enable_disk_cache!()
         @test GPUCompiler.disk_cache_enabled() == true
 
-        job, _ = NativeCompiler.Native.create_job(NativeBackend.kernel, (Vector{Int}, Int); validate=false)
+        job, _ = NativeCompiler.Native.create_job(NativeBackend.kernel, (Vector{Int}, Int); validate = false)
         @assert job.source == kernel_mi
         ci = GPUCompiler.ci_cache_lookup(GPUCompiler.ci_cache(job), job.source, job.world, job.world)
         @assert ci !== nothing

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -1,423 +1,423 @@
 @testset "IR" begin
 
-@testset "exceptions" begin
-    mod = @eval module $(gensym())
+    @testset "exceptions" begin
+        mod = @eval module $(gensym())
         foobar() = throw(DivideError())
-    end
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_foobar_[0-9]+}}"
-        # plain exceptions should get lowered to a call to the GPU run-time
-        # not a jl_throw referencing a jl_value_t representing the exception
-        check"CHECK-NOT: jl_throw"
-        check"CHECK: gpu_report_exception"
+        end
+        @test @filecheck begin
+            check"CHECK-LABEL: define void @{{(julia|j)_foobar_[0-9]+}}"
+            # plain exceptions should get lowered to a call to the GPU run-time
+            # not a jl_throw referencing a jl_value_t representing the exception
+            check"CHECK-NOT: jl_throw"
+            check"CHECK: gpu_report_exception"
 
-        PTX.code_llvm(mod.foobar, Tuple{}; dump_module=true)
-    end
-end
-
-@testset "kernel functions" begin
-@testset "kernel argument attributes" begin
-    mod = @eval module $(gensym())
-        kernel(x) = return
-
-        struct Aggregate
-            x::Int
+            PTX.code_llvm(mod.foobar, Tuple{}; dump_module = true)
         end
     end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"TYPED-SAME: ({{({ i64 }|\[1 x i64\])}}*"
-        check"OPAQUE-SAME: (ptr"
-        PTX.code_llvm(mod.kernel, Tuple{mod.Aggregate})
-    end
+    @testset "kernel functions" begin
+        @testset "kernel argument attributes" begin
+            mod = @eval module $(gensym())
+            kernel(x) = return
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define ptx_kernel void @_Z6kernel9Aggregate"
-        check"TYPED-NOT: *"
-        check"OPAQUE-NOT: ptr"
-        PTX.code_llvm(mod.kernel, Tuple{mod.Aggregate}; kernel=true)
-    end
-end
+            struct Aggregate
+                x::Int
+            end
+            end
 
-@testset "property_annotations" begin
-    mod = @eval module $(gensym())
-        kernel() = return
-    end
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"TYPED-SAME: ({{({ i64 }|\[1 x i64\])}}*"
+                check"OPAQUE-SAME: (ptr"
+                PTX.code_llvm(mod.kernel, Tuple{mod.Aggregate})
+            end
 
-    @test @filecheck begin
-        check"CHECK-NOT: nvvm.annotations"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK-NOT: maxntid"
-        check"CHECK-NOT: reqntid"
-        check"CHECK-NOT: minctasm"
-        check"CHECK-NOT: maxnreg"
-        check"CHECK: nvvm.annotations"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK: maxntidx\", i32 42"
-        check"CHECK: maxntidy\", i32 1"
-        check"CHECK: maxntidz\", i32 1"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true, maxthreads=42)
-    end
-
-    @test @filecheck begin
-        check"CHECK: reqntidx\", i32 42"
-        check"CHECK: reqntidy\", i32 1"
-        check"CHECK: reqntidz\", i32 1"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true, minthreads=42)
-    end
-
-    @test @filecheck begin
-        check"CHECK: minctasm\", i32 42"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true, blocks_per_sm=42)
-    end
-
-    @test @filecheck begin
-        check"CHECK: maxnreg\", i32 42"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true, maxregs=42)
-    end
-end
-
-LLVM.version() >= v"8" && @testset "calling convention" begin
-    mod = @eval module $(gensym())
-        kernel() = return
-    end
-
-    @test @filecheck begin
-        check"CHECK-NOT: ptx_kernel"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK: ptx_kernel"
-        PTX.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true)
-    end
-end
-
-@testset "kernel state" begin
-    # state should be passed by value to kernel functions
-
-    mod = @eval module $(gensym())
-        kernel() = return
-    end
-
-    @test @filecheck begin
-        check"CHECK: @{{(julia|j)_kernel[0-9_]*}}()"
-        PTX.code_llvm(mod.kernel, Tuple{})
-    end
-
-    @test @filecheck begin
-        check"CHECK: @_Z6kernel([1 x i64] %state)"
-        PTX.code_llvm(mod.kernel, Tuple{}; kernel=true)
-    end
-
-    # state should only passed to device functions that use it
-
-    mod = @eval module $(gensym())
-        @noinline child1(ptr) = unsafe_load(ptr)
-        @noinline function child2()
-            data = $PTX.kernel_state().data
-            ptr = reinterpret(Ptr{Int}, data)
-            unsafe_load(ptr)
+            @test @filecheck begin
+                check"CHECK-LABEL: define ptx_kernel void @_Z6kernel9Aggregate"
+                check"TYPED-NOT: *"
+                check"OPAQUE-NOT: ptr"
+                PTX.code_llvm(mod.kernel, Tuple{mod.Aggregate}; kernel = true)
+            end
         end
 
-        function kernel(ptr)
-            unsafe_store!(ptr, child1(ptr) + child2())
+        @testset "property_annotations" begin
+            mod = @eval module $(gensym())
+            kernel() = return
+            end
+
+            @test @filecheck begin
+                check"CHECK-NOT: nvvm.annotations"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true)
+            end
+
+            @test @filecheck begin
+                check"CHECK-NOT: maxntid"
+                check"CHECK-NOT: reqntid"
+                check"CHECK-NOT: minctasm"
+                check"CHECK-NOT: maxnreg"
+                check"CHECK: nvvm.annotations"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true)
+            end
+
+            @test @filecheck begin
+                check"CHECK: maxntidx\", i32 42"
+                check"CHECK: maxntidy\", i32 1"
+                check"CHECK: maxntidz\", i32 1"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true, maxthreads = 42)
+            end
+
+            @test @filecheck begin
+                check"CHECK: reqntidx\", i32 42"
+                check"CHECK: reqntidy\", i32 1"
+                check"CHECK: reqntidz\", i32 1"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true, minthreads = 42)
+            end
+
+            @test @filecheck begin
+                check"CHECK: minctasm\", i32 42"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true, blocks_per_sm = 42)
+            end
+
+            @test @filecheck begin
+                check"CHECK: maxnreg\", i32 42"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true, maxregs = 42)
+            end
+        end
+
+        LLVM.version() >= v"8" && @testset "calling convention" begin
+            mod = @eval module $(gensym())
+            kernel() = return
+            end
+
+            @test @filecheck begin
+                check"CHECK-NOT: ptx_kernel"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true)
+            end
+
+            @test @filecheck begin
+                check"CHECK: ptx_kernel"
+                PTX.code_llvm(mod.kernel, Tuple{}; dump_module = true, kernel = true)
+            end
+        end
+
+        @testset "kernel state" begin
+            # state should be passed by value to kernel functions
+
+            mod = @eval module $(gensym())
+            kernel() = return
+            end
+
+            @test @filecheck begin
+                check"CHECK: @{{(julia|j)_kernel[0-9_]*}}()"
+                PTX.code_llvm(mod.kernel, Tuple{})
+            end
+
+            @test @filecheck begin
+                check"CHECK: @_Z6kernel([1 x i64] %state)"
+                PTX.code_llvm(mod.kernel, Tuple{}; kernel = true)
+            end
+
+            # state should only passed to device functions that use it
+
+            mod = @eval module $(gensym())
+            @noinline child1(ptr) = unsafe_load(ptr)
+            @noinline function child2()
+                data = $PTX.kernel_state().data
+                ptr = reinterpret(Ptr{Int}, data)
+                unsafe_load(ptr)
+            end
+
+            function kernel(ptr)
+                unsafe_store!(ptr, child1(ptr) + child2())
+                return
+            end
+            end
+
+            # kernel should take state argument before all else
+            @test @filecheck begin
+                check"CHECK-LABEL: define ptx_kernel void @_Z6kernelP5Int64([1 x i64] %state"
+                check"CHECK-NOT: julia.gpu.state_getter"
+                PTX.code_llvm(mod.kernel, Tuple{Ptr{Int64}}; kernel = true, dump_module = true)
+            end
+            # child1 doesn't use the state
+            @test @filecheck begin
+                check"CHECK-LABEL: define{{.*}} i64 @{{(julia|j)_child1_[0-9]+}}"
+                PTX.code_llvm(mod.kernel, Tuple{Ptr{Int64}}; kernel = true, dump_module = true)
+            end
+            # child2 does
+            @test @filecheck begin
+                check"CHECK-LABEL: define{{.*}} i64 @{{(julia|j)_child2_[0-9]+}}"
+                PTX.code_llvm(mod.kernel, Tuple{Ptr{Int64}}; kernel = true, dump_module = true)
+            end
+        end
+    end
+
+    @testset "Mock Enzyme" begin
+        function kernel(a)
+            unsafe_store!(a, unsafe_load(a)^2)
             return
         end
-    end
 
-    # kernel should take state argument before all else
-    @test @filecheck begin
-        check"CHECK-LABEL: define ptx_kernel void @_Z6kernelP5Int64([1 x i64] %state"
-        check"CHECK-NOT: julia.gpu.state_getter"
-        PTX.code_llvm(mod.kernel, Tuple{Ptr{Int64}}; kernel=true, dump_module=true)
-    end
-    # child1 doesn't use the state
-    @test @filecheck begin
-        check"CHECK-LABEL: define{{.*}} i64 @{{(julia|j)_child1_[0-9]+}}"
-        PTX.code_llvm(mod.kernel, Tuple{Ptr{Int64}}; kernel=true, dump_module=true)
-    end
-    # child2 does
-    @test @filecheck begin
-        check"CHECK-LABEL: define{{.*}} i64 @{{(julia|j)_child2_[0-9]+}}"
-        PTX.code_llvm(mod.kernel, Tuple{Ptr{Int64}}; kernel=true, dump_module=true)
-    end
-end
-end
+        function dkernel(a)
+            ptr = Enzyme.deferred_codegen(typeof(kernel), Tuple{Ptr{Float64}})
+            ccall(ptr, Cvoid, (Ptr{Float64},), a)
+            return
+        end
 
-@testset "Mock Enzyme" begin
-    function kernel(a)
-        unsafe_store!(a, unsafe_load(a)^2)
-        return
+        ir = sprint(io -> Native.code_llvm(io, dkernel, Tuple{Ptr{Float64}}; debuginfo = :none))
+        @test !occursin("deferred_codegen", ir)
+        @test occursin("call void @julia_", ir)
     end
-    
-    function dkernel(a)
-        ptr = Enzyme.deferred_codegen(typeof(kernel), Tuple{Ptr{Float64}})
-        ccall(ptr, Cvoid, (Ptr{Float64},), a)
-        return
-    end
-
-    ir = sprint(io->Native.code_llvm(io, dkernel, Tuple{Ptr{Float64}}; debuginfo=:none))
-    @test !occursin("deferred_codegen", ir)
-    @test occursin("call void @julia_", ir)
-end
 
 end
 
 ############################################################################################
 if :NVPTX in LLVM.backends()
-@testset "assembly" begin
+    @testset "assembly" begin
 
-@testset "child functions" begin
-    # we often test using @noinline child functions, so test whether these survive
-    # (despite not having side-effects)
+        @testset "child functions" begin
+            # we often test using @noinline child functions, so test whether these survive
+            # (despite not having side-effects)
 
-    mod = @eval module $(gensym())
-        import ..sink
-        @noinline child(i) = sink(i)
-        function parent(i)
-            child(i)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: .visible .func {{(julia|j)_parent[0-9_]*}}"
-        check"CHECK: call.uni"
-        check"CHECK-NEXT: {{(julia|j)_child_}}"
-        PTX.code_native(mod.parent, Tuple{Int64})
-    end
-end
-
-@testset "kernel functions" begin
-    mod = @eval module $(gensym())
-        import ..sink
-        @noinline nonentry(i) = sink(i)
-        function entry(i)
-            nonentry(i)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-NOT: .visible .func {{(julia|j)_nonentry}}"
-        check"CHECK-LABEL: .visible .entry _Z5entry5Int64"
-        check"CHECK: {{(julia|j)_nonentry}}"
-        PTX.code_native(mod.entry, Tuple{Int64}; kernel=true, dump_module=true)
-    end
-
-@testset "property_annotations" begin
-    @test @filecheck begin
-        check"CHECK-NOT: maxntid"
-        PTX.code_native(mod.entry, Tuple{Int64}; kernel=true)
-    end
-
-    @test @filecheck begin
-        check"CHECK: .maxntid 42, 1, 1"
-        PTX.code_native(mod.entry, Tuple{Int64}; kernel=true, maxthreads=42)
-    end
-
-    @test @filecheck begin
-        check"CHECK: .reqntid 42, 1, 1"
-        PTX.code_native(mod.entry, Tuple{Int64}; kernel=true, minthreads=42)
-    end
-
-    @test @filecheck begin
-        check"CHECK: .minnctapersm 42"
-        PTX.code_native(mod.entry, Tuple{Int64}; kernel=true, blocks_per_sm=42)
-    end
-
-    if LLVM.version() >= v"4.0"
-        @test @filecheck begin
-            check"CHECK: .maxnreg 42"
-            PTX.code_native(mod.entry, Tuple{Int64}; kernel=true, maxregs=42)
-        end
-    end
-end
-end
-
-@testset "child function reuse" begin
-    # bug: depending on a child function from multiple parents resulted in
-    #      the child only being present once
-
-    mod = @eval module $(gensym())
-        import ..sink
-        @noinline child(i) = sink(i)
-        function parent1(i)
-            child(i)
-            return
-        end
-        function parent2(i)
-            child(i+1)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK: .func {{(julia|j)_child}}"
-        PTX.code_native(mod.parent1, Tuple{Int})
-    end
-
-    @test @filecheck begin
-        check"CHECK: .func {{(julia|j)_child}}"
-        PTX.code_native(mod.parent2, Tuple{Int})
-    end
-end
-
-@testset "child function reuse bis" begin
-    # bug: similar, but slightly different issue as above
-    #      in the case of two child functions
-
-    mod = @eval module $(gensym())
-        import ..sink
-        @noinline child1(i) = sink(i)
-        @noinline child2(i) = sink(i+1)
-        function parent1(i)
-            child1(i) + child2(i)
-            return
-        end
-        function parent2(i)
-            child1(i+1) + child2(i+1)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-DAG: .func {{(julia|j)_child1}}"
-        check"CHECK-DAG: .func {{(julia|j)_child2}}"
-        PTX.code_native(mod.parent1, Tuple{Int})
-    end
-
-    @test @filecheck begin
-        check"CHECK-DAG: .func {{(julia|j)_child1}}"
-        check"CHECK-DAG: .func {{(julia|j)_child2}}"
-        PTX.code_native(mod.parent2, Tuple{Int})
-    end
-end
-
-@testset "indirect sysimg function use" begin
-    # issue #9: re-using sysimg functions should force recompilation
-    #           (host fldmod1->mod1 throws, so the PTX code shouldn't contain a throw)
-
-    # NOTE: Int32 to test for #49
-    mod = @eval module $(gensym())
-        function kernel(out)
-            wid, lane = fldmod1(unsafe_load(out), Int32(32))
-            unsafe_store!(out, wid)
-            return
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: .visible .func {{(julia|j)_kernel[0-9_]*}}"
-        check"CHECK-NOT: jl_throw"
-        check"CHECK-NOT: jl_invoke"
-        PTX.code_native(mod.kernel, Tuple{Ptr{Int32}})
-    end
-end
-
-@testset "LLVM intrinsics" begin
-    # issue #13 (a): cannot select trunc
-    mod = @eval module $(gensym())
-        function kernel(x)
-            unsafe_trunc(Int, x)
-            return
-        end
-    end
-    PTX.code_native(devnull, mod.kernel, Tuple{Float64})
-    @test "We did not crash!" != ""
-end
-
-@testset "exception arguments" begin
-    mod = @eval module $(gensym())
-        function kernel(a)
-            unsafe_store!(a, trunc(Int, unsafe_load(a)))
-            return
-        end
-    end
-    PTX.code_native(devnull, mod.kernel, Tuple{Ptr{Float64}})
-    @test "We did not crash!" != ""
-end
-
-@testset "GC and TLS lowering" begin
-    mod = @eval module $(gensym())
-        import ..sink
-
-        mutable struct PleaseAllocate
-            y::Csize_t
-        end
-
-        # common pattern in Julia 0.7: outlined throw to avoid a GC frame in the calling code
-        @noinline function inner(x)
-            sink(x.y)
-            nothing
-        end
-
-        function kernel(i)
-            inner(PleaseAllocate(Csize_t(42)))
-            nothing
-        end
-    end
-
-    @test @filecheck begin
-        check"CHECK-LABEL: .visible .func {{(julia|j)_kernel[0-9_]*}}"
-        check"CHECK-NOT: julia.push_gc_frame"
-        check"CHECK-NOT: julia.pop_gc_frame"
-        check"CHECK-NOT: julia.get_gc_frame_slot"
-        check"CHECK-NOT: julia.new_gc_frame"
-        check"CHECK: gpu_gc_pool_alloc"
-        PTX.code_native(mod.kernel, Tuple{Int})
-    end
-
-    # make sure that we can still ellide allocations
-    mod = @eval module $(gensym())
-        function ref_kernel(ptr, i)
-            data = Ref{Int64}()
-            data[] = 0
-            if i > 1
-                data[] = 1
-            else
-                data[] = 2
+            mod = @eval module $(gensym())
+            import ..sink
+            @noinline child(i) = sink(i)
+            function parent(i)
+                child(i)
+                return
             end
-            unsafe_store!(ptr, data[], i)
-            return nothing
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: .visible .func {{(julia|j)_parent[0-9_]*}}"
+                check"CHECK: call.uni"
+                check"CHECK-NEXT: {{(julia|j)_child_}}"
+                PTX.code_native(mod.parent, Tuple{Int64})
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: .visible .func {{(julia|j)_ref_kernel[0-9_]*}}"
-        check"CHECK-NOT: gpu_gc_pool_alloc"
-        PTX.code_native(mod.ref_kernel, Tuple{Ptr{Int64}, Int})
-    end
-end
+        @testset "kernel functions" begin
+            mod = @eval module $(gensym())
+            import ..sink
+            @noinline nonentry(i) = sink(i)
+            function entry(i)
+                nonentry(i)
+                return
+            end
+            end
 
-@testset "float boxes" begin
-    mod = @eval module $(gensym())
-        function kernel(a,b)
-            c = Int32(a)
-            # the conversion to Int32 may fail, in which case the input Float32 is boxed in
-            # order to pass it to the @nospecialize exception constructor. we should really
-            # avoid that (eg. by avoiding @nospecialize, or optimize the unused arguments
-            # away), but for now the box should just work.
-            unsafe_store!(b, c)
-            return
+            @test @filecheck begin
+                check"CHECK-NOT: .visible .func {{(julia|j)_nonentry}}"
+                check"CHECK-LABEL: .visible .entry _Z5entry5Int64"
+                check"CHECK: {{(julia|j)_nonentry}}"
+                PTX.code_native(mod.entry, Tuple{Int64}; kernel = true, dump_module = true)
+            end
+
+            @testset "property_annotations" begin
+                @test @filecheck begin
+                    check"CHECK-NOT: maxntid"
+                    PTX.code_native(mod.entry, Tuple{Int64}; kernel = true)
+                end
+
+                @test @filecheck begin
+                    check"CHECK: .maxntid 42, 1, 1"
+                    PTX.code_native(mod.entry, Tuple{Int64}; kernel = true, maxthreads = 42)
+                end
+
+                @test @filecheck begin
+                    check"CHECK: .reqntid 42, 1, 1"
+                    PTX.code_native(mod.entry, Tuple{Int64}; kernel = true, minthreads = 42)
+                end
+
+                @test @filecheck begin
+                    check"CHECK: .minnctapersm 42"
+                    PTX.code_native(mod.entry, Tuple{Int64}; kernel = true, blocks_per_sm = 42)
+                end
+
+                if LLVM.version() >= v"4.0"
+                    @test @filecheck begin
+                        check"CHECK: .maxnreg 42"
+                        PTX.code_native(mod.entry, Tuple{Int64}; kernel = true, maxregs = 42)
+                    end
+                end
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK: jl_box_float32"
-        PTX.code_llvm(mod.kernel, Tuple{Float32,Ptr{Float32}})
-    end
-    PTX.code_native(devnull, mod.kernel, Tuple{Float32,Ptr{Float32}})
-end
+        @testset "child function reuse" begin
+            # bug: depending on a child function from multiple parents resulted in
+            #      the child only being present once
 
-end
+            mod = @eval module $(gensym())
+            import ..sink
+            @noinline child(i) = sink(i)
+            function parent1(i)
+                child(i)
+                return
+            end
+            function parent2(i)
+                child(i + 1)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK: .func {{(julia|j)_child}}"
+                PTX.code_native(mod.parent1, Tuple{Int})
+            end
+
+            @test @filecheck begin
+                check"CHECK: .func {{(julia|j)_child}}"
+                PTX.code_native(mod.parent2, Tuple{Int})
+            end
+        end
+
+        @testset "child function reuse bis" begin
+            # bug: similar, but slightly different issue as above
+            #      in the case of two child functions
+
+            mod = @eval module $(gensym())
+            import ..sink
+            @noinline child1(i) = sink(i)
+            @noinline child2(i) = sink(i + 1)
+            function parent1(i)
+                child1(i) + child2(i)
+                return
+            end
+            function parent2(i)
+                child1(i + 1) + child2(i + 1)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-DAG: .func {{(julia|j)_child1}}"
+                check"CHECK-DAG: .func {{(julia|j)_child2}}"
+                PTX.code_native(mod.parent1, Tuple{Int})
+            end
+
+            @test @filecheck begin
+                check"CHECK-DAG: .func {{(julia|j)_child1}}"
+                check"CHECK-DAG: .func {{(julia|j)_child2}}"
+                PTX.code_native(mod.parent2, Tuple{Int})
+            end
+        end
+
+        @testset "indirect sysimg function use" begin
+            # issue #9: re-using sysimg functions should force recompilation
+            #           (host fldmod1->mod1 throws, so the PTX code shouldn't contain a throw)
+
+            # NOTE: Int32 to test for #49
+            mod = @eval module $(gensym())
+            function kernel(out)
+                wid, lane = fldmod1(unsafe_load(out), Int32(32))
+                unsafe_store!(out, wid)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: .visible .func {{(julia|j)_kernel[0-9_]*}}"
+                check"CHECK-NOT: jl_throw"
+                check"CHECK-NOT: jl_invoke"
+                PTX.code_native(mod.kernel, Tuple{Ptr{Int32}})
+            end
+        end
+
+        @testset "LLVM intrinsics" begin
+            # issue #13 (a): cannot select trunc
+            mod = @eval module $(gensym())
+            function kernel(x)
+                unsafe_trunc(Int, x)
+                return
+            end
+            end
+            PTX.code_native(devnull, mod.kernel, Tuple{Float64})
+            @test "We did not crash!" != ""
+        end
+
+        @testset "exception arguments" begin
+            mod = @eval module $(gensym())
+            function kernel(a)
+                unsafe_store!(a, trunc(Int, unsafe_load(a)))
+                return
+            end
+            end
+            PTX.code_native(devnull, mod.kernel, Tuple{Ptr{Float64}})
+            @test "We did not crash!" != ""
+        end
+
+        @testset "GC and TLS lowering" begin
+            mod = @eval module $(gensym())
+            import ..sink
+
+            mutable struct PleaseAllocate
+                y::Csize_t
+            end
+
+            # common pattern in Julia 0.7: outlined throw to avoid a GC frame in the calling code
+            @noinline function inner(x)
+                sink(x.y)
+                nothing
+            end
+
+            function kernel(i)
+                inner(PleaseAllocate(Csize_t(42)))
+                nothing
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: .visible .func {{(julia|j)_kernel[0-9_]*}}"
+                check"CHECK-NOT: julia.push_gc_frame"
+                check"CHECK-NOT: julia.pop_gc_frame"
+                check"CHECK-NOT: julia.get_gc_frame_slot"
+                check"CHECK-NOT: julia.new_gc_frame"
+                check"CHECK: gpu_gc_pool_alloc"
+                PTX.code_native(mod.kernel, Tuple{Int})
+            end
+
+            # make sure that we can still ellide allocations
+            mod = @eval module $(gensym())
+            function ref_kernel(ptr, i)
+                data = Ref{Int64}()
+                data[] = 0
+                if i > 1
+                    data[] = 1
+                else
+                    data[] = 2
+                end
+                unsafe_store!(ptr, data[], i)
+                return nothing
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: .visible .func {{(julia|j)_ref_kernel[0-9_]*}}"
+                check"CHECK-NOT: gpu_gc_pool_alloc"
+                PTX.code_native(mod.ref_kernel, Tuple{Ptr{Int64}, Int})
+            end
+        end
+
+        @testset "float boxes" begin
+            mod = @eval module $(gensym())
+            function kernel(a, b)
+                c = Int32(a)
+                # the conversion to Int32 may fail, in which case the input Float32 is boxed in
+                # order to pass it to the @nospecialize exception constructor. we should really
+                # avoid that (eg. by avoiding @nospecialize, or optimize the unused arguments
+                # away), but for now the box should just work.
+                unsafe_store!(b, c)
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK: jl_box_float32"
+                PTX.code_llvm(mod.kernel, Tuple{Float32, Ptr{Float32}})
+            end
+            PTX.code_native(devnull, mod.kernel, Tuple{Float32, Ptr{Float32}})
+        end
+
+    end
 end # NVPTX in LLVM.backends()

--- a/test/ptx/precompile.jl
+++ b/test/ptx/precompile.jl
@@ -2,28 +2,31 @@ precompile_test_harness("Inference caching") do load_path
     # Write out the PTX test helpers as a micro package
     create_standalone(load_path, "PTXCompiler", "ptx.jl")
 
-    write(joinpath(load_path, "PTXBackend.jl"), :(
-        module PTXBackend
-        import PTXCompiler
-        using PrecompileTools
+    write(
+        joinpath(load_path, "PTXBackend.jl"), :(
+            module PTXBackend
+            import PTXCompiler
+            using PrecompileTools
 
-        function kernel()
-            return
-        end
+            function kernel()
+                return
+            end
 
-        let
-            job, _ = PTXCompiler.PTX.create_job(kernel, ())
-            precompile(job)
-        end
-
-        # identity is foreign
-        @setup_workload begin
-            job, _ = PTXCompiler.PTX.create_job(identity, (Int,))
-            @compile_workload begin
+            let
+                job, _ = PTXCompiler.PTX.create_job(kernel, ())
                 precompile(job)
             end
-        end
-    end) |> string)
+
+            # identity is foreign
+            @setup_workload begin
+                job, _ = PTXCompiler.PTX.create_job(identity, (Int,))
+                @compile_workload begin
+                    precompile(job)
+                end
+            end
+            end
+        ) |> string
+    )
 
     Base.compilecache(Base.PkgId("PTXBackend"))
     @eval let
@@ -49,6 +52,6 @@ precompile_test_harness("Inference caching") do load_path
         @test check_presence(kernel_mi, token)
 
         # check that identity survived
-        @test check_presence(identity_mi, token) broken=VERSION>=v"1.12.0-DEV.1268"
+        @test check_presence(identity_mi, token) broken = VERSION >= v"1.12.0-DEV.1268"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,10 +22,10 @@ function test_filter(test)
     if LLVM.is_asserts() && test == "gcn"
         # XXX: GCN's non-0 stack address space triggers LLVM assertions due to Julia bugs
         return false
-     end
-     if VERSION < v"1.11" && test in ("ptx/precompile", "native/precompile")
-         return false
-     end
+    end
+    if VERSION < v"1.11" && test in ("ptx/precompile", "native/precompile")
+        return false
+    end
     return true
 end
 

--- a/test/spirv.jl
+++ b/test/spirv.jl
@@ -1,148 +1,160 @@
 for backend in (:khronos, :llvm)
 
-@testset "IR" begin
+    @testset "IR" begin
 
-@testset "kernel functions" begin
-@testset "calling convention" begin
-    mod = @eval module $(gensym())
-        kernel() = return
-    end
+        @testset "kernel functions" begin
+            @testset "calling convention" begin
+                mod = @eval module $(gensym())
+                kernel() = return
+                end
 
-    @test @filecheck begin
-        check"CHECK-NOT: spir_kernel"
-        SPIRV.code_llvm(mod.kernel, Tuple{}; backend, dump_module=true)
-    end
+                @test @filecheck begin
+                    check"CHECK-NOT: spir_kernel"
+                    SPIRV.code_llvm(mod.kernel, Tuple{}; backend, dump_module = true)
+                end
 
-    @test @filecheck begin
-        check"CHECK: spir_kernel"
-        SPIRV.code_llvm(mod.kernel, Tuple{}; backend, dump_module=true, kernel=true)
-    end
-end
+                @test @filecheck begin
+                    check"CHECK: spir_kernel"
+                    SPIRV.code_llvm(mod.kernel, Tuple{}; backend, dump_module = true, kernel = true)
+                end
+            end
 
-@testset "byval workaround" begin
-    mod = @eval module $(gensym())
-        kernel(x) = return
-    end
+            @testset "byval workaround" begin
+                mod = @eval module $(gensym())
+                kernel(x) = return
+                end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        SPIRV.code_llvm(mod.kernel, Tuple{Tuple{Int}}; backend)
-    end
+                @test @filecheck begin
+                    check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                    SPIRV.code_llvm(mod.kernel, Tuple{Tuple{Int}}; backend)
+                end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define spir_kernel void @_Z6kernel"
-        SPIRV.code_llvm(mod.kernel, Tuple{Tuple{Int}}; backend, kernel=true)
-    end
-end
+                @test @filecheck begin
+                    check"CHECK-LABEL: define spir_kernel void @_Z6kernel"
+                    SPIRV.code_llvm(mod.kernel, Tuple{Tuple{Int}}; backend, kernel = true)
+                end
+            end
 
-@testset "byval bug" begin
-    # byval added alwaysinline, which could conflict with noinline and fail verification
-    mod = @eval module $(gensym())
-        @noinline kernel() = return
-    end
-    @test @filecheck begin
-        check"CHECK-LABEL: define spir_kernel void @_Z6kernel"
-        SPIRV.code_llvm(mod.kernel, Tuple{}; backend, kernel=true)
-    end
-end
-end
-
-@testset "unsupported type detection" begin
-    mod = @eval module $(gensym())
-        function kernel(ptr, val)
-            unsafe_store!(ptr, val)
-            return
+            @testset "byval bug" begin
+                # byval added alwaysinline, which could conflict with noinline and fail verification
+                mod = @eval module $(gensym())
+                @noinline kernel() = return
+                end
+                @test @filecheck begin
+                    check"CHECK-LABEL: define spir_kernel void @_Z6kernel"
+                    SPIRV.code_llvm(mod.kernel, Tuple{}; backend, kernel = true)
+                end
+            end
         end
-    end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK: store half"
-        SPIRV.code_llvm(mod.kernel, Tuple{Ptr{Float16}, Float16}; backend)
-    end
+        @testset "unsupported type detection" begin
+            mod = @eval module $(gensym())
+            function kernel(ptr, val)
+                unsafe_store!(ptr, val)
+                return
+            end
+            end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK: store float"
-        SPIRV.code_llvm(mod.kernel, Tuple{Ptr{Float32}, Float32}; backend)
-    end
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK: store half"
+                SPIRV.code_llvm(mod.kernel, Tuple{Ptr{Float16}, Float16}; backend)
+            end
 
-    @test @filecheck begin
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        check"CHECK: store double"
-        SPIRV.code_llvm(mod.kernel, Tuple{Ptr{Float64}, Float64}; backend)
-    end
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK: store float"
+                SPIRV.code_llvm(mod.kernel, Tuple{Ptr{Float32}, Float32}; backend)
+            end
 
-    @test_throws_message(InvalidIRError,
-                         SPIRV.code_execution(mod.kernel, Tuple{Ptr{Float16}, Float16};
-                                              backend, supports_fp16=false)) do msg
-        occursin("unsupported use of half value", msg) &&
-        occursin("[1] unsafe_store!", msg) &&
-        occursin(r"\[\d+\] kernel", msg)
-    end
+            @test @filecheck begin
+                check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+                check"CHECK: store double"
+                SPIRV.code_llvm(mod.kernel, Tuple{Ptr{Float64}, Float64}; backend)
+            end
 
-    @test_throws_message(InvalidIRError,
-                         SPIRV.code_execution(mod.kernel, Tuple{Ptr{Float64}, Float64};
-                                              backend, supports_fp64=false)) do msg
-        occursin("unsupported use of double value", msg) &&
-        occursin("[1] unsafe_store!", msg) &&
-        occursin(r"\[\d+\] kernel", msg)
-    end
-end
+            @test_throws_message(
+                InvalidIRError,
+                SPIRV.code_execution(
+                    mod.kernel, Tuple{Ptr{Float16}, Float16};
+                    backend, supports_fp16 = false
+                )
+            ) do msg
+                occursin("unsupported use of half value", msg) &&
+                    occursin("[1] unsafe_store!", msg) &&
+                    occursin(r"\[\d+\] kernel", msg)
+            end
 
-end
-
-############################################################################################
-
-@testset "asm" begin
-
-@testset "trap removal" begin
-    mod = @eval module $(gensym())
-        function kernel(x)
-            x && error()
-            return
+            @test_throws_message(
+                InvalidIRError,
+                SPIRV.code_execution(
+                    mod.kernel, Tuple{Ptr{Float64}, Float64};
+                    backend, supports_fp64 = false
+                )
+            ) do msg
+                occursin("unsupported use of double value", msg) &&
+                    occursin("[1] unsafe_store!", msg) &&
+                    occursin(r"\[\d+\] kernel", msg)
+            end
         end
+
     end
 
-    @test @filecheck begin
-        check"CHECK: %_Z6kernel4Bool = OpFunction %void None"
-        SPIRV.code_native(mod.kernel, Tuple{Bool}; backend, kernel=true)
+    ############################################################################################
+
+    @testset "asm" begin
+
+        @testset "trap removal" begin
+            mod = @eval module $(gensym())
+            function kernel(x)
+                x && error()
+                return
+            end
+            end
+
+            @test @filecheck begin
+                check"CHECK: %_Z6kernel4Bool = OpFunction %void None"
+                SPIRV.code_native(mod.kernel, Tuple{Bool}; backend, kernel = true)
+            end
+        end
+
     end
-end
 
-end
-
-@testset "replace i128 allocas" begin
-    mod = @eval module $(gensym())
+    @testset "replace i128 allocas" begin
+        mod = @eval module $(gensym())
         # reimplement some of SIMD.jl
         struct Vec{N, T}
             data::NTuple{N, Core.VecElement{T}}
         end
         @generated function fadd(x::Vec{N, Float32}, y::Vec{N, Float32}) where {N}
             quote
-                Vec(Base.llvmcall($"""
-                    %ret = fadd <$N x float> %0, %1
-                    ret <$N x float> %ret
-                """, NTuple{N, Core.VecElement{Float32}}, NTuple{2, NTuple{N, Core.VecElement{Float32}}}, x.data, y.data))
+                Vec(
+                    Base.llvmcall(
+                        $"""
+                            %ret = fadd <$N x float> %0, %1
+                            ret <$N x float> %ret
+                        """, NTuple{N, Core.VecElement{Float32}}, NTuple{2, NTuple{N, Core.VecElement{Float32}}}, x.data, y.data
+                    )
+                )
             end
         end
         kernel(x...) = @noinline fadd(x...)
-    end
+        end
 
-    @test @filecheck begin
-        # TODO: should structs of `NTuple{VecElement{T}}` be passed by value instead of sret?
-        check"CHECK-NOT: i128"
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        @static VERSION >= v"1.12" && check"CHECK: alloca <2 x i64>, align 16"
-        SPIRV.code_llvm(mod.kernel, NTuple{2, mod.Vec{4, Float32}}; backend, dump_module=true)
-    end
+        @test @filecheck begin
+            # TODO: should structs of `NTuple{VecElement{T}}` be passed by value instead of sret?
+            check"CHECK-NOT: i128"
+            check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+            @static VERSION >= v"1.12" && check"CHECK: alloca <2 x i64>, align 16"
+            SPIRV.code_llvm(mod.kernel, NTuple{2, mod.Vec{4, Float32}}; backend, dump_module = true)
+        end
 
-    @test @filecheck begin
-        check"CHECK-NOT: i128"
-        check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
-        @static VERSION >= v"1.12" && check"CHECK: alloca [2 x <2 x i64>], align 16"
-        SPIRV.code_llvm(mod.kernel, NTuple{2, mod.Vec{8, Float32}}; backend, dump_module=true)
+        @test @filecheck begin
+            check"CHECK-NOT: i128"
+            check"CHECK-LABEL: define void @{{(julia|j)_kernel_[0-9]+}}"
+            @static VERSION >= v"1.12" && check"CHECK: alloca [2 x <2 x i64>], align 16"
+            SPIRV.code_llvm(mod.kernel, NTuple{2, mod.Vec{8, Float32}}; backend, dump_module = true)
+        end
     end
-end
 
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,10 +1,10 @@
 @testset "split_kwargs" begin
-    kwargs = [:(a=1), :(b=2), :(c=3), :(d=4)]
+    kwargs = [:(a = 1), :(b = 2), :(c = 3), :(d = 4)]
     groups = GPUCompiler.split_kwargs(kwargs, [:a], [:b, :c])
     @test length(groups) == 3
-    @test groups[1] == [:(a=1)]
-    @test groups[2] == [:(b=2), :(c=3)]
-    @test groups[3] == [:(d=4)]
+    @test groups[1] == [:(a = 1)]
+    @test groups[2] == [:(b = 2), :(c = 3)]
+    @test groups[3] == [:(d = 4)]
 end
 
 @testset "mangling" begin
@@ -28,7 +28,7 @@ end
     @test mangle(identity, Val{-1}) == "identity(Val<-1>)"
     @test mangle(identity, Val{Cshort(1)}) == "identity(Val<(short)1>)"
     @test mangle(identity, Val{1.0}) == "identity(Val<0x1p+0>)"
-    @test mangle(identity, Val{1f0}) == "identity(Val<0x1p+0f>)"
+    @test mangle(identity, Val{1.0f0}) == "identity(Val<0x1p+0f>)"
     @test mangle(identity, Val{'a'}) == "identity(Val<97u>)"
     @test mangle(identity, Val{'∅'}) == "identity(Val<8709u>)"
 
@@ -50,10 +50,12 @@ end
     @test mangle(identity, Tuple{Vararg{Int}}) == "identity(Tuple<>)"
 
     # many substitutions
-    @test mangle(identity, Val{1}, Val{2}, Val{3}, Val{4}, Val{5}, Val{6}, Val{7}, Val{8},
-                           Val{9}, Val{10}, Val{11}, Val{12}, Val{13}, Val{14}, Val{15},
-                           Val{16}, Val{16}) ==
-          "identity(Val<1>, Val<2>, Val<3>, Val<4>, Val<5>, Val<6>, Val<7>, Val<8>, Val<9>, Val<10>, Val<11>, Val<12>, Val<13>, Val<14>, Val<15>, Val<16>, Val<16>)"
+    @test mangle(
+        identity, Val{1}, Val{2}, Val{3}, Val{4}, Val{5}, Val{6}, Val{7}, Val{8},
+        Val{9}, Val{10}, Val{11}, Val{12}, Val{13}, Val{14}, Val{15},
+        Val{16}, Val{16}
+    ) ==
+        "identity(Val<1>, Val<2>, Val<3>, Val<4>, Val<5>, Val<6>, Val<7>, Val<8>, Val<9>, Val<10>, Val<11>, Val<12>, Val<13>, Val<14>, Val<15>, Val<16>, Val<16>)"
 
     # intertwined substitutions
     @test mangle(
@@ -111,14 +113,14 @@ DoubleStackedMT() = StackedMethodTable(Base.get_world_counter(), OtherMT, LayerM
         @test isoverlayed(DoubleStackedMT()) == true
     end
 
-    o_sin  = findsup(Tuple{typeof(sin), Float64}, OverlayMT())
-    s_sin  = findsup(Tuple{typeof(sin), Float64}, StackedMT())
+    o_sin = findsup(Tuple{typeof(sin), Float64}, OverlayMT())
+    s_sin = findsup(Tuple{typeof(sin), Float64}, StackedMT())
     ss_sin = findsup(Tuple{typeof(sin), Float64}, DoubleStackedMT())
     @test s_sin == o_sin
     @test ss_sin == o_sin
 
-    o_sin  = findall(Tuple{typeof(sin), Float64}, OverlayMT())
-    s_sin  = findall(Tuple{typeof(sin), Float64}, StackedMT())
+    o_sin = findall(Tuple{typeof(sin), Float64}, OverlayMT())
+    s_sin = findall(Tuple{typeof(sin), Float64}, StackedMT())
     ss_sin = findall(Tuple{typeof(sin), Float64}, DoubleStackedMT())
     if VERSION >= v"1.11.0-DEV.363"
         @test o_sin.matches == s_sin.matches
@@ -150,8 +152,8 @@ next_world = Base.get_world_counter()
     @test worlds.min_world > prev_world
     @test worlds.max_world == typemax(typeof(next_world))
 
-    o_sin  = findall(Tuple{typeof(sin), Float64}, OverlayMT())
-    s_sin  = findall(Tuple{typeof(sin), Float64}, StackedMT())
+    o_sin = findall(Tuple{typeof(sin), Float64}, OverlayMT())
+    s_sin = findall(Tuple{typeof(sin), Float64}, StackedMT())
     ss_sin = findall(Tuple{typeof(sin), Float64}, DoubleStackedMT())
     if VERSION >= v"1.11.0-DEV.363"
         @test o_sin.matches == s_sin.matches


### PR DESCRIPTION
 - Enable imaging-mode PLT lookups only on Julia versions that expose use_jlplt,
    preserving older compat.
  - Make StaticCompiler host targets emit relocatable TLS getters by rewriting
    intrinsic and inttoptr forms and ensuring the pass runs after upstream
    transforms.
  - Update docs and fix the native ccall test message match.
  - Tests: julia --project -q -e 'using Pkg; Pkg.test()'.

These changes are required for runtime-linked StaticCompiler targets. Without these GPUCompiler patches, executables that link the Julia runtime would bake absolute TLS addresses and crash at startup. 