### PR TITLE
Enable users to map from GV to Julia value

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -325,7 +325,10 @@ const __llvm_initialized = Ref(false)
         name = LLVM.name(gv)
         init = get(gv_to_value, name, nothing)
         if init !== nothing
-            @assert initializer(gv) === nothing
+            if initializer(gv) !== nothing
+                # TODO: How is this happening we should have stripped initializers earlier
+                @show string(initializer(gv)), init
+            end
             val = const_inttoptr(ConstantInt(reinterpret(UInt, init)), LLVM.PointerType())
             initializer!(gv, val)
         end

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -197,7 +197,7 @@ const __llvm_initialized = Ref(false)
     end
 
     @tracepoint "IR generation" begin
-        ir, compiled = irgen(job)
+        ir, compiled, gv_to_value = irgen(job)
         if job.config.entry_abi === :specfunc
             entry_fn = compiled[job.source].specfunc
         else
@@ -422,7 +422,7 @@ const __llvm_initialized = Ref(false)
         @tracepoint "verification" verify(ir)
     end
 
-    return ir, (; entry, compiled)
+    return ir, (; entry, compiled, gv_to_value)
 end
 
 @locked function emit_asm(@nospecialize(job::CompilerJob), ir::LLVM.Module,

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -253,12 +253,12 @@ end
             if !ondisk_hit && path !== nothing && disk_cache_enabled()
                 @debug "Writing out on-disk cache" job path
                 mkpath(dirname(path))
-                if haskey(asm.meta, :gv_to_value)
+                if haskey(asm[2].meta, :gv_to_value)
                     # TODO: Serializer cannot handle Core.IntrinsicFunction
                     # We kinda want Julia to serialize the values in `gv_to_value` in the pkgimg and us just having to store an index
                     # for now we just empty them out
                     # We would need to remove the initializers from LLVM IR as well to be correct, and then link these in at runtime
-                    empty!(asm.meta.gv_to_value)
+                    empty!(asm[2].meta.gv_to_value)
                 end
                 entry = DiskCacheEntry(src.specTypes, cfg, asm)
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -253,6 +253,13 @@ end
             if !ondisk_hit && path !== nothing && disk_cache_enabled()
                 @debug "Writing out on-disk cache" job path
                 mkpath(dirname(path))
+                if haskey(asm.meta, :gv_to_value)
+                    # TODO: Serializer cannot handle Core.IntrinsicFunction
+                    # We kinda want Julia to serialize the values in `gv_to_value` in the pkgimg and us just having to store an index
+                    # for now we just empty them out
+                    # We would need to remove the initializers from LLVM IR as well to be correct, and then link these in at runtime
+                    empty!(asm.meta.gv_to_value)
+                end
                 entry = DiskCacheEntry(src.specTypes, cfg, asm)
 
                 # atomic write to disk

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -253,12 +253,12 @@ end
             if !ondisk_hit && path !== nothing && disk_cache_enabled()
                 @debug "Writing out on-disk cache" job path
                 mkpath(dirname(path))
-                if haskey(asm[2].meta, :gv_to_value)
+                if haskey(asm[2], :gv_to_value)
                     # TODO: Serializer cannot handle Core.IntrinsicFunction
                     # We kinda want Julia to serialize the values in `gv_to_value` in the pkgimg and us just having to store an index
                     # for now we just empty them out
                     # We would need to remove the initializers from LLVM IR as well to be correct, and then link these in at runtime
-                    empty!(asm[2].meta.gv_to_value)
+                    empty!(asm[2].gv_to_value)
                 end
                 entry = DiskCacheEntry(src.specTypes, cfg, asm)
 

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -1,7 +1,7 @@
 # LLVM IR generation
 
 function irgen(@nospecialize(job::CompilerJob))
-    mod, compiled = @tracepoint "emission" compile_method_instance(job)
+    mod, compiled, gv_to_value = @tracepoint "emission" compile_method_instance(job)
     if job.config.entry_abi === :specfunc
         entry_fn = compiled[job.source].specfunc
     else
@@ -120,7 +120,9 @@ function irgen(@nospecialize(job::CompilerJob))
         can_throw(job) || lower_throw!(mod)
     end
 
-    return mod, compiled
+    # TODO: should we filter out non-preserved_gvs?
+
+    return mod, compiled, gv_to_value
 end
 
 

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -55,6 +55,11 @@ function irgen(@nospecialize(job::CompilerJob))
         new_name = safe_name(old_name)
         if old_name != new_name
             LLVM.name!(val, new_name)
+            val = get(gv_to_value, old_name, nothing)
+            if val !== nothing
+                delete!(gv_to_value, old_name)
+                gv_to_value[new_name] = val
+            end
         end
     end
 
@@ -119,8 +124,6 @@ function irgen(@nospecialize(job::CompilerJob))
         current_job = job
         can_throw(job) || lower_throw!(mod)
     end
-
-    # TODO: should we filter out non-preserved_gvs?
 
     return mod, compiled, gv_to_value
 end

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -832,7 +832,6 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
                 end
             end
         end
-        gvalues = Set(gvalues)
         for gv in globals(llvm_mod)
             init = LLVM.initializer(gv)
             if init === nothing


### PR DESCRIPTION
Two fold motivation.

Currently, we perform the JIT favourite trick on all globals, we inline the runtime pointers, this makes the resulting code non-relocatable. A concrete example of that would be something like:

```
function f(x)
    if x === :x
    end
end
```

The memory location of `:x` changes upon session restart (as do other things like Types, Singletons), and for objects like this Julia performs a simple pointer comparison. So we can actually support this operation on the GPU.

Yet, we cannot cache the resulting kernel, or if we do, we will perform the wrong computation. So what we must do instead is to initialize the global after loading it from cache. 

Now that is a tricky affair (backend dependent), we can do it on LLVM IR, I believe AMDGPU could also do it, the CPU backends can use something like `JITDylib`, but I don't think we can do it on the obj file from Nvidia, and I don't about other backends.

So we should likely mark compilations that use globals with runtime pointers as ineligible for caching.

The second motivation stems from Enzyme where we would like to have a mapping from global to Julia object, and it can be hard to figure out which globals are Julia objects and which ones are not.