### PR TITLE
Derive the deferred world from the parent one.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "1.8.2"
+version = "1.8.3"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [deps]

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -238,8 +238,8 @@ const __llvm_initialized = Ref(false)
                     dyn_val
                 else
                     ft, tt = dyn_val
-                    dyn_src = methodinstance(ft, tt, tls_world_age())
-                    CompilerJob(dyn_src, job.config)
+                    dyn_src = methodinstance(ft, tt, job.world)
+                    CompilerJob(dyn_src, job.config, job.world)
                 end
 
                 push!(get!(worklist, dyn_job, LLVM.CallInst[]), call)


### PR DESCRIPTION
This allows invoking the compiler in a frozen world.