### PR TITLE
Adjust to upcoming sparam_vals representation change

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,11 @@
+## julia compat
+if VERSION >= v"1.12"
+    __has_internal_julia_change(version_or::VersionNumber, feature::Symbol) =
+        Base.__has_internal_change(version_or, feature)
+else
+    __has_internal_julia_change(version_or::VersionNumber, feature::Symbol) =
+        false
+end
 ## debug verification
 
 should_verify() = ccall(:jl_is_debugbuild, Cint, ()) == 1 ||

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -33,7 +33,7 @@ function check_method(@nospecialize(job::CompilerJob))
     ft <: Core.Builtin && error("$(unsafe_function_from_type(ft)) is not a generic function")
 
     for sparam in job.source.sparam_vals
-        if sparam isa TypeVar
+        if sparam isa (__has_internal_julia_change(v"1.14-alpha", :svectvar) ? Core.SimpleVector : TypeVar)
             throw(KernelError(job, "method captures typevar '$sparam' (you probably use an unbound type variable)"))
         end
     end


### PR DESCRIPTION
Adjusts to https://github.com/JuliaLang/julia/pull/61645. Uses the __has_internal_change mechanism, so should be safely mergable even before the base PR merges.