### PR TITLE
Revert "Fix always_inline via inlining policy override"

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -257,14 +257,12 @@ if VERSION >= v"1.11.0-DEV.1552"
 get_interpreter(@nospecialize(job::CompilerJob)) =
     GPUInterpreter(job.world; method_table_view=maybe_cached(method_table_view(job)),
                    token=ci_cache_token(job), inf_params=inference_params(job),
-                   opt_params=optimization_params(job),
-                   always_inline=job.config.always_inline)
+                   opt_params=optimization_params(job))
 else
 get_interpreter(@nospecialize(job::CompilerJob)) =
     GPUInterpreter(job.world; method_table_view=maybe_cached(method_table_view(job)),
                    code_cache=ci_cache(job), inf_params=inference_params(job),
-                   opt_params=optimization_params(job),
-                   always_inline=job.config.always_inline)
+                   opt_params=optimization_params(job))
 end
 
 # does this target support throwing Julia exceptions with jl_throw?

--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -420,8 +420,6 @@ end
 
     inf_params::CC.InferenceParams
     opt_params::CC.OptimizationParams
-
-    always_inline::Bool
 end
 
 @static if HAS_INTEGRATED_CACHE
@@ -429,15 +427,14 @@ function GPUInterpreter(world::UInt=Base.get_world_counter();
                         method_table_view::CC.MethodTableView,
                         token::Any,
                         inf_params::CC.InferenceParams,
-                        opt_params::CC.OptimizationParams,
-                        always_inline::Bool=false)
+                        opt_params::CC.OptimizationParams)
     @assert world <= Base.get_world_counter()
 
     inf_cache = INFERENCE_CACHE_TYPE()
 
     return GPUInterpreter(world, method_table_view,
                           token, inf_cache,
-                          inf_params, opt_params, always_inline)
+                          inf_params, opt_params)
 end
 
 function GPUInterpreter(interp::GPUInterpreter;
@@ -446,11 +443,10 @@ function GPUInterpreter(interp::GPUInterpreter;
                         token::Any=interp.token,
                         inf_cache::INFERENCE_CACHE_TYPE=interp.inf_cache,
                         inf_params::CC.InferenceParams=interp.inf_params,
-                        opt_params::CC.OptimizationParams=interp.opt_params,
-                        always_inline::Bool=interp.always_inline)
+                        opt_params::CC.OptimizationParams=interp.opt_params)
     return GPUInterpreter(world, method_table_view,
                           token, inf_cache,
-                          inf_params, opt_params, always_inline)
+                          inf_params, opt_params)
 end
 
 else
@@ -459,15 +455,14 @@ function GPUInterpreter(world::UInt=Base.get_world_counter();
                         method_table_view::CC.MethodTableView,
                         code_cache::CodeCache,
                         inf_params::CC.InferenceParams,
-                        opt_params::CC.OptimizationParams,
-                        always_inline::Bool=false)
+                        opt_params::CC.OptimizationParams)
     @assert world <= Base.get_world_counter()
 
     inf_cache = Vector{CC.InferenceResult}()
 
     return GPUInterpreter(world, method_table_view,
                           code_cache, inf_cache,
-                          inf_params, opt_params, always_inline)
+                          inf_params, opt_params)
 end
 
 function GPUInterpreter(interp::GPUInterpreter;
@@ -476,11 +471,10 @@ function GPUInterpreter(interp::GPUInterpreter;
                         code_cache::CodeCache=interp.code_cache,
                         inf_cache::Vector{CC.InferenceResult}=interp.inf_cache,
                         inf_params::CC.InferenceParams=interp.inf_params,
-                        opt_params::CC.OptimizationParams=interp.opt_params,
-                        always_inline::Bool=interp.always_inline)
+                        opt_params::CC.OptimizationParams=interp.opt_params)
     return GPUInterpreter(world, method_table_view,
                           code_cache, inf_cache,
-                          inf_params, opt_params, always_inline)
+                          inf_params, opt_params)
 end
 end # HAS_INTEGRATED_CACHE
 
@@ -504,11 +498,7 @@ end
 
 CC.may_optimize(interp::GPUInterpreter) = true
 CC.may_compress(interp::GPUInterpreter) = true
-# When `always_inline=true`, preserve optimized IR for every callee: otherwise
-# `transform_result_for_cache` drops sources whose `inlining_cost` saturated to
-# `MAX_INLINE_COST`, leaving nothing for our `src_inlining_policy` override to
-# inline. See JuliaGPU/GPUCompiler.jl#527.
-CC.may_discard_trees(interp::GPUInterpreter) = !interp.always_inline
+CC.may_discard_trees(interp::GPUInterpreter) = true
 @static if VERSION <= v"1.12.0-DEV.1531"
 CC.verbose_stmt_info(interp::GPUInterpreter) = false
 end
@@ -532,52 +522,6 @@ function CC.concrete_eval_eligible(interp::GPUInterpreter,
         f::Any, result::CC.MethodCallResult, arginfo::CC.ArgInfo)
     ret === false && return nothing
     return ret
-end
-
-# Force inlining of all functions with source code when `always_inline=true`.
-#
-# Julia's inliner stores per-function inlining cost in a fixed-width integer
-# field on CodeInfo, then sets `is_inlineable(src) := inlining_cost != MAX_INLINE_COST`.
-# When the body cost exceeds the storage's representable range it saturates to
-# MAX_INLINE_COST and the function becomes permanently non-inlineable, regardless
-# of the caller's `inline_cost_threshold`. The storage is UInt16 on 1.11/1.12
-# (cap ≈65535) and was narrowed to UInt8 on 1.13+ (cap ≈5000 via
-# jl_encode_inlining_cost), at which point reasonably-sized GPU kernel callees
-# routinely saturate. See JuliaGPU/GPUCompiler.jl#527 and JuliaLang/julia#51599.
-#
-# Bypassing the `is_inlineable` check here makes the inliner respect our
-# `inline_cost_threshold = MAX_INLINE_COST` setting in practice. Julia 1.12+
-# split the legacy `inlining_policy` (returns src or nothing) into
-# `src_inlining_policy` (returns Bool); we override the version-appropriate hook.
-@static if isdefined(CC, :src_inlining_policy)
-    function CC.src_inlining_policy(interp::GPUInterpreter,
-            @nospecialize(src), @nospecialize(info::CC.CallInfo), stmt_flag::UInt32)
-        if interp.always_inline
-            @static if isdefined(CC, :OptimizationState)
-                isa(src, CC.OptimizationState) && (src = src.src)
-            end
-            isa(src, CC.MaybeCompressed) && return true
-            isa(src, CC.IRCode) && return true
-        end
-        return @invoke CC.src_inlining_policy(interp::CC.AbstractInterpreter,
-            src::Any, info::CC.CallInfo, stmt_flag::UInt32)
-    end
-else
-    function CC.inlining_policy(interp::GPUInterpreter,
-            @nospecialize(src), @nospecialize(info::CC.CallInfo), stmt_flag::UInt32)
-        if interp.always_inline
-            if isa(src, CC.MaybeCompressed)
-                CC.is_source_inferred(src) || return nothing
-                return src
-            elseif isa(src, CC.IRCode)
-                return src
-            elseif isa(src, CC.SemiConcreteResult)
-                return src
-            end
-        end
-        return @invoke CC.inlining_policy(interp::CC.AbstractInterpreter,
-            src::Any, info::CC.CallInfo, stmt_flag::UInt32)
-    end
 end
 
 

--- a/test/native.jl
+++ b/test/native.jl
@@ -356,13 +356,13 @@ end
 end
 
 @testset "always_inline" begin
-    # The body has to be big enough that the inferred `inlining_cost` field
-    # saturates to `MAX_INLINE_COST`, otherwise it gets inlined trivially.
-    # That field is UInt16 on 1.11/1.12 and UInt8 on 1.13+. See
-    # JuliaGPU/GPUCompiler.jl#527 and JuliaLang/julia#51599.
+    # XXX: broken by JuliaLang/julia#51599, see JuliaGPU/GPUCompiler.jl#527.
+    #      yet somehow this works on 1.12?
+    broken = VERSION >= v"1.13-"
+
     mod = @eval module $(gensym())
         import ..sink
-        expensive(x) = $(foldl((e, _) -> :($sink($e) + $sink(x)), 1:1600; init=:x))
+        expensive(x) = $(foldl((e, _) -> :($sink($e) + $sink(x)), 1:100; init=:x))
         function g(x)
             expensive(x)
             return
@@ -378,20 +378,20 @@ end
         Native.code_llvm(mod.g, Tuple{Int64}; dump_module=true, kernel=true)
     end
 
-    @test @filecheck begin
+    @test @filecheck(begin
         @check_not "@{{(julia|j)_expensive_[0-9]+}}"
         Native.code_llvm(mod.g, Tuple{Int64}; dump_module=true, kernel=true, always_inline=true)
-    end
+    end) broken=broken
 
     @test @filecheck begin
         @check "@{{(julia|j)_expensive_[0-9]+}}"
         Native.code_llvm(mod.h, Tuple{Int64}; dump_module=true, kernel=true)
     end
 
-    @test @filecheck begin
+    @test @filecheck(begin
         @check_not "@{{(julia|j)_expensive_[0-9]+}}"
         Native.code_llvm(mod.h, Tuple{Int64}; dump_module=true, kernel=true, always_inline=true)
-    end
+    end) broken=broken
 end
 
 @testset "function attributes" begin


### PR DESCRIPTION
Reverts JuliaGPU/GPUCompiler.jl#795, which breaks the following MWE:

```julia
using CUDA
function mykernel(A)
    i = (Int(threadIdx().x) - 1) + (Int(blockIdx().x) - 1) * Int(blockDim().x)
    A[i+1] = i   # out-of-range index ⇒ throw_boundserror reachable
    return
end
A = CuArray{Int}(undef, 16)
@cuda always_inline=true threads=8 mykernel(A)   # InvalidIRError
@cuda                  threads=8 mykernel(A)     # OK
```

```
InvalidIRError: ... resulted in invalid LLVM IR
Reason: unsupported dynamic function invocation (call to unsafe_store!)
Stacktrace:
 [1] setproperty!         @ CUDACore/src/device/runtime.jl:89
 [2] throw_boundserror    @ CUDACore/src/device/quirks.jl:13
 [3] throw_boundserror    @ CUDACore/src/device/quirks.jl:53
 [4] arrayset             @ CUDACore/src/device/array.jl:130
 [5] setindex!            @ CUDACore/src/device/array.jl:177
 [6] mykernel             @ ...
```

This surfaced with KernelAbstraction.jl's unittest_testsuite`  which contains an `always_inline=true`.

@aviatesk Could you take a look at this? I wanted to fix this downstream since https://github.com/JuliaLang/julia/pull/48257 doesn't seem to be moving forwards, and we really need this in the GPU stack (in fact, cuTile.jl depends on the ability to inline everything).

Here's a description by Claude:

## What's happening

CUDA's `Base.setproperty!(::ExceptionInfo, sym::Symbol, value)` (`CUDACore/src/device/runtime.jl:79`) has six Symbol-dispatched branches with different value types per branch (`Int32`, `@NamedTuple{x,y,z::Int32}`, `Ptr{UInt8}`). Its body is big enough that `inlining_cost` saturates to `MAX_INLINE_COST=0xffff` — verified directly:

```julia
m = first(methods(setproperty!, (CUDACore.ExceptionInfo, Symbol, Any)))
Base.uncompressed_ir(m).inlining_cost   # 0xffff
```

Before #795, the default policy rejected this saturated `MaybeCompressed` source (`is_inlineable=false`), so `setproperty!` stayed out-of-line and the standalone-compiled body — with type-incompatible branches correctly folded to `Core.throw_methoderror` calls by inference — validated fine.

After #795, the override force-inlines the **generic** `MaybeCompressed` body (slottypes `[..., Symbol, Ptr{UInt8}]`) into `throw_boundserror`. The full if/elseif chain survives:

```
%6  = builtin (:subtype === :status)::Bool       # not folded!
%17 = builtin (:subtype === :threadIdx)::Bool    # not folded!
... 12 such comparisons preserved as runtime checks
```

The dead `:threadIdx`/`:blockIdx` branches contain `unsafe_store!(::Ptr{NamedTuple{...}}, ::Ptr{UInt8})` — type-incompatible dispatches that ssa_inlining + optimization can't resolve statically. They end up as `ijl_apply_generic(unsafe_store!, ...)` calls in the final IR, which validation rejects.

The const-prop'd specialized versions (cost=10, body folded to a single `pointerset`) **are** offered to the policy too, but the inliner picks the generic source for some calls. I couldn't track down exactly why in the time I spent on it.

## Probable cause

Force-inlining a `MaybeCompressed` source whose `inlining_cost` saturated is unsafe when the body has dead branches that only fold under const-prop. Julia's inliner doesn't re-run the constant-folding that would have eliminated those branches during regular inference; `ssa_inlining_pass!` + `compact!` + ADCE don't fold `===` on Symbol literals after they've been inlined as builtin calls into a larger body.

The motivating case in #795 (`philox2x_rounds`-style: saturated from raw call count, no Symbol-dispatched branches) doesn't hit this — its inlined body has nothing to fold. cuTile uses the same policy shape and works for the same reason.

## Sanity checks while debugging

- Reverting just `may_discard_trees`: still fails.
- Reverting just `src_inlining_policy`: passes. So the policy override is the trigger, not the tree-preservation change.
- Matching cuTile's policy exactly (no `@invoke` fall-through, `inline_cost_threshold=typemax(Int)`): still fails. cuTile would fail on this CUDA pattern too; it just doesn't have one.
- Restricting the override to non-`ConstCallInfo` calls: fixes the `@cuda` MWE but not the KA path (where the inliner offers both generic and const-prop'd sources and still picks the generic one).
- Restricting the override to `IRCode` only: fixes both. But in the failing PTX compile the inliner never passes `IRCode`, so this is effectively a full revert.