### PR TITLE
Register deferred_codegen in GlobalJD on Julia 1.14+.

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -150,12 +150,21 @@ end
     end
 end
 
-# Register deferred_codegen as a global function so that it can be called with `ccall("extern deferred_codegen"`
-# Called from __init__
-# On 1.11+ this is needed due to a Julia bug that drops the pointer when code-coverage is enabled.
+# Register deferred_codegen as a global function so that it can be called with
+# `ccall("extern deferred_codegen", ...)`. Called from __init__.
+#
+# On 1.11+ this is needed due to a Julia bug that drops the pointer when code-coverage is
+# enabled. On 1.14+ (JuliaLang/julia#60988), `JITDylib(jljit)` returns a fresh private
+# dylib that JD does not search; instead, register the symbol in the `JuliaGlobals` JD,
+# which JD links to with `MatchExportedSymbolsOnly`.
 function register_deferred_codegen()
     @dispose jljit=JuliaOJIT() begin
-        jd = JITDylib(jljit)
+        jd = @static if VERSION >= v"1.14.0-DEV.2171"
+            es = ExecutionSession(jljit)
+            something(LLVM.lookup_dylib(es, "JuliaGlobals"))
+        else
+            JITDylib(jljit)
+        end
 
         address = LLVM.API.LLVMOrcJITTargetAddress(
             reinterpret(UInt, @cfunction(deferred_codegen, Ptr{Cvoid}, (Ptr{Cvoid},))))


### PR DESCRIPTION
JuliaLang/julia#60988 changed `JITDylib(jljit)` to return a fresh private dylib that's only searched outward (to GlobalJD/SessionJD), so defining "deferred_codegen" there is invisible to JIT-compiled user code in JD.

Use `LLVM.lookup_dylib(es, "JuliaGlobals")` to grab the existing GlobalJD — which JD links to with `MatchExportedSymbolsOnly` — and define the absolute symbol there. JD's lookup chain then resolves "deferred_codegen" through GlobalJD.

The pre-1.14 branch is unchanged.

---

Old approach was more idiomatic, using an intrinsic, but broken Enzyme and had some inlining issues because of the Ptr ABI switch. So let's go with the simpler solution now.

---

Julia 1.14 (JuliaLang/julia#60988) removed the shared ExternalJD, so registering "deferred_codegen" as an absolute symbol on a fresh JITDylib is no longer visible to JIT-compiled user code. Instead, emit the marker function with a linkonce_odr passthrough body inline via Base.llvmcall, making the IR self-contained on every Julia version. GPUCompiler still finds and rewrites the calls as before; only the JIT-link fallback path changes.

Shouldn't be breaking, and works with CUDA.jl. Of course, Enzyme.jl reaches into GPUCompiler.jl internals so is broken by this :shrug: