### PR TITLE
Strip back-end runtime stub bodies before InternalizePass.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "1.13.2"
+version = "1.13.3"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -104,6 +104,25 @@ function irgen(@nospecialize(job::CompilerJob))
             end
         end
 
+        # back-end-provided runtime stubs (`Runtime.compile(:sym, ...)`) carry
+        # a *weak* `gpu_<name>` body so CPU-AOT pipelines (juliac, sysimage,
+        # PrecompileTools) can satisfy CPU symbol resolution. On the GPU path
+        # we want the back-end's strong definition from the runtime library to
+        # take over, but `InternalizePass` below would convert the weak body
+        # to `internal` and `link!(...; only_needed=true)` would then refuse
+        # to import the strong override (`Linker::linkIfNeeded` requires the
+        # destination to be a true declaration, not merely weak). Erase the
+        # stub bodies so each becomes a plain external declaration; the
+        # runtime library's strong def is then linked in normally.
+        for method in values(Runtime.methods)
+            method.def isa Symbol || continue
+            haskey(functions(mod), method.llvm_name) || continue
+            f = functions(mod)[method.llvm_name]
+            isdeclaration(f) && continue
+            empty!(f)
+            linkage!(f, LLVM.API.LLVMExternalLinkage)
+        end
+
         # internalize all functions and, but keep exported global variables.
         linkage!(entry, LLVM.API.LLVMExternalLinkage)
         preserved_gvs = String[LLVM.name(entry)]


### PR DESCRIPTION
The CPU-AOT-safe weak `gpu_<name>` body from `Runtime.compile(:sym, ...)` would get internalized by GPU codegen, and `link!(...; only_needed=true)` then refuses to pull in the back-end's strong override (`linkIfNeeded` requires the destination to be a true declaration). Erase the stub body on the GPU path so the runtime library's strong def is linked in normally. Basically going back to the situation before the whole change (an external call to a declared, not defined stub).