### PR TITLE
Metal: include the debug level in the runtime slug

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -78,9 +78,11 @@ pass_by_value(job::CompilerJob{MetalCompilerTarget}) = false
 
 ## job
 
-# TODO: encode debug build or not in the compiler job
-#       https://github.com/JuliaGPU/CUDAnative.jl/issues/368
-runtime_slug(job::CompilerJob{MetalCompilerTarget}) = "metal-macos$(job.config.target.macos)"
+# the debug-info level is part of the slug (as on PTX): it changes the debug metadata emitted
+# into the runtime library, and the device-exception reporters branch on it, so a library
+# built at one level must not be reused at another.
+runtime_slug(job::CompilerJob{MetalCompilerTarget}) =
+    "metal-macos$(job.config.target.macos)-debuginfo=$(Int(llvm_debug_info(job)))"
 
 isintrinsic(@nospecialize(job::CompilerJob{MetalCompilerTarget}), fn::String) =
     return startswith(fn, "air.")


### PR DESCRIPTION
The runtime library's debug metadata and the device-exception reporters depend on the debug level, so a library built at one `-g` must not be reused at another. Mirrors PTX.