### PR TITLE
Metal: Improve lowering of math intrinsics

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -82,6 +82,10 @@ llvm_targetinfo(::MetalCompilerTarget) = MetalTTI()
 
 pass_by_value(job::CompilerJob{MetalCompilerTarget}) = false
 
+# Apple GPUs have fused multiply-add, so `fma` should use the hardware instruction (lowered
+# from `llvm.fma` to `air.fma`) rather than Julia's Float64-based `fma_emulated` fallback.
+have_fma(@nospecialize(target::MetalCompilerTarget), T::Type) = true
+
 
 ## job
 
@@ -1379,16 +1383,27 @@ function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Funct
                 error("Unsupported maximum/minimum type: $typ")
             end
 
-            # create a function that performs the IEEE-compliant operation.
-            # normally we'd do this inline, but LLVM.jl doesn't have BB split functionality.
-            new_intr_fn = if is_minimum
-                "air.minimum.f$(8*sizeof(jltyp))"
+            # @fastmath / fastmath=true set `nnan` (assume no NaNs), so we can skip the
+            # NaN-propagating wrapper and call the relaxed AIR builtin directly, matching Apple's
+            # -ffast-math: f32 has air.fast_f{min,max}; f16 has no fast form, so use air.f{min,max}.
+            fast_fn = if !LLVM.fast_math(call).nnan
+                nothing
+            elseif typ == LLVM.FloatType()
+                is_minimum ? "air.fast_fmin.f32" : "air.fast_fmax.f32"
             else
-                "air.maximum.f$(8*sizeof(jltyp))"
+                is_minimum ? "air.fmin.f$(8*sizeof(jltyp))" : "air.fmax.f$(8*sizeof(jltyp))"
             end
+
+            # otherwise create a function that performs the IEEE-compliant operation. normally
+            # we'd do this inline, but LLVM.jl doesn't have BB split functionality.
+            new_intr_fn = something(fast_fn, is_minimum ? "air.minimum.f$(8*sizeof(jltyp))" :
+                                                          "air.maximum.f$(8*sizeof(jltyp))")
 
             if haskey(functions(mod), new_intr_fn)
                 new_intr = functions(mod)[new_intr_fn]
+            elseif fast_fn !== nothing
+                # relaxed builtin: just declare it, no wrapper needed
+                new_intr = LLVM.Function(mod, new_intr_fn, call_ft)
             else
                 new_intr = LLVM.Function(mod, new_intr_fn, call_ft)
                 push!(function_attributes(new_intr), EnumAttribute("alwaysinline"))

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -1063,6 +1063,55 @@ end
 #
 # we don't have a proper back-end, so we're missing out on intrinsics-related functionality.
 
+# AIR has no vector floating-point min/max intrinsic; only the scalar `air.fmin`/`air.fmax`
+# exist. Julia's NaN-propagating `min`/`max` lower to `llvm.minimum`/`llvm.maximum` (and the
+# non-propagating `llvm.minnum`/`llvm.maxnum`), which LLVM's vectorizers can widen to vector
+# intrinsics. Lowering those directly would emit a nonexistent `air.fmin.v4f32`-style call, or
+# hit the "Unsupported maximum/minimum type" error in the minimum/maximum handler below. So we
+# scalarize each vector min/max into element-wise scalar intrinsic calls first and let the
+# scalar lowering handle them — the same lowering LLVM itself uses on targets lacking a vector
+# form, and semantically exact.
+function scalarize_vector_minmax!(fun::LLVM.Function)
+    minmax = LLVM.Intrinsic.(["llvm.minnum", "llvm.maxnum", "llvm.minimum", "llvm.maximum"])
+
+    worklist = LLVM.CallBase[]
+    for bb in blocks(fun), inst in instructions(bb)
+        inst isa LLVM.CallBase || continue
+        callee = called_operand(inst)
+        (callee isa LLVM.Function && LLVM.isintrinsic(callee)) || continue
+        LLVM.Intrinsic(callee) in minmax || continue
+        value_type(inst) isa LLVM.VectorType || continue
+        push!(worklist, inst)
+    end
+    isempty(worklist) && return false
+
+    mod = LLVM.parent(fun)
+    for call in worklist
+        vecty = value_type(call)::LLVM.VectorType
+        elty = eltype(vecty)
+        # the scalar overload of the same intrinsic, e.g. llvm.minimum.v4f32 -> llvm.minimum.f32
+        intr = LLVM.Intrinsic(called_operand(call))
+        scalar_f = LLVM.Function(mod, intr, LLVMType[elty])
+        scalar_ft = function_type(scalar_f)
+        arg0, arg1 = arguments(call)
+        @dispose builder=IRBuilder() begin
+            position!(builder, call)
+            debuglocation!(builder, call)
+            res = PoisonValue(vecty)
+            for i in 0:Int(length(vecty))-1
+                idx = ConstantInt(LLVM.Int32Type(), i)
+                a = extract_element!(builder, arg0, idx)
+                b = extract_element!(builder, arg1, idx)
+                s = call!(builder, scalar_ft, scalar_f, LLVM.Value[a, b])
+                res = insert_element!(builder, res, s, idx)
+            end
+            replace_uses!(call, res)
+            erase!(call)
+        end
+    end
+    return true
+end
+
 # replace LLVM intrinsics with AIR equivalents
 function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Function)
     isdeclaration(fun) && return false
@@ -1071,6 +1120,9 @@ function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Funct
 
     mod = LLVM.parent(fun)
     changed = false
+
+    # AIR lacks vector min/max intrinsics; scalarize so the per-call lowering below applies.
+    changed |= scalarize_vector_minmax!(fun)
 
     # determine worklist
     worklist = LLVM.CallBase[]

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -45,6 +45,12 @@ Base.@kwdef struct MetalCompilerTarget <: AbstractCompilerTarget
     macos::VersionNumber
     air::VersionNumber
     metal::VersionNumber
+
+    # whether to use fast math; defaults to the process-wide `--math-mode=fast`. mirrors the
+    # PTX target: when set, `apply_fastmath!` flags every floating-point op `afn`, which the
+    # intrinsic lowering reads to pick the relaxed `air.fast_*` device functions over the
+    # precise `air.*` ones (e.g. `air.fast_sqrt` instead of `air.sqrt`).
+    fastmath::Bool = Base.JLOptions().fast_math == 1
 end
 
 # for backwards compatibility
@@ -55,6 +61,7 @@ function Base.hash(target::MetalCompilerTarget, h::UInt)
     h = hash(target.macos, h)
     h = hash(target.air, h)
     h = hash(target.metal, h)
+    h = hash(target.fastmath, h)
 end
 
 source_code(target::MetalCompilerTarget) = "text"
@@ -88,6 +95,14 @@ isintrinsic(@nospecialize(job::CompilerJob{MetalCompilerTarget}), fn::String) =
     return startswith(fn, "air.")
 
 function finish_linked_module!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::LLVM.Module)
+    # propagate `target.fastmath` as `@fastmath`-everywhere semantics, so the math-intrinsic
+    # lowering in `finish_ir!` picks the relaxed `air.fast_*` functions. done here (post-link,
+    # pre-optimize) so bodies pulled in from the runtime library get the flags too, mirroring
+    # the PTX target.
+    if job.config.target.fastmath
+        apply_fastmath!(mod)
+    end
+
     for f in kernels(mod)
         # update calling conventions
         f = pass_by_reference!(job, mod, f)
@@ -1112,17 +1127,79 @@ function scalarize_vector_minmax!(fun::LLVM.Function)
     return true
 end
 
+# floating-point math intrinsics that Julia emits as plain `llvm.*` and that Metal exposes as
+# AIR device functions. Each has a precise `air.<op>` for f16/f32; some additionally have a
+# relaxed, f32-only `air.fast_<op>` that we select when the call is `afn`-flagged — set per-op
+# by `@fastmath` or module-wide by `apply_fastmath!` when `target.fastmath` is on.
+#
+# This is the back-end half of the "front-end emits LLVM, back-end lowers" design (cf. the PTX
+# target's fast-math passes): it lets Metal.jl drop its hand-written `air.*`/`air.fast_*`
+# overrides for these ops and rely on the LLVM intrinsics Julia already generates. `round` is
+# covered too — Julia lowers it to `llvm.rint` (round-to-even).
+function lower_math_intrinsics!(fun::LLVM.Function)
+    # llvm intrinsic => (precise air op, relaxed f32 air op or `nothing`)
+    # Verified against Apple's frontend (`xcrun metal -S -emit-llvm`, precise vs -ffast-math):
+    # every op has an `air.<op>.f16` and `air.<op>.f32`; all but `fma` also have an f32-only
+    # `air.fast_<op>` that Apple selects under fast math. Half always stays precise, and `fma`
+    # is exact so even fast math keeps `air.fma.{f16,f32}`.
+    math_intrinsics = Dict(
+        LLVM.Intrinsic("llvm.sqrt")  => ("air.sqrt",  "air.fast_sqrt"),
+        LLVM.Intrinsic("llvm.fma")   => ("air.fma",   nothing),
+        LLVM.Intrinsic("llvm.floor") => ("air.floor", "air.fast_floor"),
+        LLVM.Intrinsic("llvm.ceil")  => ("air.ceil",  "air.fast_ceil"),
+        LLVM.Intrinsic("llvm.trunc") => ("air.trunc", "air.fast_trunc"),
+        LLVM.Intrinsic("llvm.rint")  => ("air.rint",  "air.fast_rint"),
+    )
+
+    worklist = Tuple{LLVM.CallBase, String, Union{String,Nothing}}[]
+    for bb in blocks(fun), inst in instructions(bb)
+        inst isa LLVM.CallBase || continue
+        callee = called_operand(inst)
+        (callee isa LLVM.Function && LLVM.isintrinsic(callee)) || continue
+        mapping = get(math_intrinsics, LLVM.Intrinsic(callee), nothing)
+        mapping === nothing && continue
+        # Metal floats are f16/f32 only; skip f64 (rejected by validate_ir) and vector types
+        # (these ops have no `air.<op>.v4f32`) rather than synthesize a nonexistent intrinsic.
+        typ = value_type(inst)
+        (typ == LLVM.HalfType() || typ == LLVM.FloatType()) || continue
+        push!(worklist, (inst, mapping[1], mapping[2]))
+    end
+    isempty(worklist) && return false
+
+    mod = LLVM.parent(fun)
+    fns = functions(mod)
+    for (call, precise, fast) in worklist
+        typ = value_type(call)
+        # the relaxed variant exists for f32 only; f16 always uses the precise op
+        use_fast = fast !== nothing && typ == LLVM.FloatType() && LLVM.fast_math(call).afn
+        suffix = typ == LLVM.HalfType() ? "f16" : "f32"
+        fn = "$(use_fast ? fast : precise).$suffix"
+        ft = function_type(called_operand(call))
+        air = haskey(fns, fn) ? fns[fn] : LLVM.Function(mod, fn, ft)
+        @dispose builder=IRBuilder() begin
+            position!(builder, call)
+            debuglocation!(builder, call)
+            new_value = call!(builder, ft, air, arguments(call))
+            replace_uses!(call, new_value)
+            erase!(call)
+        end
+    end
+    return true
+end
+
 # replace LLVM intrinsics with AIR equivalents
 function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Function)
     isdeclaration(fun) && return false
-
-    # TODO: fastmath
 
     mod = LLVM.parent(fun)
     changed = false
 
     # AIR lacks vector min/max intrinsics; scalarize so the per-call lowering below applies.
     changed |= scalarize_vector_minmax!(fun)
+
+    # lower the floating-point math intrinsics Julia emits (sqrt, fma, floor, ...) to their
+    # AIR device functions, picking the relaxed `air.fast_*` variant for `afn`-flagged calls.
+    changed |= lower_math_intrinsics!(fun)
 
     # determine worklist
     worklist = LLVM.CallBase[]

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -1274,6 +1274,41 @@ function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Funct
                 fn *= "." * type_suffix(typ)
             end
 
+            # AIR's value intrinsics take only the value operands. `llvm.abs` carries an extra
+            # `i1 is_int_min_poison` flag that `air.abs` does not, so drop any operand whose
+            # type isn't the result type before building the call. (For the others every
+            # operand is the result type, so this is a no-op.)
+            air_args = LLVM.Value[a for a in arguments(call) if value_type(a) == typ]
+            air_ft = LLVM.FunctionType(typ, LLVMType[typ for _ in air_args])
+            new_intr = if haskey(functions(mod), fn)
+                functions(mod)[fn]
+            else
+                LLVM.Function(mod, fn, air_ft)
+            end
+            @dispose builder=IRBuilder() begin
+                position!(builder, call)
+                debuglocation!(builder, call)
+
+                new_value = call!(builder, air_ft, new_intr, air_args)
+                replace_uses!(call, new_value)
+                erase!(call)
+                changed = true
+            end
+        end
+
+        # integer bit intrinsics: pure renames to AIR's builtin names (same signature, including
+        # the `i1` on clz/ctz). Apple's frontend emits these `air.*` rather than the `llvm.*`
+        # forms, so we rename rather than rely on the metallib loader accepting `llvm.*`.
+        bit_renames = Dict(
+            LLVM.Intrinsic("llvm.ctlz")       => ("llvm.ctlz",       "air.clz"),
+            LLVM.Intrinsic("llvm.cttz")       => ("llvm.cttz",       "air.ctz"),
+            LLVM.Intrinsic("llvm.ctpop")      => ("llvm.ctpop",      "air.popcount"),
+            LLVM.Intrinsic("llvm.bitreverse") => ("llvm.bitreverse", "air.reverse_bits"),
+        )
+        if haskey(bit_renames, intr)
+            llvm_base, air_base = bit_renames[intr]
+            # keep the mangled type suffix, e.g. llvm.ctlz.i32 -> air.clz.i32
+            fn = air_base * LLVM.name(call_fun)[length(llvm_base)+1:end]
             new_intr = if haskey(functions(mod), fn)
                 functions(mod)[fn]
             else

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -1191,6 +1191,62 @@ function lower_math_intrinsics!(fun::LLVM.Function)
     return true
 end
 
+# Fuse chained integer min/max into AIR's native 3-way builtins: a 2-way
+# `air.{min,max}.{s,u}.iN` whose operand is a single-use call to the same builtin becomes
+# `air.{min,max}3.{s,u}.iN(a, b, c)`. AGX has 3-way min/max, but neither Julia (which reduces
+# `min(a,b,c)` to nested 2-arg calls) nor Apple's own frontend emits it. Done in the back-end so
+# every chained min/max benefits, not just literal 3-argument calls. Integer only: float min/max
+# go through the NaN-propagating wrapper, which `air.f{min,max}3` would not preserve.
+function fuse_minmax3!(fun::LLVM.Function)
+    mod = LLVM.parent(fun)
+    pat = r"^air\.(min|max)\.(s|u)\.i(8|16|32|64)$"
+    changed = false
+
+    # fold one pair then rescan: each fold removes a call, so this terminates, and rescanning
+    # avoids mutating the instruction stream while iterating it.
+    while true
+        fold = nothing  # (outer, inner, other_operand)
+        for bb in blocks(fun), outer in instructions(bb)
+            outer isa LLVM.CallInst || continue
+            oc = called_operand(outer)
+            (oc isa LLVM.Function && match(pat, LLVM.name(oc)) !== nothing) || continue
+            oargs = arguments(outer)
+            length(oargs) == 2 || continue
+            for i in 1:2
+                inner = oargs[i]
+                inner isa LLVM.CallInst || continue
+                ic = called_operand(inner)
+                # same builtin (name pins down min/max, signedness and width)
+                (ic isa LLVM.Function && LLVM.name(ic) == LLVM.name(oc)) || continue
+                # inner must feed only this outer, else folding it would drop a live value
+                length(collect(uses(inner))) == 1 || continue
+                fold = (outer, inner, oargs[i == 1 ? 2 : 1])
+                break
+            end
+            fold === nothing || break
+        end
+        fold === nothing && break
+
+        outer, inner, other = fold
+        m = match(pat, LLVM.name(called_operand(outer)))
+        fn3 = "air.$(m[1])3.$(m[2]).i$(m[3])"
+        T = value_type(outer)
+        ft3 = LLVM.FunctionType(T, LLVMType[T, T, T])
+        f3 = haskey(functions(mod), fn3) ? functions(mod)[fn3] : LLVM.Function(mod, fn3, ft3)
+        iargs = arguments(inner)
+        @dispose builder=IRBuilder() begin
+            position!(builder, outer)
+            debuglocation!(builder, outer)
+            v = call!(builder, ft3, f3, LLVM.Value[iargs[1], iargs[2], other])
+            replace_uses!(outer, v)
+            erase!(outer)
+            erase!(inner)   # now dead (its only use was `outer`)
+        end
+        changed = true
+    end
+    return changed
+end
+
 # replace LLVM intrinsics with AIR equivalents
 function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Function)
     isdeclaration(fun) && return false
@@ -1495,6 +1551,9 @@ function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Funct
             end
         end
     end
+
+    # fuse chained integer min/max (now lowered to air.min/max) into AIR's 3-way builtins
+    changed |= fuse_minmax3!(fun)
 
     return changed
 end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -600,4 +600,63 @@ end
     end
 end
 
+@testset "integer intrinsic lowering" begin
+    # The integer ops Julia emits as llvm.* are lowered to their AIR builtins, so Metal.jl need
+    # not wrap them. Names/signatures verified against Apple's frontend:
+    #   llvm.abs (value,i1)  -> air.abs.{s,u}.iN(value)   (the i1 poison flag is dropped)
+    #   llvm.{s,u}{min,max}  -> air.{min,max}.{s,u}.iN
+    #   llvm.ctlz (v,i1)     -> air.clz.iN(v,i1)          (pure renames, i1 kept)
+    #   llvm.cttz (v,i1)     -> air.ctz.iN(v,i1)
+    #   llvm.ctpop           -> air.popcount.iN
+    #   llvm.bitreverse      -> air.reverse_bits.iN
+    km = @eval module $(gensym())
+        f() = return
+    end
+    job, _ = Metal.create_job(km.f, Tuple{})
+
+    Context() do ctx
+        ir = """
+        declare i32 @llvm.abs.i32(i32, i1)
+        declare i32 @llvm.smin.i32(i32, i32)
+        declare i32 @llvm.umax.i32(i32, i32)
+        declare i32 @llvm.ctlz.i32(i32, i1)
+        declare i32 @llvm.cttz.i32(i32, i1)
+        declare i32 @llvm.ctpop.i32(i32)
+        declare i32 @llvm.bitreverse.i32(i32)
+        define void @f(i32 %x, i32 %y) {
+          %a = call i32 @llvm.abs.i32(i32 %x, i1 true)
+          %b = call i32 @llvm.smin.i32(i32 %x, i32 %y)
+          %c = call i32 @llvm.umax.i32(i32 %x, i32 %y)
+          %d = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+          %e = call i32 @llvm.cttz.i32(i32 %x, i1 false)
+          %g = call i32 @llvm.ctpop.i32(i32 %x)
+          %h = call i32 @llvm.bitreverse.i32(i32 %x)
+          ret void
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        f = functions(mod)["f"]
+        GPUCompiler.lower_llvm_intrinsics!(job, f)
+
+        sigs = Dict{String,String}()
+        for bb in blocks(f), i in instructions(bb)
+            i isa LLVM.CallBase || continue
+            c = called_operand(i)
+            c isa LLVM.Function && (sigs[LLVM.name(c)] = string(LLVM.function_type(c)))
+        end
+        # abs drops the i1 poison operand
+        @test haskey(sigs, "air.abs.s.i32") && sigs["air.abs.s.i32"] == "i32 (i32)"
+        @test haskey(sigs, "air.min.s.i32") && sigs["air.min.s.i32"] == "i32 (i32, i32)"
+        @test haskey(sigs, "air.max.u.i32")
+        # clz/ctz keep the i1; popcount/reverse_bits are single-operand
+        @test haskey(sigs, "air.clz.i32") && sigs["air.clz.i32"] == "i32 (i32, i1)"
+        @test haskey(sigs, "air.ctz.i32") && sigs["air.ctz.i32"] == "i32 (i32, i1)"
+        @test haskey(sigs, "air.popcount.i32") && sigs["air.popcount.i32"] == "i32 (i32)"
+        @test haskey(sigs, "air.reverse_bits.i32")
+        # no llvm.* intrinsics survive
+        @test !any(startswith(n, "llvm.") for n in keys(sigs))
+        @test (verify(mod); true)
+    end
+end
+
 end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -512,4 +512,92 @@ end
     end
 end
 
+@testset "math intrinsic lowering" begin
+    # Front-ends emit plain LLVM math intrinsics; the back-end lowers them to AIR device
+    # functions. Precise `air.<op>` by default; the relaxed, f32-only `air.fast_<op>` when the
+    # call is `afn`-flagged (set per-op by @fastmath or module-wide by apply_fastmath!). This
+    # lets Metal.jl drop its hand-written air.* overrides for these ops. `round` is included
+    # via llvm.rint (Julia lowers round-to-even to it).
+    function called_names(f)
+        names = String[]
+        for bb in blocks(f), i in instructions(bb)
+            i isa LLVM.CallBase || continue
+            c = called_operand(i)
+            c isa LLVM.Function && push!(names, LLVM.name(c))
+        end
+        names
+    end
+
+    Context() do ctx
+        ir = """
+        declare float @llvm.sqrt.f32(float)
+        declare half  @llvm.sqrt.f16(half)
+        declare float @llvm.floor.f32(float)
+        declare float @llvm.ceil.f32(float)
+        declare float @llvm.trunc.f32(float)
+        declare float @llvm.rint.f32(float)
+        declare float @llvm.fma.f32(float, float, float)
+        declare half  @llvm.fma.f16(half, half, half)
+        declare <4 x float> @llvm.sqrt.v4f32(<4 x float>)
+        define void @f(float %x, half %h, <4 x float> %v) {
+          %a = call float @llvm.sqrt.f32(float %x)
+          %b = call afn float @llvm.sqrt.f32(float %x)
+          %c = call afn half @llvm.sqrt.f16(half %h)
+          %d = call float @llvm.floor.f32(float %x)
+          %d2 = call afn float @llvm.floor.f32(float %x)
+          %e = call float @llvm.ceil.f32(float %x)
+          %g = call float @llvm.trunc.f32(float %x)
+          %i = call float @llvm.rint.f32(float %x)
+          %j = call float @llvm.fma.f32(float %x, float %x, float %x)
+          %l = call half @llvm.fma.f16(half %h, half %h, half %h)
+          %k = call <4 x float> @llvm.sqrt.v4f32(<4 x float> %v)
+          ret void
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        f = functions(mod)["f"]
+        @test GPUCompiler.lower_math_intrinsics!(f)
+        names = called_names(f)
+
+        # precise by default; relaxed only for the f32 afn-flagged sqrt
+        @test "air.sqrt.f32" in names
+        @test "air.fast_sqrt.f32" in names
+        # f16 has no fast variant, so afn still maps to the precise op
+        @test "air.sqrt.f16" in names
+        @test !("air.fast_sqrt.f16" in names)
+        # rounding ops have fast f32 variants too (selected for the afn floor)
+        @test "air.floor.f32" in names
+        @test "air.fast_floor.f32" in names
+        @test "air.ceil.f32" in names
+        @test "air.trunc.f32" in names
+        @test "air.rint.f32" in names      # Julia's round arrives as llvm.rint
+        # fma has both f16 and f32 precise forms, and no fast variant
+        @test "air.fma.f32" in names
+        @test "air.fma.f16" in names
+        @test !("air.fast_fma.f32" in names)
+        # no scalar llvm.* math intrinsics survive; the vector one is left (no air.<op>.v4f32)
+        @test !any(n -> startswith(n, "llvm.") && !endswith(n, "v4f32"), names)
+        @test "llvm.sqrt.v4f32" in names
+        @test (verify(mod); true)
+    end
+
+    # apply_fastmath! flags every FP op `afn` (target.fastmath path), so even calls written
+    # without @fastmath lower to the relaxed variant.
+    Context() do ctx
+        ir = """
+        declare float @llvm.sqrt.f32(float)
+        define float @f(float %x) {
+          %a = call float @llvm.sqrt.f32(float %x)
+          ret float %a
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        GPUCompiler.apply_fastmath!(mod)
+        f = functions(mod)["f"]
+        @test GPUCompiler.lower_math_intrinsics!(f)
+        @test "air.fast_sqrt.f32" in called_names(f)
+        @test (verify(mod); true)
+    end
+end
+
 end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -693,4 +693,49 @@ end
     end
 end
 
+@testset "integer min/max fusion" begin
+    # chained integer min/max (e.g. min(a,b,c) reduced to nested 2-arg calls) is fused to AGX's
+    # 3-way air.{min,max}3 builtin, but only when the inner result feeds just the outer and both
+    # are the same builtin.
+    names(f) = [LLVM.name(called_operand(i)) for bb in blocks(f) for i in instructions(bb)
+                if i isa LLVM.CallBase && called_operand(i) isa LLVM.Function]
+    Context() do ctx
+        ir = """
+        declare i32 @air.min.s.i32(i32, i32)
+        declare i32 @air.max.u.i32(i32, i32)
+        define i32 @fold(i32 %a, i32 %b, i32 %c) {
+          %i = call i32 @air.min.s.i32(i32 %a, i32 %b)
+          %o = call i32 @air.min.s.i32(i32 %i, i32 %c)
+          ret i32 %o
+        }
+        define i32 @fold_arg2(i32 %a, i32 %b, i32 %c) {
+          %i = call i32 @air.max.u.i32(i32 %a, i32 %b)
+          %o = call i32 @air.max.u.i32(i32 %c, i32 %i)
+          ret i32 %o
+        }
+        define i32 @multiuse(i32 %a, i32 %b, i32 %c, i32* %p) {
+          %i = call i32 @air.min.s.i32(i32 %a, i32 %b)
+          %o = call i32 @air.min.s.i32(i32 %i, i32 %c)
+          store i32 %i, i32* %p
+          ret i32 %o
+        }
+        define i32 @mixed(i32 %a, i32 %b, i32 %c) {
+          %i = call i32 @air.max.u.i32(i32 %a, i32 %b)
+          %o = call i32 @air.min.s.i32(i32 %i, i32 %c)
+          ret i32 %o
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        @test GPUCompiler.fuse_minmax3!(functions(mod)["fold"])
+        @test names(functions(mod)["fold"]) == ["air.min3.s.i32"]
+        @test GPUCompiler.fuse_minmax3!(functions(mod)["fold_arg2"])
+        @test names(functions(mod)["fold_arg2"]) == ["air.max3.u.i32"]
+        # inner feeds a store too -> not fused
+        @test !GPUCompiler.fuse_minmax3!(functions(mod)["multiuse"])
+        # min of a max -> not the same builtin, not fused
+        @test !GPUCompiler.fuse_minmax3!(functions(mod)["mixed"])
+        @test (verify(mod); true)
+    end
+end
+
 end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -659,4 +659,38 @@ end
     end
 end
 
+@testset "fast-math min/max lowering" begin
+    # Base min/max -> llvm.minimum/maximum lower to a NaN-propagating wrapper (air.minimum/
+    # maximum, which falls back to air.fmin/fmax). @fastmath/fastmath set `nnan`, so the relaxed
+    # air.fast_fmin/fmax (f32) — or bare air.fmin/fmax for f16, which has no fast form — are used.
+    km = @eval module $(gensym())
+        f() = return
+    end
+    job, _ = Metal.create_job(km.f, Tuple{})
+    names(f) = [LLVM.name(called_operand(i)) for bb in blocks(f) for i in instructions(bb)
+                if i isa LLVM.CallBase && called_operand(i) isa LLVM.Function]
+
+    Context() do ctx
+        ir = """
+        declare float @llvm.minimum.f32(float, float)
+        declare half  @llvm.maximum.f16(half, half)
+        define void @f(float %x, float %y, half %a, half %b) {
+          %p = call float @llvm.minimum.f32(float %x, float %y)        ; precise -> wrapper
+          %q = call nnan float @llvm.minimum.f32(float %x, float %y)   ; fast -> air.fast_fmin
+          %r = call nnan half @llvm.maximum.f16(half %a, half %b)      ; fast f16 -> air.fmax (no fast)
+          ret void
+        }
+        """
+        mod = parse(LLVM.Module, ir); f = functions(mod)["f"]
+        GPUCompiler.lower_llvm_intrinsics!(job, f)
+        ns = names(f)
+        @test "air.minimum.f32" in ns          # precise: NaN-propagating wrapper
+        @test "air.fast_fmin.f32" in ns        # @fastmath f32: relaxed
+        @test "air.fmax.f16" in ns             # @fastmath f16: no fast form, bare builtin
+        @test !("air.fast_fmax.f16" in ns)
+        @test !any(startswith(n, "llvm.") for n in ns)
+        @test (verify(mod); true)
+    end
+end
+
 end

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -450,4 +450,66 @@ end
     end
 end
 
+@testset "vector min/max scalarization" begin
+    # AIR has no vector floating-point min/max intrinsic, only scalar air.fmin/air.fmax. Julia's
+    # NaN-propagating min/max lower to llvm.minimum/llvm.maximum (and llvm.minnum/llvm.maxnum),
+    # which LLVM's vectorizers can widen to vector form. Lowering a vector intrinsic directly
+    # would emit a nonexistent air.fmin.v4f32-style call (minnum/maxnum) or hit an unsupported-
+    # type error (minimum/maximum), so we scalarize into element-wise scalar intrinsic calls.
+    is_vec_minmax(i) = i isa LLVM.CallBase && value_type(i) isa LLVM.VectorType &&
+        called_operand(i) isa LLVM.Function &&
+        LLVM.isintrinsic(called_operand(i)) &&
+        LLVM.Intrinsic(called_operand(i)) in
+            LLVM.Intrinsic.(["llvm.minnum", "llvm.maxnum", "llvm.minimum", "llvm.maximum"])
+
+    Context() do ctx
+        ir = """
+        declare <4 x float> @llvm.minimum.v4f32(<4 x float>, <4 x float>)
+        declare <2 x float> @llvm.maxnum.v2f32(<2 x float>, <2 x float>)
+        define <4 x float> @f(<4 x float> %a, <4 x float> %b, <2 x float> %c, <2 x float> %d) {
+        entry:
+          %mn = call <4 x float> @llvm.minimum.v4f32(<4 x float> %a, <4 x float> %b)
+          %mx = call <2 x float> @llvm.maxnum.v2f32(<2 x float> %c, <2 x float> %d)
+          %e0 = extractelement <2 x float> %mx, i32 0
+          %r = insertelement <4 x float> %mn, float %e0, i32 0
+          ret <4 x float> %r
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        f = functions(mod)["f"]
+        insts() = [i for bb in blocks(f) for i in instructions(bb)]
+
+        # precondition: a vector minimum (width 4) and a vector maxnum (width 2)
+        @test count(is_vec_minmax, insts()) == 2
+
+        @test GPUCompiler.scalarize_vector_minmax!(f)
+
+        # no vector min/max calls survive; each is replaced by per-lane scalar intrinsic calls
+        @test count(is_vec_minmax, insts()) == 0
+        scalar_calls = filter(insts()) do i
+            i isa LLVM.CallBase && value_type(i) == LLVM.FloatType() &&
+                called_operand(i) isa LLVM.Function &&
+                LLVM.isintrinsic(called_operand(i))
+        end
+        @test length(scalar_calls) == 6   # 4 from the v4f32 + 2 from the v2f32
+        @test Set(LLVM.name(called_operand(c)) for c in scalar_calls) ==
+            Set(["llvm.minimum.f32", "llvm.maxnum.f32"])
+        @test (verify(mod); true)
+    end
+
+    # a scalar min/max is already lowerable and must be left untouched
+    Context() do ctx
+        ir = """
+        declare float @llvm.minimum.f32(float, float)
+        define float @g(float %a, float %b) {
+          %r = call float @llvm.minimum.f32(float %a, float %b)
+          ret float %r
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        @test !GPUCompiler.scalarize_vector_minmax!(functions(mod)["g"])
+        @test (verify(mod); true)
+    end
+end
+
 end


### PR DESCRIPTION
Just like we did for CUDA.jl, this will allow us to use LLVM intrinsics in Metal.jl.