### PR TITLE
Group PTX fast-math optimization passes under `:fastmath`

### DIFF
--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -291,7 +291,7 @@ function optimize_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
             register!(pb, NVVMReflectPass())
             add!(pb, NVVMReflectPass())
         end
-        if get(optimization_options(job), :ptxfastmath, true)
+        if get(optimization_options(job), :fastmath, true)
             add!(pb, PTXRSqrtFastPass())
             add!(pb, PTXFDivFastPass())
             add!(pb, PTXFSqrtFastPass())

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -291,9 +291,11 @@ function optimize_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
             register!(pb, NVVMReflectPass())
             add!(pb, NVVMReflectPass())
         end
-        add!(pb, PTXRSqrtFastPass())
-        add!(pb, PTXFDivFastPass())
-        add!(pb, PTXFSqrtFastPass())
+        if get(optimization_options(job), :ptxfastmath, true)
+            add!(pb, PTXRSqrtFastPass())
+            add!(pb, PTXFDivFastPass())
+            add!(pb, PTXFSqrtFastPass())
+        end
 
         add!(pb, NewPMFunctionPassManager()) do fpm
             # needed by GemmKernels.jl-like code


### PR DESCRIPTION
cc @gbaraldi @giordano 

split out from https://github.com/JuliaGPU/GPUCompiler.jl/pull/823