### PR TITLE
Metal: drop the spurious i1 operand when lowering ctlz/cttz to air.clz/air.ctz

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -1473,9 +1473,11 @@ function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Funct
             end
         end
 
-        # integer bit intrinsics: pure renames to AIR's builtin names (same signature, including
-        # the `i1` on clz/ctz). Apple's frontend emits these `air.*` rather than the `llvm.*`
-        # forms, so we rename rather than rely on the metallib loader accepting `llvm.*`.
+        # integer bit intrinsics: rename to AIR's builtin names. ctpop/bitreverse keep their
+        # single value operand; clz/ctz must drop LLVM's trailing `i1 is_zero_undef`, since
+        # AIR's air.clz/air.ctz take only the value operand. Apple's frontend emits these
+        # `air.*` rather than the `llvm.*` forms, so we rename rather than rely on the metallib
+        # loader accepting `llvm.*`.
         bit_renames = Dict(
             LLVM.Intrinsic("llvm.ctlz")       => ("llvm.ctlz",       "air.clz"),
             LLVM.Intrinsic("llvm.cttz")       => ("llvm.cttz",       "air.ctz"),
@@ -1486,16 +1488,21 @@ function lower_llvm_intrinsics!(@nospecialize(job::CompilerJob), fun::LLVM.Funct
             llvm_base, air_base = bit_renames[intr]
             # keep the mangled type suffix, e.g. llvm.ctlz.i32 -> air.clz.i32
             fn = air_base * LLVM.name(call_fun)[length(llvm_base)+1:end]
+            # drop any operand whose type isn't the result type (the `i1` on clz/ctz),
+            # mirroring the air.abs handling above; no-op for popcount/bitreverse.
+            typ = value_type(call)
+            air_args = LLVM.Value[a for a in arguments(call) if value_type(a) == typ]
+            air_ft = LLVM.FunctionType(typ, LLVMType[typ for _ in air_args])
             new_intr = if haskey(functions(mod), fn)
                 functions(mod)[fn]
             else
-                LLVM.Function(mod, fn, call_ft)
+                LLVM.Function(mod, fn, air_ft)
             end
             @dispose builder=IRBuilder() begin
                 position!(builder, call)
                 debuglocation!(builder, call)
 
-                new_value = call!(builder, call_ft, new_intr, arguments(call))
+                new_value = call!(builder, air_ft, new_intr, air_args)
                 replace_uses!(call, new_value)
                 erase!(call)
                 changed = true


### PR DESCRIPTION
`lower_llvm_intrinsics!`'s `bit_renames` pass renames `llvm.ctlz`/`llvm.cttz` to `air.clz`/`air.ctz` but keeps LLVM's trailing `i1 is_zero_undef`. AIR's `air.clz`/`air.ctz` take only the value operand (and Metal's `leading_zeros`/`trailing_zeros` device overrides already emit the 1-arg form), so a kernel that reaches both sources ends up with a signature clash the bitcode downgrader rejects:

```
error: '@air.clz.i32' defined with type 'i32 (i32)*' but expected 'i32 (i32, i1)*'
```

Fix: drop the operand whose type isn't the result type (the `i1`) for clz/ctz, mirroring the `air.abs` handling just above. No-op for `ctpop`/`bitreverse`.

Reproducer (only Metal needed — fails on 1.16.0…1.18, OK on ≤1.15.x):

```julia
using Metal
f(o) = (@inbounds o[1] = rem(o[1], 3f0) + leading_zeros(reinterpret(Int32, o[1])); return)
Metal.@metal f(Metal.mtl(Float32[1.5f0]))   # => Compilation to AIR failed
```

`rem(::Float32,::Float32)` reaches `Base.rem_internal`, which calls `ctlz_int` → 2-arg `air.clz`; `leading_zeros` → 1-arg `air.clz` via the device override. Regressed in #821.
