### PR TITLE
[release-1.17] Emit deprecation warnings without switching tasks. (backport #831)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "1.17.0"
+version = "1.17.1"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,20 +1,20 @@
 # Deprecations scheduled for removal in the next major release.
 
 function defs(mod::LLVM.Module)
-    Base.depwarn("`GPUCompiler.defs(mod)` is deprecated; inline `filter(f -> !isdeclaration(f), collect(functions(mod)))`.",
+    safe_depwarn("`GPUCompiler.defs(mod)` is deprecated; inline `filter(f -> !isdeclaration(f), collect(functions(mod)))`.",
                  :defs)
     filter(f -> !isdeclaration(f), collect(functions(mod)))
 end
 
 function decls(mod::LLVM.Module)
-    Base.depwarn("`GPUCompiler.decls(mod)` is deprecated; inline `filter(f -> isdeclaration(f) && !LLVM.isintrinsic(f), collect(functions(mod)))`.",
+    safe_depwarn("`GPUCompiler.decls(mod)` is deprecated; inline `filter(f -> isdeclaration(f) && !LLVM.isintrinsic(f), collect(functions(mod)))`.",
                  :decls)
     filter(f -> isdeclaration(f) && !LLVM.isintrinsic(f), collect(functions(mod)))
 end
 
 link_library!(mod::LLVM.Module, lib::LLVM.Module) = link_library!(mod, [lib])
 function link_library!(mod::LLVM.Module, libs::Vector{LLVM.Module})
-    Base.depwarn("`GPUCompiler.link_library!` is deprecated; call `LLVM.link!(mod, copy(lib))` directly, or `LLVM.link!(mod, lib; only_needed=true)` with a freshly-parsed library.",
+    safe_depwarn("`GPUCompiler.link_library!` is deprecated; call `LLVM.link!(mod, copy(lib))` directly, or `LLVM.link!(mod, lib; only_needed=true)` with a freshly-parsed library.",
                  :link_library!)
     libs = [copy(lib) for lib in libs]
     for lib in libs

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -55,7 +55,7 @@ Compile a `job` to one of the following formats as specified by the `target` arg
 function compile(target::Symbol, @nospecialize(job::CompilerJob); kwargs...)
     # XXX: remove on next major version
     if !isempty(kwargs)
-        Base.depwarn("The GPUCompiler `compile` API does not take keyword arguments anymore. Use CompilerConfig instead.", :compile)
+        safe_depwarn("The GPUCompiler `compile` API does not take keyword arguments anymore. Use CompilerConfig instead.", :compile)
         config = CompilerConfig(job.config; kwargs...)
         job = CompilerJob(job.source, config)
     end
@@ -70,7 +70,7 @@ end
 # XXX: remove on next major version
 function codegen(output::Symbol, @nospecialize(job::CompilerJob); kwargs...)
     if !isempty(kwargs)
-        Base.depwarn("The GPUCompiler `codegen` function is an internal API. Use `GPUCompiler.compile` (with any kwargs passed to `CompilerConfig`) instead.", :codegen)
+        safe_depwarn("The GPUCompiler `codegen` function is an internal API. Use `GPUCompiler.compile` (with any kwargs passed to `CompilerConfig`) instead.", :codegen)
         config = CompilerConfig(job.config; kwargs...)
         job = CompilerJob(job.source, config)
     end
@@ -191,7 +191,7 @@ const __llvm_initialized = Ref(false)
 @locked function emit_llvm(@nospecialize(job::CompilerJob); kwargs...)
     # XXX: remove on next major version
     if !isempty(kwargs)
-        Base.depwarn("The GPUCompiler `emit_llvm` function is an internal API. Use `GPUCompiler.compile` (with any kwargs passed to `CompilerConfig`) instead.", :emit_llvm)
+        safe_depwarn("The GPUCompiler `emit_llvm` function is an internal API. Use `GPUCompiler.compile` (with any kwargs passed to `CompilerConfig`) instead.", :emit_llvm)
         config = CompilerConfig(job.config; kwargs...)
         job = CompilerJob(job.source, config)
     end
@@ -325,7 +325,7 @@ const __llvm_initialized = Ref(false)
             # target-specific libraries
             @tracepoint "target libraries" begin
                 if has_legacy_link_libraries(job)
-                    Base.depwarn(
+                    safe_depwarn(
                         "3-arg `link_libraries!(job, mod, undefined_fns)` is deprecated; " *
                         "migrate your override to the 2-arg form `link_libraries!(job, mod)`. " *
                         "Instead of inspecting `undefined_fns` to decide what to link, " *

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -45,7 +45,7 @@ function irgen(@nospecialize(job::CompilerJob))
 
     deprecation_marker = process_module!(job, mod)
     if deprecation_marker != DeprecationMarker()
-        Base.depwarn("GPUCompiler.process_module! is deprecated; implement GPUCompiler.finish_module! instead", :process_module)
+        safe_depwarn("GPUCompiler.process_module! is deprecated; implement GPUCompiler.finish_module! instead", :process_module)
     end
 
     # sanitize global values (Julia doesn't when using the external codegen policy)
@@ -71,7 +71,7 @@ function irgen(@nospecialize(job::CompilerJob))
     end
     deprecation_marker = process_entry!(job, mod, entry)
     if deprecation_marker != DeprecationMarker()
-        Base.depwarn("GPUCompiler.process_entry! is deprecated; implement GPUCompiler.finish_module! instead", :process_entry)
+        safe_depwarn("GPUCompiler.process_entry! is deprecated; implement GPUCompiler.finish_module! instead", :process_entry)
         entry = deprecation_marker
     end
     if job.config.entry_abi === :specfunc

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -130,6 +130,67 @@ macro safe_show(exs...)
 end
 
 
+## safe deprecation warnings
+
+const depwarn_lock = Threads.SpinLock()
+# the frame is a `Ptr{Cvoid}` for compiled frames, or a `Base.InterpreterIP` for
+# interpreted ones (e.g., when the deprecated function is called from top level)
+const depwarn_seen = Set{Tuple{Union{Ptr{Cvoid},Base.InterpreterIP},Symbol}}()
+
+"""
+    safe_depwarn(msg, funcsym; force=false)
+
+A `Base.depwarn` that does not switch tasks, so it can be used where task switches are
+illegal: `@locked` regions holding the typeinf lock, generated functions, or abstract
+interpreter callbacks. `Base.depwarn` logs through the active logger, whose I/O may
+yield; this version writes the warning synchronously to `Core.stderr`, like `@safe_warn`
+does. It still attributes the warning to the caller, warns only once per call site, and
+throws under `--depwarn=error`. Custom loggers are bypassed, though.
+"""
+function safe_depwarn(msg, funcsym; force::Bool=false)
+    @static if VERSION >= v"1.12.0-DEV.769"
+        # compilation does not hold the typeinf lock, so we can warn regularly
+        return Base.depwarn(msg, funcsym; force)
+    else
+        opts = Base.JLOptions()
+        if opts.depwarn == 2
+            throw(ErrorException(msg))
+        end
+        force || opts.depwarn == 1 || return
+
+        # respect the verbosity of the global logger, like `@safe_warn` does
+        Logging.Warn >= _invoked_min_enabled_level(global_logger()) || return
+
+        # attribute the warning to the caller, like `Base.depwarn`
+        # (`backtrace` and `firstcaller` do not switch tasks)
+        bt = Base.backtrace()
+        frame, caller = Base.firstcaller(bt, funcsym)
+
+        # only warn once per call site. we can't use the logger's `maxlog` for this,
+        # since we construct a fresh logger every time
+        Base.@lock depwarn_lock begin
+            (frame, funcsym) in depwarn_seen && return
+            push!(depwarn_seen, (frame, funcsym))
+        end
+
+        linfo = caller.linfo
+        mod = if linfo isa Core.MethodInstance
+            def = linfo.def
+            def isa Module ? def : def.module
+        else
+            Core
+        end
+
+        # emit synchronously; writes to `Core.stderr` do not switch tasks
+        io = IOContext(Core.stderr, :color => STDERR_HAS_COLOR[])
+        logger = Logging.ConsoleLogger(io)
+        Logging.handle_message(logger, Logging.Warn, msg, mod, :depwarn,
+                               (frame, funcsym), String(caller.file), caller.line;
+                               caller)
+        return
+    end
+end
+
 
 ## codegen locking
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,6 +7,51 @@
     @test groups[3] == [:(d=4)]
 end
 
+@noinline old_api() = GPUCompiler.safe_depwarn("`old_api` is deprecated.", :old_api; force=true)
+# @noinline so that both invocations below share a single `old_api` call site,
+# which is what the warning gets deduplicated on (like `Base.depwarn`)
+@noinline use_old_api() = old_api()
+
+@testset "safe_depwarn" begin
+    if VERSION >= v"1.12.0-DEV.769"
+        # forwards to Base.depwarn, which logs through the active logger
+        logs, _ = Test.collect_test_logs() do
+            use_old_api()
+        end
+        @test any(logs) do record
+            record.group === :depwarn && occursin("old_api", string(record.message))
+        end
+    else
+        # emits synchronously to Core.stderr
+        output = mktemp() do path, io
+            redirect_stderr(io) do
+                for _ in 1:2
+                    use_old_api()
+                end
+            end
+            flush(io)
+            read(path, String)
+        end
+        @test occursin("`old_api` is deprecated.", output)
+        # attributed to the caller of the deprecated function
+        @test occursin("use_old_api", output)
+        # repeated calls from the same call site only warn once
+        # (using `count` as `findall` is imported from Core.Compiler below)
+        @test count("is deprecated", output) == 1
+
+        # interpreted call sites are identified by a `Base.InterpreterIP` instead of a
+        # plain instruction pointer; make sure the call-site tracking can handle that
+        output = mktemp() do path, io
+            redirect_stderr(io) do
+                eval(:(old_api()))
+            end
+            flush(io)
+            read(path, String)
+        end
+        @test occursin("`old_api` is deprecated.", output)
+    end
+end
+
 @testset "mangling" begin
     using demumble_jll
 


### PR DESCRIPTION
Backport https://github.com/JuliaGPU/GPUCompiler.jl/pull/831
cc @simeonschaub 