### PR TITLE
Record line coverage of device code at compile time.

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -707,6 +707,37 @@ function Base.precompile(@nospecialize(job::CompilerJob))
 end
 
 
+## code coverage
+
+# When the host process runs with `--code-coverage`, lowered code contains
+# `:code_coverage_effect` expressions, which the compiler only inserts for code that is
+# actually being tracked. Device code cannot count executions, as it cannot call into the
+# Julia runtime, so instead we mark those lines as visited when compiling them: Coverage of
+# device code thus means "this code was compiled", with counts reflecting the number of
+# compilations rather than executions.
+function record_coverage(src::CodeInfo)
+    for (pc, stmt) in enumerate(src.code)
+        (stmt isa Expr && stmt.head === :code_coverage_effect) || continue
+        @static if VERSION >= v"1.12-"
+            scopes = Base.IRShow.buildLineInfoNode(src.debuginfo, nothing, pc)
+            isempty(scopes) && continue
+            loc = scopes[end]   # innermost scope, i.e., the inlined callee
+            file, line = loc.file, loc.line
+        else
+            lineidx = src.codelocs[pc]
+            lineidx == 0 && continue
+            loc = src.linetable[lineidx]::Core.LineInfoNode
+            file, line = loc.file, loc.line
+        end
+        file isa Symbol || continue
+        filename = String(file)
+        (isempty(filename) || line <= 0) && continue
+        ccall(:jl_coverage_visit_line, Cvoid, (Cstring, Csize_t, Cint),
+              filename, ncodeunits(filename), line)
+    end
+    return
+end
+
 const HAS_LLVM_GET_CIS = (
     VERSION >= v"1.13.0-DEV.1120" || (
         Libdl.dlsym(
@@ -724,6 +755,14 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
     interp = get_interpreter(job)
     cache = CC.code_cache(interp)
     populated = ci_cache_populate(interp, cache, job.source, job.world, job.world)
+
+    # record line coverage of all compiled code (on older versions of Julia, where
+    # `ci_cache_populate` does not return sources, this happens after codegen instead)
+    if Base.JLOptions().code_coverage != 0
+        for (ci, src) in populated
+            record_coverage(src)
+        end
+    end
 
     # create a callback to look-up function in our cache,
     # and keep track of the method instances we needed.
@@ -961,6 +1000,20 @@ function compile_method_instance(@nospecialize(job::CompilerJob))
 
     # Avoid redundant code_instances. This is necessary to avoid false positives trying to add the same key'd mi to the compiled Dict.
     unique!(code_instances)
+
+    # record line coverage of all compiled code (on newer versions of Julia, this happens
+    # based on the sources returned by `ci_cache_populate` instead)
+    if Base.JLOptions().code_coverage != 0 && isempty(populated)
+        for ci in code_instances
+            src = ci.inferred
+            if src isa String
+                src = Base._uncompressed_ir(ci, src)
+            end
+            if src isa CodeInfo
+                record_coverage(src)
+            end
+        end
+    end
 
     resize!(method_instances, length(code_instances))
     for (i, ci) in enumerate(code_instances)

--- a/test/native.jl
+++ b/test/native.jl
@@ -223,6 +223,51 @@ end
         # this also applies to Symbols
         Native.code_execution(Returns(nothing), (Symbol,))
     end
+
+    @testset "code coverage" begin
+        mod = @eval module $(gensym())
+            @inline inlined_callee(x) = x + one(x)
+            @noinline noinline_callee(x) = x * 2
+            entry(x) = noinline_callee(inlined_callee(x))
+        end
+
+        # whether any line in `lo:hi` of `file` has a nonzero execution count in an
+        # lcov tracefile
+        function lcov_any_covered(tracefile, file, lo, hi)
+            in_block = false
+            for l in eachline(tracefile)
+                if startswith(l, "SF:")
+                    in_block = (l == "SF:" * file)
+                elseif l == "end_of_record"
+                    in_block = false
+                elseif in_block && startswith(l, "DA:")
+                    ln, cnt = parse.(Int, split(l[4:end], ","))
+                    lo <= ln <= hi && cnt >= 1 && return true
+                end
+            end
+            return false
+        end
+
+        if Base.JLOptions().code_coverage == 0
+            @test_skip "requires --code-coverage"
+        else
+            job, _ = Native.create_job(mod.entry, (Int,))
+            JuliaContext() do ctx
+                GPUCompiler.compile(:asm, job)
+            end
+
+            # flush coverage data in-process; the device functions must show covered
+            # lines even though they were never executed by the host.
+            mktempdir() do dir
+                tracefile = joinpath(dir, "coverage.info")
+                ccall(:jl_write_coverage_data, Cvoid, (Cstring,), tracefile)
+                for f in (mod.inlined_callee, mod.noinline_callee, mod.entry)
+                    m = only(methods(f))
+                    @test lcov_any_covered(tracefile, string(m.file), m.line, m.line + 1)
+                end
+            end
+        end
+    end
 end
 
 ############################################################################################


### PR DESCRIPTION
When the host process runs with --code-coverage, lowered code contains :code_coverage_effect expressions, which the compiler only inserts for code that is actually being tracked. Device code cannot count executions (it cannot call into the Julia runtime), so instead mark those lines as visited when compiling them, by calling jl_coverage_visit_line on the host. Coverage of device code thus means "this code was compiled", with counts reflecting the number of compilations rather than executions.

Inspired by https://github.com/JuliaGPU/cuTile.jl/pull/249