### PR TITLE
Require LLVM 9.9 and use the new debug location accessors.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ NVPTX_LLVM_Backend_jll = "ef6e0fe3-e6ef-59c0-bde6-4989574699e0"
 [compat]
 ExprTools = "0.1"
 InteractiveUtils = "1"
-LLVM = "9.8.1"
+LLVM = "9.9"
 LLVMDowngrader_jll = "0.8"
 Libdl = "1"
 Logging = "1"

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -14,19 +14,17 @@ function backtrace(inst::LLVM.Instruction, bt = StackTraces.StackFrame[])
         push!(done, inst)
 
         # look up the debug information from the current instruction
-        if haskey(metadata(inst), LLVM.MD_dbg)
-            loc = metadata(inst)[LLVM.MD_dbg]
-            while loc !== nothing
-                scope = LLVM.scope(loc)
-                if scope !== nothing
-                    name = replace(LLVM.name(scope), r";$"=>"")
-                    file = LLVM.file(scope)
-                    path = joinpath(LLVM.directory(file), LLVM.filename(file))
-                    line = LLVM.line(loc)
-                    push!(bt, StackTraces.StackFrame(name, path, line))
-                end
-                loc = LLVM.inlined_at(loc)
+        loc = LLVM.debuglocation(inst)
+        while loc !== nothing
+            scope = LLVM.scope(loc)
+            if scope !== nothing
+                name = replace(LLVM.name(scope), r";$"=>"")
+                file = LLVM.file(scope)
+                path = joinpath(LLVM.directory(file), LLVM.filename(file))
+                line = LLVM.line(loc)
+                push!(bt, StackTraces.StackFrame(name, path, line))
             end
+            loc = LLVM.inlined_at(loc)
         end
 
         # move up the call chain
@@ -35,15 +33,13 @@ function backtrace(inst::LLVM.Instruction, bt = StackTraces.StackFrame[])
         callers = filter(val -> isa(user(val), LLVM.CallInst), collect(uses(f)))
         ## get rid of calls without debug info
         filter!(callers) do call
-            md = metadata(user(call))
-            haskey(md, LLVM.MD_dbg)
+            LLVM.debuglocation(user(call)) !== nothing
         end
         if !isempty(callers)
             # figure out the call sites of this instruction
             call_sites = unique(callers) do call
                 # there could be multiple calls, originating from the same source location
-                md = metadata(user(call))
-                md[LLVM.MD_dbg]
+                LLVM.debuglocation(user(call))
             end
 
             if length(call_sites) > 1


### PR DESCRIPTION
Replaces manual MD_dbg metadata lookups in backtrace() with the debuglocation(::Instruction) accessor introduced in LLVM.jl 9.9.