### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,0 +1,51 @@
+steps:
+  - label: "Metal.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+      julia -e 'println("--- :julia: Instantiating project")
+                using Pkg
+                Pkg.develop(; path=pwd())
+                Pkg.develop(; name="Metal")' || exit 3
+
+      julia -e 'println("+++ :julia: Running tests")
+                using Pkg
+                Pkg.test("Metal"; coverage=true)'
+    agents:
+      queue: "juliaecosystem"
+      os: "macos"
+      arch: "aarch64"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 120
+    soft_fail:
+      - exit_status: 3
+
+  - label: "Enzyme.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+      julia -e 'println("--- :julia: Instantiating project")
+                using Pkg
+                Pkg.develop(; path=pwd())
+                Pkg.develop(; name="Enzyme")' || exit 3
+
+      julia -e 'println("+++ :julia: Running tests")
+                using Pkg
+                Pkg.test("Enzyme"; coverage=true, julia_args=`--depwarn=no`)'
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 120
+    soft_fail:
+      - exit_status: 3
+
+env:
+  JULIA_PKG_SERVER: "" # it often struggles with our large artifacts

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,8 +16,7 @@ steps:
                 using Pkg
                 Pkg.test("CUDA"; coverage=true)'
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
     timeout_in_minutes: 120
     soft_fail:
@@ -43,34 +42,9 @@ steps:
                 using Pkg
                 Pkg.test("oneAPI"; coverage=true)'
     agents:
-      queue: "juliagpu"
-      intel: "*"
+      queue: "oneapi"
     if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
     timeout_in_minutes: 60
-    soft_fail:
-      - exit_status: 3
-
-  - label: "Metal.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: |
-      julia -e 'println("--- :julia: Instantiating project")
-                using Pkg
-                Pkg.develop(; path=pwd())
-                Pkg.develop(; name="Metal")' || exit 3
-
-      julia -e 'println("+++ :julia: Running tests")
-                using Pkg
-                Pkg.test("Metal"; coverage=true)'
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
-    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
-    timeout_in_minutes: 120
     soft_fail:
       - exit_status: 3
 
@@ -90,8 +64,7 @@ steps:
                  using Pkg
                  Pkg.test("AMDGPU"; coverage=true)'
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
     if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
     timeout_in_minutes: 60
     soft_fail:
@@ -116,32 +89,7 @@ steps:
     agents:
       # XXX: not on "juliaecosystem" because those workers don't have libc-dev
       #      see JuliaGPU/OpenCL.jl#303
-      queue: "juliagpu"
-      cuda: "*"
-    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
-    timeout_in_minutes: 120
-    soft_fail:
-      - exit_status: 3
-
-  - label: "Enzyme.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: |
-      julia -e 'println("--- :julia: Instantiating project")
-                using Pkg
-                Pkg.develop(; path=pwd())
-                Pkg.develop(; name="Enzyme")' || exit 3
-
-      julia -e 'println("+++ :julia: Running tests")
-                using Pkg
-                Pkg.test("Enzyme"; coverage=true, julia_args=`--depwarn=no`)'
-    agents:
-      queue: "juliaecosystem"
-      os: "linux"
-      arch: "x86_64"
+      queue: "cuda"
     if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
     timeout_in_minutes: 120
     soft_fail:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

Since queues are scoped to a cluster, a single pipeline can no longer mix JuliaGPU and `juliaecosystem` jobs: `pipeline.yml` now contains only the GPU jobs (and remains the default upload for the existing Buildkite pipeline), while the `juliaecosystem` steps (Metal.jl, Enzyme.jl) have moved unmodified to `pipeline-julia.yml`, to be uploaded by a separate pipeline in the ecosystem cluster once that is back online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)