### PR TITLE
Move Metal.jl testing back to the main pipeline

### DIFF
--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,28 +1,4 @@
 steps:
-  - label: "Metal.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.11"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: |
-      julia -e 'println("--- :julia: Instantiating project")
-                using Pkg
-                Pkg.develop(; path=pwd())
-                Pkg.develop(; name="Metal")' || exit 3
-
-      julia -e 'println("+++ :julia: Running tests")
-                using Pkg
-                Pkg.test("Metal"; coverage=true)'
-    agents:
-      queue: "juliaecosystem"
-      os: "macos"
-      arch: "aarch64"
-    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
-    timeout_in_minutes: 120
-    soft_fail:
-      - exit_status: 3
-
   - label: "Enzyme.jl"
     plugins:
       - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,28 @@ steps:
     soft_fail:
       - exit_status: 3
 
+  - label: "Metal.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.11"
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    command: |
+      julia -e 'println("--- :julia: Instantiating project")
+                using Pkg
+                Pkg.develop(; path=pwd())
+                Pkg.develop(; name="Metal")' || exit 3
+
+      julia -e 'println("+++ :julia: Running tests")
+                using Pkg
+                Pkg.test("Metal"; coverage=true)'
+    agents:
+      queue: "metal"
+    if: build.message !~ /\[skip tests\]/ && !build.pull_request.draft
+    timeout_in_minutes: 120
+    soft_fail:
+      - exit_status: 3
+
   - label: "OpenCL.jl"
     plugins:
       - JuliaCI/julia#v1:


### PR DESCRIPTION
The JuliaGPU cluster now has a macOS agent with an Apple Silicon GPU (`monoceros.1`, a seatbelt-sandboxed buildkite-agent with native Metal access), registered with a dedicated `metal` queue. The Metal.jl job can therefore move back from `pipeline-julia.yml` into the main pipeline, leaving only the Enzyme.jl job for the ecosystem cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)