### PR TITLE
Metal: Fixes for dynamic allocations

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -343,15 +343,6 @@ const __llvm_initialized = Ref(false)
 
             # GPU run-time library
             if !uses_julia_runtime(job)
-                # Calls to `gc_pool_alloc` are inserted after linking, so spoof
-                # it here so that lazy linking pulls it in, if needed.
-                if haskey(functions(ir), "julia.gc_alloc_obj")
-                    rt = Runtime.get(:gc_pool_alloc)
-                    if !haskey(functions(ir), rt.llvm_name)
-                        LLVM.Function(ir, rt.llvm_name, convert(LLVM.FunctionType, rt))
-                    end
-                end
-
                 @tracepoint "runtime library" link!(ir, runtime; only_needed=true)
             end
         end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -392,6 +392,9 @@ finish_linked_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = retur
 # post-Julia optimization processing of the module
 optimize_module!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = return
 
+# post-runtime-intrinsic-lowering processing of the module
+finish_runtime_intrinsics!(@nospecialize(job::CompilerJob), mod::LLVM.Module) = false
+
 # final processing of the IR, right before validation and machine-code generation
 finish_ir!(@nospecialize(job::CompilerJob), mod::LLVM.Module, entry::LLVM.Function) =
     entry

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -800,8 +800,8 @@ function add_kernel_state!(mod::LLVM.Module)
     job = current_job::CompilerJob
 
     # check if we even need a kernel state argument
+    job.config.kernel || return false
     state = kernel_state_type(job)
-    @assert job.config.kernel
     if state === Nothing
         return false
     end

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -251,6 +251,15 @@ function finish_runtime_intrinsics!(@nospecialize(job::CompilerJob{MetalCompiler
         add_input_arguments!(job, mod, f, kernel_intrinsics)
         changed = true
     end
+    @dispose pb=NewPMPassBuilder() begin
+        LLVM.target_transform_info!(pb, MetalTTI())
+        add!(pb, ModuleInlinerWrapperPass())
+        add!(pb, NewPMFunctionPassManager()) do fpm
+            add!(fpm, instcombine_pass(job))
+            add!(fpm, SimplifyCFGPass())
+        end
+        run!(pb, mod, llvm_machine(job.config.target))
+    end
     return changed
 end
 
@@ -416,6 +425,12 @@ end
 # this keeps the `:llvm` output (e.g. `code_llvm`) close to what Julia generated, using
 # generic LLVM intrinsics, while the `:asm`/`:obj` outputs contain AIR intrinsics.
 function lower_air!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::LLVM.Module)
+    # Avoid generic-space null tests of pointers selected from concrete address spaces.
+    # AIR can miscompile the generic comparison, while comparing in the source address
+    # space and casting only the surviving pointer is the shape Julia emits for direct
+    # Metal.malloc uses.
+    rewrite_generic_null_selects!(mod)
+
     # strip device-side `trap`s and rewrite `unreachable` into clean returns (#433, #370). this
     # runs post-`optimize!`, after the trap has finished serving as the optimizer guard; the pass
     # force-inlines throwing functions into the kernel first so the rewrite is sound, then scrubs
@@ -916,6 +931,67 @@ function propagate_argument_address_spaces!(mod::LLVM.Module)
     while propagate_argument_address_spaces_once!(mod)
         changed = true
     end
+    return changed
+end
+
+function select_source_and_null(sel::LLVM.SelectInst)
+    ops = collect(operands(sel))
+    cond, lhs, rhs = ops
+    src_lhs = addrspacecast_to_generic_source(lhs)
+    src_rhs = addrspacecast_to_generic_source(rhs)
+    if src_lhs !== nothing && isnull(rhs)
+        return cond, src_lhs, true
+    elseif isnull(lhs) && src_rhs !== nothing
+        return cond, src_rhs, false
+    end
+    return nothing
+end
+
+function rewrite_generic_null_selects!(mod::LLVM.Module)
+    changed = false
+    worklist = LLVM.ICmpInst[]
+    for f in functions(mod)
+        isdeclaration(f) && continue
+        for bb in blocks(f), inst in instructions(bb)
+            inst isa LLVM.ICmpInst || continue
+            pred = predicate(inst)
+            pred in (LLVM.API.LLVMIntEQ, LLVM.API.LLVMIntNE) || continue
+            ops = collect(operands(inst))
+            sel_idx = ops[1] isa LLVM.SelectInst && isnull(ops[2]) ? 1 :
+                      ops[2] isa LLVM.SelectInst && isnull(ops[1]) ? 2 : 0
+            sel_idx == 0 && continue
+            sel = ops[sel_idx]::LLVM.SelectInst
+            value_type(sel) isa LLVM.PointerType || continue
+            addrspace(value_type(sel)) == 0 || continue
+            select_info = select_source_and_null(sel)
+            select_info === nothing && continue
+            push!(worklist, inst)
+        end
+    end
+
+    for inst in worklist
+        ops = collect(operands(inst))
+        sel = (ops[1] isa LLVM.SelectInst ? ops[1] : ops[2])::LLVM.SelectInst
+        cond, src, cast_is_true_value = select_source_and_null(sel)
+        @dispose builder=IRBuilder() begin
+            position!(builder, inst)
+            src_is_null = icmp!(builder, LLVM.API.LLVMIntEQ, src, null(value_type(src)))
+            replacement = if predicate(inst) == LLVM.API.LLVMIntEQ
+                select!(builder, cond,
+                        cast_is_true_value ? src_is_null : ConstantInt(LLVM.Int1Type(), 1),
+                        cast_is_true_value ? ConstantInt(LLVM.Int1Type(), 1) : src_is_null)
+            else
+                src_is_not_null = icmp!(builder, LLVM.API.LLVMIntNE, src, null(value_type(src)))
+                select!(builder, cond,
+                        cast_is_true_value ? src_is_not_null : ConstantInt(LLVM.Int1Type(), 0),
+                        cast_is_true_value ? ConstantInt(LLVM.Int1Type(), 0) : src_is_not_null)
+            end
+            replace_uses!(inst, replacement)
+            erase!(inst)
+        end
+        changed = true
+    end
+
     return changed
 end
 

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -205,7 +205,6 @@ function finish_linked_module!(@nospecialize(job::CompilerJob{MetalCompilerTarge
     for f in kernels(mod)
         # update calling conventions
         f = pass_by_reference!(job, mod, f)
-        f = add_input_arguments!(job, mod, f, kernel_intrinsics)
     end
 
     # emit the AIR and Metal version numbers as constants in the module. this makes it
@@ -241,6 +240,18 @@ function finish_linked_module!(@nospecialize(job::CompilerJob{MetalCompilerTarge
     end
 
     return
+end
+
+function finish_runtime_intrinsics!(@nospecialize(job::CompilerJob{MetalCompilerTarget}),
+                                    mod::LLVM.Module)
+    # AIR input arguments need to be threaded after GC lowering and runtime linking:
+    # `gpu_gc_pool_alloc` can call runtime helpers that use thread-position intrinsics.
+    changed = false
+    for f in kernels(mod)
+        add_input_arguments!(job, mod, f, kernel_intrinsics)
+        changed = true
+    end
+    return changed
 end
 
 function validate_ir(job::CompilerJob{MetalCompilerTarget}, mod::LLVM.Module)

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -327,9 +327,11 @@ function buildIntrinsicLoweringPipeline(mpm, @nospecialize(job::CompilerJob), op
         add!(mpm, NewPMFunctionPassManager()) do fpm
             add!(fpm, GPULowerGCFramePass())
         end
-        add!(mpm, GPULinkRuntimePass())
-        add!(mpm, GPULinkLibrariesPass())
-        add!(mpm, GPUFinishRuntimeIntrinsicsPass())
+        if job.config.libraries
+            add!(mpm, GPULinkRuntimePass())
+            add!(mpm, GPULinkLibrariesPass())
+            add!(mpm, GPUFinishRuntimeIntrinsicsPass())
+        end
     end
 
     # lower kernel state intrinsics
@@ -472,6 +474,7 @@ GPULowerCPUFeaturesPass() = NewPMModulePass("GPULowerCPUFeatures", cpu_features!
 
 function link_runtime!(mod::LLVM.Module)
     job = current_job::CompilerJob
+    job.config.libraries || return false
     uses_julia_runtime(job) && return false
 
     # GC lowering can introduce new calls to GPU runtime functions after the runtime

--- a/src/optim.jl
+++ b/src/optim.jl
@@ -62,6 +62,9 @@ function optimize!(@nospecialize(job::CompilerJob), mod::LLVM.Module; opt_level=
         register!(pb, GPULowerCPUFeaturesPass())
         register!(pb, GPULowerPTLSPass())
         register!(pb, GPULowerGCFramePass())
+        register!(pb, GPULinkRuntimePass())
+        register!(pb, GPULinkLibrariesPass())
+        register!(pb, GPUFinishRuntimeIntrinsicsPass())
         register!(pb, AddKernelStatePass())
         register!(pb, LowerKernelStatePass())
         register!(pb, CleanupKernelStatePass())
@@ -324,6 +327,9 @@ function buildIntrinsicLoweringPipeline(mpm, @nospecialize(job::CompilerJob), op
         add!(mpm, NewPMFunctionPassManager()) do fpm
             add!(fpm, GPULowerGCFramePass())
         end
+        add!(mpm, GPULinkRuntimePass())
+        add!(mpm, GPULinkLibrariesPass())
+        add!(mpm, GPUFinishRuntimeIntrinsicsPass())
     end
 
     # lower kernel state intrinsics
@@ -463,6 +469,45 @@ function cpu_features!(mod::LLVM.Module)
     return changed
 end
 GPULowerCPUFeaturesPass() = NewPMModulePass("GPULowerCPUFeatures", cpu_features!)
+
+function link_runtime!(mod::LLVM.Module)
+    job = current_job::CompilerJob
+    uses_julia_runtime(job) && return false
+
+    # GC lowering can introduce new calls to GPU runtime functions after the runtime
+    # was linked initially. Link again now so those calls resolve to definitions before
+    # later intrinsic-lowering passes inspect or rewrite the runtime call graph.
+    runtime = load_runtime(job)
+    link!(mod, runtime; only_needed=true)
+    return true
+end
+GPULinkRuntimePass() = NewPMModulePass("GPULinkRuntime", link_runtime!)
+
+function link_libraries!(mod::LLVM.Module)
+    job = current_job::CompilerJob
+    job.config.libraries || return false
+
+    # Runtime functions materialized by GC lowering can introduce target-library
+    # references after the normal library-linking phase has run. Give back-ends a
+    # second chance to resolve those references before they lower their own runtime
+    # intrinsics. This is a no-op for back-ends without a link_libraries! override.
+    if has_legacy_link_libraries(job)
+        undefined_fns = [LLVM.name(f) for f in functions(mod)
+                         if isdeclaration(f) && !LLVM.isintrinsic(f)]
+        link_libraries!(job, mod, undefined_fns)
+    else
+        link_libraries!(job, mod)
+    end
+    return true
+end
+GPULinkLibrariesPass() = NewPMModulePass("GPULinkLibraries", link_libraries!)
+
+function finish_runtime_intrinsics!(mod::LLVM.Module)
+    job = current_job::CompilerJob
+    return finish_runtime_intrinsics!(job, mod)
+end
+GPUFinishRuntimeIntrinsicsPass() =
+    NewPMModulePass("GPUFinishRuntimeIntrinsics", finish_runtime_intrinsics!)
 
 # lower object allocations to to PTX malloc
 #

--- a/test/helpers/metal.jl
+++ b/test/helpers/metal.jl
@@ -6,11 +6,42 @@ import ..TestRuntime
 struct CompilerParams <: AbstractCompilerParams end
 GPUCompiler.runtime_module(::CompilerJob{<:Any,CompilerParams}) = TestRuntime
 
+struct ThreadedRuntimeCompilerParams <: AbstractCompilerParams end
+
+module ThreadedRuntime
+    using ..GPUCompiler
+
+    signal_exception() = return
+    malloc(sz) = C_NULL
+    function report_oom(sz)
+        ccall("extern julia.air.thread_position_in_grid.v3i32", llvmcall,
+              NTuple{3, VecElement{UInt32}}, ())
+        return
+    end
+    report_exception(ex) = return
+    report_exception_name(ex) = return
+    report_exception_frame(idx, func, file, line) = return
+end
+
+ThreadedRuntimeCompilerJob = CompilerJob{MetalCompilerTarget,ThreadedRuntimeCompilerParams}
+GPUCompiler.runtime_module(::ThreadedRuntimeCompilerJob) = ThreadedRuntime
+GPUCompiler.runtime_slug(job::ThreadedRuntimeCompilerJob) =
+    "metal-threadedruntime-macos$(job.config.target.macos)-debuginfo=$(Int(GPUCompiler.llvm_debug_info(job)))"
+
 function create_job(@nospecialize(func), @nospecialize(types); kwargs...)
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
     target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
     params = CompilerParams()
+    config = CompilerConfig(target, params; kernel=false, config_kwargs...)
+    CompilerJob(source, config), kwargs
+end
+
+function create_threaded_runtime_job(@nospecialize(func), @nospecialize(types); kwargs...)
+    config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
+    source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
+    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
+    params = ThreadedRuntimeCompilerParams()
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
     CompilerJob(source, config), kwargs
 end
@@ -30,6 +61,12 @@ function code_llvm(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     GPUCompiler.code_llvm(io, job; kwargs...)
 end
 
+function code_llvm_threaded_runtime(io::IO, @nospecialize(func), @nospecialize(types);
+                                    kwargs...)
+    job, kwargs = create_threaded_runtime_job(func, types; kwargs...)
+    GPUCompiler.code_llvm(io, job; kwargs...)
+end
+
 function code_native(io::IO, @nospecialize(func), @nospecialize(types); kwargs...)
     job, kwargs = create_job(func, types; kwargs...)
     GPUCompiler.code_native(io, job; kwargs...)
@@ -43,6 +80,9 @@ for method in (:code_warntype, :code_llvm, :code_native)
             $method(stdout, func, types; kwargs...)
     end
 end
+
+code_llvm_threaded_runtime(@nospecialize(func), @nospecialize(types); kwargs...) =
+    code_llvm_threaded_runtime(stdout, func, types; kwargs...)
 
 # simulates codegen for a kernel function: validates by default
 function code_execution(@nospecialize(func), @nospecialize(types); kwargs...)

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -139,6 +139,54 @@ end
     end
 end
 
+@testset "GC runtime input arguments" begin
+    mod = @eval module $(gensym())
+        mutable struct PleaseAllocate
+            y::Csize_t
+        end
+
+        @noinline function inner(x)
+            sink(x.y)
+            return
+        end
+
+        function kernel(i)
+            inner(PleaseAllocate(Csize_t(i)))
+            return
+        end
+
+        function ref_kernel(ptr, i)
+            data = Ref{Int64}()
+            data[] = 0
+            if i > 1
+                data[] = 1
+            else
+                data[] = 2
+            end
+            unsafe_store!(ptr, data[], i)
+            return
+        end
+    end
+
+    ir = sprint() do io
+        Metal.code_llvm_threaded_runtime(io, mod.kernel, Tuple{Int};
+                                         kernel=true, dump_module=true)
+    end
+    @test occursin(r"define .*@gpu_gc_pool_alloc\(", ir)
+    @test occursin(r"call .*@gpu_gc_pool_alloc\([^)]*<3 x i32>", ir)
+    @test occursin("thread_position_in_grid", ir)
+    @test !occursin(r"declare .*@gpu_gc_pool_alloc\(", ir)
+
+    # Make sure moving Metal's input-argument threading after GC lowering does not force
+    # allocations that the optimizer can still prove unnecessary.
+    ir = sprint() do io
+        Metal.code_llvm_threaded_runtime(io, mod.ref_kernel,
+                                         Tuple{Core.LLVMPtr{Int64,1}, Int};
+                                         kernel=true, dump_module=true)
+    end
+    @test !occursin("gpu_gc_pool_alloc", ir)
+end
+
 @testset "vector intrinsics" begin
     mod = @eval module $(gensym())
         foo(x, y) = ccall("llvm.smax.v2i64", llvmcall, NTuple{2, VecElement{Int64}},

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -172,8 +172,7 @@ end
         Metal.code_llvm_threaded_runtime(io, mod.kernel, Tuple{Int};
                                          kernel=true, dump_module=true)
     end
-    @test occursin(r"define .*@gpu_gc_pool_alloc\(", ir)
-    @test occursin(r"call .*@gpu_gc_pool_alloc\([^)]*<3 x i32>", ir)
+    @test occursin(r"define .*@gpu_gc_pool_alloc\([^)]*<3 x i32>", ir)
     @test occursin("thread_position_in_grid", ir)
     @test !occursin(r"declare .*@gpu_gc_pool_alloc\(", ir)
 
@@ -339,6 +338,38 @@ end
         @check cond=typed_ptrs "load float, float addrspace(2)*"
         Metal.code_llvm(mod.kernel, Tuple{Core.LLVMPtr{Float32,1}, Int};
                         dump_module=true, kernel=true)
+    end
+end
+
+@testset "generic null select rewrite" begin
+    JuliaContext() do ctx
+        mod = LLVM.Module("test")
+        T_i1 = LLVM.Int1Type()
+        T_void = LLVM.VoidType()
+        T_p0 = supports_typed_pointers() ? LLVM.PointerType(LLVM.Int8Type(), 0) :
+                                           LLVM.PointerType(0)
+        T_p1 = supports_typed_pointers() ? LLVM.PointerType(LLVM.Int8Type(), 1) :
+                                           LLVM.PointerType(1)
+        f = LLVM.Function(mod, "f", LLVM.FunctionType(T_void, [T_p1]))
+        @dispose builder=IRBuilder() begin
+            entry = BasicBlock(f, "entry")
+            position!(builder, entry)
+            p0 = addrspacecast!(builder, parameters(f)[1], T_p0)
+            sel = select!(builder, ConstantInt(T_i1, 1), p0, null(T_p0))
+            cmp = icmp!(builder, LLVM.API.LLVMIntEQ, sel, null(T_p0))
+            ok = BasicBlock(f, "ok")
+            fail = BasicBlock(f, "fail")
+            br!(builder, cmp, fail, ok)
+            position!(builder, ok)
+            ret!(builder)
+            position!(builder, fail)
+            ret!(builder)
+        end
+
+        @test GPUCompiler.rewrite_generic_null_selects!(mod)
+        ir = string(mod)
+        @test occursin(r"icmp eq .*addrspace\(1\).*null", ir)
+        @test !occursin(r"icmp eq ptr %.* null", ir)
     end
 end
 


### PR DESCRIPTION
Kernels that trigger a dynamic GC allocation (i.e. emit `julia.gc_alloc_obj`) miscompiled on Metal. Two distinct problems stacked on top of each other:

1. The GPU runtime's `gpu_gc_pool_alloc` is only materialized by `GPULowerGCFramePass` *during* optimization — after the early runtime link and after Metal has already threaded its AIR implicit input arguments (e.g. `thread_position_in_grid`) into kernels. If the allocation helper transitively calls such an intrinsic (via `report_oom`), the kernel and the late-linked runtime ended up disagreeing about call-graph signatures, leaving an unresolved/insufficiently-lowered runtime helper.
2. Once the runtime *is* correctly linked and threaded, `gpu_gc_pool_alloc`'s `ptr == C_NULL` check lowers into a shape AIR miscompiles: a null test on a *generic* pointer that was `addrspacecast` from device space and selected against `null`.

This PR moves GPU runtime relinking and Metal's AIR input-argument threading out of the link/`finish_linked_module!` stage and into the post-GC-lowering optimization pipeline, so the runtime definition and the generated call sites agree before kernel-state lowering and cleanup run. Then normalize the allocation null check into the address space Julia uses for direct `Metal.malloc`.