### PR TITLE
Align runtime datalayout when relinking after non-integral stripping

### DIFF
--- a/src/optim.jl
+++ b/src/optim.jl
@@ -498,6 +498,10 @@ function link_runtime!(mod::LLVM.Module)
     # was linked initially. Link again now so those calls resolve to definitions before
     # later intrinsic-lowering passes inspect or rewrite the runtime call graph.
     runtime = load_runtime(job)
+    # `RemoveNIPass` stripped non-integral address spaces from `mod`'s datalayout, but the
+    # cached runtime kept them; align it (as with target libraries) to avoid a warning.
+    triple!(runtime, triple(mod))
+    datalayout!(runtime, datalayout(mod))
     link!(mod, runtime; only_needed=true)
     return true
 end


### PR DESCRIPTION
The post-GC-lowering runtime relink runs after `RemoveNIPass` has stripped Julia's non-integral address spaces from the module datalayout, while the cached runtime library still carries them. This produced a spurious "Linking two modules of different data layouts" warning during (pre)compilation.

Align the runtime's triple and datalayout to the destination before linking, mirroring how target libraries (e.g. libdevice) are linked.

Fixes https://github.com/JuliaGPU/CUDA.jl/issues/3177