### PR TITLE
Harden compiler-error display against disposed LLVM modules

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -21,6 +21,9 @@ function Base.showerror(io::IO, err::KernelError)
     Base.show_backtrace(io, err.bt)
 end
 
+# `show` via `showerror` (cf. InvalidIRError)
+Base.show(io::IO, err::KernelError) = showerror(io, err)
+
 
 struct InternalCompilerError <: Exception
     job::CompilerJob

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -160,6 +160,9 @@ function Base.showerror(io::IO, err::InvalidIRError)
     return
 end
 
+# `show` via `showerror`, avoiding the default field-dump that derefs disposed IR
+Base.show(io::IO, err::InvalidIRError) = showerror(io, err)
+
 function check_ir(job, args...)
     errors = check_ir!(job, IRError[], args...)
     unique!(errors)
@@ -365,7 +368,9 @@ function check_ir_values(mod::LLVM.Module, predicate, msg="value")
     for fun in functions(mod), bb in blocks(fun), inst in instructions(bb)
         if predicate(inst) || any(predicate, operands(inst))
             bt = backtrace(inst)
-            push!(errors, (msg, bt, inst))
+            # snapshot to a string: the error may outlive the module, and showing a
+            # disposed LLVM value segfaults
+            push!(errors, (msg, bt, string(inst)))
         end
     end
     return errors


### PR DESCRIPTION
InvalidIRError retained a live LLVM.Instruction (from check_ir_values), so showing a caught error after its module was disposed segfaulted in Value::getName (e.g. Test rendering a failed test's exception). Snapshot the instruction to a string at construction, and route `show` through `showerror` for InvalidIRError/KernelError so display never field-dumps internal IR refs.