### PR TITLE
compiler: Use upcoming TypeEgal dispatch keys for type callees

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -16,9 +16,21 @@ end
 
 export methodinstance, generic_methodinstance
 
+@static if isdefined(Core, :TypeEgal)
+    @inline function dispatch_function_key(ft::Type)
+        if Base.isType(ft)
+            f = Base.type_parameter(ft)
+            !Base.has_free_typevars(f) && return Core.TypeEgal{f}
+        end
+        return ft
+    end
+else
+    @inline dispatch_function_key(ft::Type) = ft
+end
+
 @inline function signature_type_by_tt(ft::Type, tt::Type)
     u = Base.unwrap_unionall(tt)::DataType
-    return Base.rewrap_unionall(Tuple{ft, u.parameters...}, tt)
+    return Base.rewrap_unionall(Tuple{dispatch_function_key(ft), u.parameters...}, tt)
 end
 
 # create a MethodError from a function type

--- a/test/native.jl
+++ b/test/native.jl
@@ -22,6 +22,12 @@
     end
 end
 
+@testset "method instances for type-valued callees" begin
+    mi = GPUCompiler.methodinstance(Base._stable_typeof(Memory{Int}), Tuple{typeof(undef), Int})
+    @test mi isa Core.MethodInstance
+    @test Base.isdispatchtuple(mi.specTypes)
+end
+
 @testset "compilation" begin
     @testset "callable structs" begin
         mod = @eval module $(gensym())


### PR DESCRIPTION
The Base PR JuliaLang/julia#62001 is expected to spell exact closed type-object dispatch keys as Core.TypeEgal. When looking up method instances from a stable function type, use that upcoming dispatch spelling for closed Type{T} callee keys so constructor calls such as Memory{Int}(undef, n) remain compatible with Base.isdispatchtuple.

AI disclosure: This commit was prepared with assistance from generative AI. The resulting PR should be checked carefully by a maintainer before merging.