### PR TITLE
Remove vestigial LLVM_jll from the test environment

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -21,5 +21,5 @@ demumble_jll = "1e29f10c-031c-5a83-9565-69cddfc27673"
 
 [compat]
 Aqua = "0.8"
-LLVM_jll = "15,16,18,20"
+LLVM_jll = "15,16,18,20,21"
 ParallelTestRunner = "2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,7 +6,6 @@ GPUCompiler = "61eb1bfa-7361-4325-ad38-22787b887f55"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 LLVMDowngrader_jll = "f52de702-fb25-5922-94ba-81dd59b07444"
-LLVM_jll = "86de99a1-58d6-5da7-8064-bd56ce2e322c"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 NVPTX_LLVM_Backend_jll = "ef6e0fe3-e6ef-59c0-bde6-4989574699e0"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
@@ -21,5 +20,4 @@ demumble_jll = "1e29f10c-031c-5a83-9565-69cddfc27673"
 
 [compat]
 Aqua = "0.8"
-LLVM_jll = "15,16,18,20,21"
 ParallelTestRunner = "2"


### PR DESCRIPTION
## Problem

All `Julia nightly` CI jobs have failed since 2026-06-29. Julia 1.14 nightly ([JuliaLang/julia#61709](https://github.com/JuliaLang/julia/pull/61709)) rejects `cglobal` calls whose library-name element is a computed expression, enforced at *method-definition* time — so merely `include`-ing such a file throws:

```
TypeError: in cglobal library name, expected Symbol, got a value of type Expr
```

`test/Project.toml` pinned `LLVM_jll = "15,16,18,20"`. On nightly that capped LLVM_jll at **v20.1.8+0**, whose `platform_augmentation.jl` contains exactly such a call:

```julia
cglobal((:_ZN4llvm24DisableABIBreakingChecksE, Base.libllvm_path()), Cvoid)
```

`Pkg.test` → `instantiate` → `download_artifacts` runs each augmented JLL's `select_artifacts.jl` in a subprocess; including that file now throws and kills the whole `Pkg.test`.

## Fix

GPUCompiler's tests never use LLVM_jll directly — they use FileCheck.jl's `@filecheck`/`@check_*` macros. **FileCheck.jl itself** depends on LLVM_jll and locates the FileCheck binary via its artifact (`joinpath(LLVM_jll.artifact_dir, "tools", "FileCheck")`). So the explicit `LLVM_jll` entry in the test deps was vestigial; its only effect was the version bound, and that bound is what pinned the broken v20.1.8+0 build on nightly.

Dropping the dep lets FileCheck.jl govern resolution:
- **Julia 1.14**: FileCheck v1.2.0 (which no longer bounds LLVM_jll) resolves the fixed **LLVM_jll v21.1.8+1**, whose augmentation uses `Libdl.dlsym(dlopen(...))` ([JuliaPackaging/Yggdrasil#13664](https://github.com/JuliaPackaging/Yggdrasil/pull/13664)).
- **Older Julia (1.10–1.13)**: unaffected — julia-compat keeps LLVM_jll at ≤ v20, and those Julia versions accept the dynamic `cglobal`.

## Verification

Full suite on nightly (1.14.0-DEV), with `LLVM_jll` removed from the test deps: resolves FileCheck v1.2.0 + LLVM_jll v21.1.8+1, FileCheck binary found, **336 pass, 3 broken**. No `cglobal` instantiate error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)