### PR TITLE
relocate_gvs!: keep Type-valued globals as identity tokens

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -796,8 +796,11 @@ function relocate_gvs!(mod::LLVM.Module, gv_to_value::Dict{String, Ptr{Cvoid}})
         val = nothing
         if init != C_NULL
             obj = Base.unsafe_pointer_to_objref(init)
-            # Zero-sized objects remain identity tokens.
-            if isbitstype(typeof(obj)) && sizeof(obj) > 0 && !(obj isa Bool)
+            # Zero-sized objects remain identity tokens. Type objects also stay
+            # identity tokens: some are isbits singletons (e.g. `Union{}`, whose
+            # `typeof` is the isbits singleton `Core.TypeofBottom`), but `sizeof`
+            # is undefined for uninhabited types and would throw here.
+            if isbitstype(typeof(obj)) && !(obj isa Type) && sizeof(obj) > 0 && !(obj isa Bool)
                 val, hdr = materialize_box!(mod, gv, obj, init)
                 # non-smalltag headers carry a host DataType pointer
                 portable &= hdr < UInt(64 << 4)   # jl_max_tags << 4

--- a/test/native.jl
+++ b/test/native.jl
@@ -429,6 +429,19 @@ end
                 @test length(elements(LLVM.global_value_type(box))) == 3
                 dispose(m)
             end
+
+            # Type objects stay identity tokens rather than being materialized.
+            # `Union{}` is the tricky case: `typeof(Union{})` is the isbits
+            # singleton `Core.TypeofBottom`, so the `isbitstype` guard passes,
+            # but `sizeof(Union{})` throws (uninhabited type). It must be baked
+            # as an address, not fed to `materialize_box!`.
+            let ptr = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), Union{})
+                m, map = slot_module(ptr)
+                @test !GPUCompiler.relocate_gvs!(m, map)
+                @test !haskey(globals(m), "jl_global_0_box")
+                @test occursin("inttoptr", string(m))
+                dispose(m)
+            end
         end
     end
 


### PR DESCRIPTION
## Problem

`relocate_gvs!` decides whether to materialize a global's value with:

```julia
if isbitstype(typeof(obj)) && sizeof(obj) > 0 && !(obj isa Bool)
```

`Union{}` slips through this guard. `typeof(Union{})` is `Core.TypeofBottom`, an isbits singleton, so `isbitstype(typeof(obj))` is `true` — but `sizeof(Union{})` **throws** (`The empty type does not have a definite size since it does not have instances.`) because the type is uninhabited.

This surfaces when differentiating ordinary code with [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl) on Julia 1.12 (GPUCompiler v2 path): the primal module carries a `julia.constgv` global pointing at `Union{}`, and `relocate_gvs!` crashes while baking it in:

```
The empty type does not have a definite size since it does not have instances.
Stacktrace:
 [1] sizeof(x::Type)
 [2] relocate_gvs!(mod::LLVM.Module, gv_to_value::Dict{String, Ptr{Nothing}})
     @ GPUCompiler .../src/jlgen.jl:800
 [3] emit_llvm(job::GPUCompiler.CompilerJob)
```

## Fix

Exclude `obj isa Type` from materialization. Type objects — like any other non-isbits object — keep their host address as an identity token (baked `inttoptr`), which renders the module session-dependent, exactly as intended for objects whose identity matters.

## Test

Adds a `relocate_gvs!` unit test for a slot pointing at `Union{}`, asserting it is baked as an address rather than fed to `materialize_box!`. Verified the test crashes on `master` and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)