### PR TITLE
[GCN] fix intrinsics check

### DIFF
--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -39,8 +39,8 @@ end
 
 ## job
 
-const gcn_intrinsics = () # TODO: ("vprintf", "__assertfail", "malloc", "free")
-isintrinsic(::CompilerJob{GCNCompilerTarget}, fn::String) = in(fn, gcn_intrinsics)
+isintrinsic(@nospecialize(job::CompilerJob{GCNCompilerTarget}), fn::String) =
+    return startswith(fn, "llvm.amdgcn.")
 
 pass_by_ref(@nospecialize(job::CompilerJob{GCNCompilerTarget})) = true
 


### PR DESCRIPTION
Now that we are using more recent device libs, we need to correctly identify amdgcn intrinsics