### PR TITLE
[GCN] allow llvm.frexp and llvm.ldexp intrinsics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]

--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -39,8 +39,13 @@ end
 
 ## job
 
-isintrinsic(@nospecialize(job::CompilerJob{GCNCompilerTarget}), fn::String) =
-    return startswith(fn, "llvm.amdgcn.")
+function isintrinsic(@nospecialize(job::CompilerJob{GCNCompilerTarget}), fn::String)
+    startswith(fn, "llvm.amdgcn.") && return true
+    # The ROCm device libraries use `llvm.frexp` and `llvm.ldexp`, which were only added in
+    # LLVM 17, so they are not recognized as intrinsics by older versions of LLVM.
+    # Final code generation knows how to lower them, so accept them here.
+    return startswith(fn, "llvm.frexp.") || startswith(fn, "llvm.ldexp.")
+end
 
 pass_by_ref(@nospecialize(job::CompilerJob{GCNCompilerTarget})) = true
 


### PR DESCRIPTION
Encountered in https://github.com/JuliaGPU/AMDGPU.jl/pull/1023. These intrinsics are not recognized by the older LLVM versions of Julia 1.10 and 1.11, so they resulted in an `InvalidIRError`. They do occur in the more recent device libs though and the backend knows how to lower them, so accepts these as well