### PR TITLE
Metal: Demote unordered atomic loads and stores

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -645,6 +645,23 @@ function finish_ir!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::L
     return functions(mod)[entry_fn]
 end
 
+# Julia marks heap-reference accesses `unordered` so raced pointer reads cannot produce
+# values out of thin air. GPUCompiler has no device GC, and Metal's supported atomics
+# are already `air.atomic.*` intrinsics, so raw unordered LLVM loads/stores are unnecessary.
+# Demote them after optimization, where the weaker semantics cannot enable new transforms;
+# leave stronger orderings intact.
+function demote_unordered_atomics!(mod::LLVM.Module)
+    changed = false
+    for f in functions(mod), bb in blocks(f), inst in instructions(bb)
+        (inst isa LLVM.LoadInst || inst isa LLVM.StoreInst) || continue
+        is_atomic(inst) || continue
+        ordering(inst) == LLVM.API.LLVMAtomicOrderingUnordered || continue
+        ordering!(inst, LLVM.API.LLVMAtomicOrderingNotAtomic)
+        changed = true
+    end
+    return changed
+end
+
 # lowering of LLVM IR to AIR-compatible IR
 #
 # Metal does not have an LLVM back-end, so the lowering of target-independent LLVM IR into
@@ -658,6 +675,9 @@ function lower_air!(@nospecialize(job::CompilerJob{MetalCompilerTarget}), mod::L
     # space and casting only the surviving pointer is the shape Julia emits for direct
     # Metal.malloc uses.
     rewrite_generic_null_selects!(mod)
+
+    # AIR does not support LLVM atomic load/store instructions
+    demote_unordered_atomics!(mod)
 
     # strip device-side `trap`s and rewrite `unreachable` into clean returns (#433, #370). this
     # runs post-`optimize!`, after the trap has finished serving as the optimizer guard; the pass

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -1517,6 +1517,79 @@ end
     end
 end
 
+# Keep `malloc` non-null so the throwing branch constructs its `InexactError` argument.
+bool_conversion_mod = @eval module $(gensym())
+    using ..GPUCompiler
+    module AllocatingRuntime
+        signal_exception() = return
+        malloc(sz) = reinterpret(Ptr{Cvoid}, UInt(0x1000))
+        report_oom(sz) = return
+        report_exception(ex) = return
+        report_exception_name(ex) = return
+        report_exception_frame(idx, func, file, line) = return
+    end
+    struct AllocatingParams <: AbstractCompilerParams end
+    GPUCompiler.runtime_module(::CompilerJob{MetalCompilerTarget,AllocatingParams}) =
+        AllocatingRuntime
+
+    function kernel(a::Core.LLVMPtr{Bool,1}, x::Int)
+        unsafe_store!(a, convert(Bool, x))
+        return
+    end
+end
+function bool_conversion_job()
+    source = methodinstance(typeof(bool_conversion_mod.kernel),
+                            Tuple{Core.LLVMPtr{Bool,1}, Int}, Base.get_world_counter())
+    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
+    config = CompilerConfig(target, bool_conversion_mod.AllocatingParams(); kernel=true)
+    CompilerJob(source, config)
+end
+
+@testset "unordered atomic demotion" begin
+    # Demote unordered LLVM loads/stores, but preserve stronger atomics.
+    Context() do ctx
+        ir = """
+        define void @f(i8** %p, i8** %q, i64* %r) {
+        entry:
+          %a = load atomic i8*, i8** %p unordered, align 8
+          store atomic i8* %a, i8** %q unordered, align 8
+          %b = load atomic i64, i64* %r monotonic, align 8
+          store atomic i64 %b, i64* %r release, align 8
+          store i8* %a, i8** %p, align 8
+          ret void
+        }
+        """
+        mod = parse(LLVM.Module, ir)
+        insts() = [i for f in functions(mod) for bb in blocks(f) for i in instructions(bb)]
+        memops() = filter(i -> i isa LLVM.LoadInst || i isa LLVM.StoreInst, insts())
+
+        @test count(is_atomic, memops()) == 4
+        @test GPUCompiler.demote_unordered_atomics!(mod)
+        atomics = filter(is_atomic, memops())
+        @test length(atomics) == 2
+        @test all(i -> ordering(i) != LLVM.API.LLVMAtomicOrderingUnordered, atomics)
+        @test !occursin("unordered", string(mod))
+        @test (verify(mod); true)
+        # idempotent
+        @test !GPUCompiler.demote_unordered_atomics!(mod)
+    end
+
+    # `compilesig_invokes=false` exposes the specialized, noinline `InexactError`
+    # constructor. Julia 1.12+ stores its argument tuple's pointer field unordered.
+    job = bool_conversion_job()
+    ir = sprint(io->GPUCompiler.code_llvm(io, job; dump_module=true))
+    air = sprint(io->GPUCompiler.code_native(io, job; dump_module=true))
+    if VERSION >= v"1.11-"
+        # precondition: the specialized constructor (and its box) survive optimization
+        @test occursin(r"define .*@julia_InexactError", ir)
+        @test occursin(r"define .*@julia_InexactError", air)
+    end
+    if VERSION >= v"1.12-"
+        @test occursin(r"store atomic .* unordered", ir)
+    end
+    @test !occursin(r"(load|store) atomic", air)
+end
+
 # byval lowering must strip the (non-IPO-safe) Julia const-region metadata off loads derived
 # from the materialized argument; check the helper walks gep/addrspacecast chains and removes it.
 @testset "const-region metadata stripping for materialized args" begin

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -1517,34 +1517,6 @@ end
     end
 end
 
-# Keep `malloc` non-null so the throwing branch constructs its `InexactError` argument.
-bool_conversion_mod = @eval module $(gensym())
-    using ..GPUCompiler
-    module AllocatingRuntime
-        signal_exception() = return
-        malloc(sz) = reinterpret(Ptr{Cvoid}, UInt(0x1000))
-        report_oom(sz) = return
-        report_exception(ex) = return
-        report_exception_name(ex) = return
-        report_exception_frame(idx, func, file, line) = return
-    end
-    struct AllocatingParams <: AbstractCompilerParams end
-    GPUCompiler.runtime_module(::CompilerJob{MetalCompilerTarget,AllocatingParams}) =
-        AllocatingRuntime
-
-    function kernel(a::Core.LLVMPtr{Bool,1}, x::Int)
-        unsafe_store!(a, convert(Bool, x))
-        return
-    end
-end
-function bool_conversion_job()
-    source = methodinstance(typeof(bool_conversion_mod.kernel),
-                            Tuple{Core.LLVMPtr{Bool,1}, Int}, Base.get_world_counter())
-    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
-    config = CompilerConfig(target, bool_conversion_mod.AllocatingParams(); kernel=true)
-    CompilerJob(source, config)
-end
-
 @testset "unordered atomic demotion" begin
     # Demote unordered LLVM loads/stores, but preserve stronger atomics.
     Context() do ctx
@@ -1574,20 +1546,28 @@ end
         @test !GPUCompiler.demote_unordered_atomics!(mod)
     end
 
-    # `compilesig_invokes=false` exposes the specialized, noinline `InexactError`
-    # constructor. Julia 1.12+ stores its argument tuple's pointer field unordered.
-    job = bool_conversion_job()
+    # end-to-end: Julia's own `:unordered` accesses (as codegen emits for heap-reference
+    # fields) must reach the AIR as plain loads and stores
+    function kernel(p::Core.LLVMPtr{Int,1}, q::Core.LLVMPtr{Int,1})
+        x = Core.Intrinsics.atomic_pointerref(reinterpret(Ptr{Int}, p), :unordered)
+        Core.Intrinsics.atomic_pointerset(reinterpret(Ptr{Int}, q), x, :unordered)
+        return
+    end
+    source = methodinstance(typeof(kernel), Tuple{Core.LLVMPtr{Int,1}, Core.LLVMPtr{Int,1}},
+                            Base.get_world_counter())
+    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
+    config = CompilerConfig(target, Metal.CompilerParams(); kernel=true)
+    job = CompilerJob(source, config)
+
+    # precondition: the accesses survive optimization as unordered atomics
     ir = sprint(io->GPUCompiler.code_llvm(io, job; dump_module=true))
+    @test occursin(r"load atomic .* unordered", ir)
+    @test occursin(r"store atomic .* unordered", ir)
+
     air = sprint(io->GPUCompiler.code_native(io, job; dump_module=true))
-    if VERSION >= v"1.11-"
-        # precondition: the specialized constructor (and its box) survive optimization
-        @test occursin(r"define .*@julia_InexactError", ir)
-        @test occursin(r"define .*@julia_InexactError", air)
-    end
-    if VERSION >= v"1.12-"
-        @test occursin(r"store atomic .* unordered", ir)
-    end
     @test !occursin(r"(load|store) atomic", air)
+    @test occursin(r"load i64", air)
+    @test occursin(r"store i64", air)
 end
 
 # byval lowering must strip the (non-IPO-safe) Julia const-region metadata off loads derived


### PR DESCRIPTION
The AGX back-end crashes on these with `XPC_ERROR_CONNECTION_INTERRUPTED`, because AIR has no LLVM-level atomic load/store instructions.

The `compilesig_invokes=false` change in #899 only surfaced this issue, since `Bool(::Real)` throws an `InexactError(:Bool, Bool, x)` through its vararg `@nospecialize` constructor, which previously was a dead dynamic call that `lower_throw!` just deleted. It's now a real `noinline` call whose body allocates the `Tuple{DataType,Int64}` with an unordered pointer store, breaking `MtlArray{Bool}(undef, 2) .= 1` on 1.12+.

Since there is no GC on GPUs, this should be legal, but please correct me otherwise

@christiangnrd Can you confirm whether this fixes the Metal issues?