### PR TITLE
Preserve inferred specializations in invokes

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -621,7 +621,13 @@ function inference_params(@nospecialize(job::CompilerJob))
 end
 
 # the optimization parameters to use when constructing the GPUInterpreter
-optimization_params(@nospecialize(job::CompilerJob)) = CC.OptimizationParams()
+#
+# Keep invokes specialized to the inferred argument types. Widening to compilation
+# signatures can lose type information or target code absent from our cache.
+# `infer_compilation_signature` would infer those wider signatures too; it does not
+# preserve specialization. Back-ends can override this hook to change the policy.
+optimization_params(@nospecialize(job::CompilerJob)) =
+    CC.OptimizationParams(; compilesig_invokes=false)
 
 # how much debuginfo to emit
 function llvm_debug_info(@nospecialize(job::CompilerJob))

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -520,9 +520,10 @@ end
 
     @test @filecheck begin
         @check_label "define void @{{(julia|j)_kernel_[0-9]+}}"
-        # box: a jl_box_float32 call <1.14; 1.14+ inlines it into the devirt'd ctor
-        @check cond=(VERSION < v"1.14-")  "jl_box_float32"
-        @check cond=(VERSION >= v"1.14-") "gpu_gc_pool_alloc"
+        # 1.10 boxes through jl_box_float32; 1.11+ specializes the constructor
+        # and boxes through the GC pool allocator instead
+        @check cond=(VERSION < v"1.11-")  "jl_box_float32"
+        @check cond=(VERSION >= v"1.11-") "gpu_gc_pool_alloc"
         GCN.code_llvm(mod.kernel, Tuple{Float32,Ptr{Float32}}; dump_module=true)
     end
     GCN.code_native(devnull, mod.kernel, Tuple{Float32,Ptr{Float32}})

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -1557,6 +1557,38 @@ end
     end
 end
 
+@testset "Bool conversion exception allocation" begin
+    mod = @eval module $(gensym())
+        using ..GPUCompiler
+        module Runtime
+            # Keep allocation visible to LLVM; a constant-null allocator erases
+            # the heap-reference stores which exposed #904.
+            malloc(sz) = ccall("extern test_malloc", llvmcall, Ptr{Nothing}, (Csize_t,), sz)
+            signal_exception() = return
+            report_oom(sz) = return
+            report_exception(ex) = return
+            report_exception_name(ex) = return
+            report_exception_frame(idx, func, file, line) = return
+        end
+        struct Params <: GPUCompiler.AbstractCompilerParams end
+        GPUCompiler.runtime_module(::CompilerJob{<:Any,Params}) = Runtime
+        function kernel(out, x)
+            unsafe_store!(out, Bool(x))
+            return
+        end
+    end
+    source = methodinstance(typeof(mod.kernel), Tuple{Core.LLVMPtr{Bool,1},Int},
+                            Base.get_world_counter())
+    target = MetalCompilerTarget(; macos=v"12.2", metal=v"3.0", air=v"3.0")
+    job = CompilerJob(source, CompilerConfig(target, mod.Params(); kernel=true))
+    ir = sprint(io -> GPUCompiler.code_llvm(io, job; dump_module=true))
+    if VERSION >= v"1.12-"
+        @test occursin(r"store atomic .* unordered", ir)
+    end
+    air = sprint(io -> GPUCompiler.code_native(io, job; dump_module=true))
+    @test !occursin(r"(load|store) atomic", air)
+end
+
 @testset "unordered atomic demotion" begin
     # Demote unordered LLVM loads/stores, but preserve stronger atomics.
     Context() do ctx

--- a/test/native.jl
+++ b/test/native.jl
@@ -1651,8 +1651,8 @@ end
         (occursin(GPUCompiler.RUNTIME_FUNCTION, msg) ||
          occursin(GPUCompiler.UNKNOWN_FUNCTION, msg) ||
          occursin(GPUCompiler.DYNAMIC_CALL, msg)) &&
-        occursin("[1] println", msg) &&
-        occursin("[2] foobar", msg)
+        occursin(r"\[\d+\] println", msg) &&
+        occursin(r"\[\d+\] foobar", msg)
     end
 end
 
@@ -1769,32 +1769,60 @@ end
     end
 end
 
+@testset "specialized vararg invoke" begin
+    mod = @eval module $(gensym())
+        @noinline child(x, xs...) = x + sum(xs)
+        function kernel(out, x, y, z)
+            unsafe_store!(out, child(x, y, z))
+            return
+        end
+    end
+    @test @filecheck begin
+        @check_not "jl_invoke"
+        @check_not "apply_generic"
+        Native.code_llvm(mod.kernel, Tuple{Ptr{Int},Int,Int,Int}; dump_module=true)
+    end
+    Native.code_execution(mod.kernel, Tuple{Ptr{Int},Int,Int,Int})
+end
+
 @testset "dynamic call (invoke)" begin
     mod = @eval module $(gensym())
         @noinline nospecialize_child(@nospecialize(i)) = i
         kernel(a, b) = (unsafe_store!(b, nospecialize_child(a)); return)
     end
 
-    @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.kernel, Tuple{Int,Ptr{Int}})) do msg
-        occursin("invalid LLVM IR", msg) &&
-        occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
-        occursin("call to nospecialize_child", msg) &&
-        occursin("[1] kernel", msg)
+    if VERSION >= v"1.11-"
+        # Preserve the inferred specialization despite @nospecialize.
+        @test @filecheck begin
+            @check_label "define {{.*}} @{{(julia|j)_kernel_[0-9]+}}"
+            @check_not "jl_invoke"
+            @check_not "apply_generic"
+            Native.code_llvm(mod.kernel, Tuple{Int,Ptr{Int}}; dump_module=true)
+        end
+        Native.code_execution(mod.kernel, Tuple{Int,Ptr{Int}})
+    else
+        # 1.10 still emits a dynamic invoke for this @nospecialize call
+        @test_throws_message(InvalidIRError,
+                             Native.code_execution(mod.kernel, Tuple{Int,Ptr{Int}})) do msg
+            occursin("invalid LLVM IR", msg) &&
+            occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
+            occursin("call to nospecialize_child", msg) &&
+            occursin(r"\[\d+\] kernel", msg)
+        end
     end
 end
 
 @testset "dynamic call (apply)" begin
     mod = @eval module $(gensym())
-        func() = println(1)
+        func(a) = (print(Base.inferencebarrier(a)); return)
     end
 
     @test_throws_message(InvalidIRError,
-                         Native.code_execution(mod.func, Tuple{})) do msg
+                         Native.code_execution(mod.func, Tuple{Int})) do msg
         occursin("invalid LLVM IR", msg) &&
         occursin(GPUCompiler.DYNAMIC_CALL, msg) &&
         occursin("call to print", msg) &&
-        occursin("[2] func", msg)
+        occursin(r"\[\d+\] func", msg)
     end
 end
 

--- a/test/ptx.jl
+++ b/test/ptx.jl
@@ -493,9 +493,10 @@ end
 
     @test @filecheck begin
         @check_label "define void @{{(julia|j)_kernel_[0-9]+}}"
-        # box: a jl_box_float32 call <1.14; 1.14+ inlines it into the devirt'd ctor
-        @check cond=(VERSION < v"1.14-")  "jl_box_float32"
-        @check cond=(VERSION >= v"1.14-") "gpu_gc_pool_alloc"
+        # 1.10 boxes through jl_box_float32; 1.11+ specializes the constructor
+        # and boxes through the GC pool allocator instead
+        @check cond=(VERSION < v"1.11-")  "jl_box_float32"
+        @check cond=(VERSION >= v"1.11-") "gpu_gc_pool_alloc"
         PTX.code_llvm(mod.kernel, Tuple{Float32,Ptr{Float32}}; dump_module=true)
     end
     PTX.code_native(devnull, mod.kernel, Tuple{Float32,Ptr{Float32}})


### PR DESCRIPTION
Set `compilesig_invokes=false` so non-inlined calls retain their inferred specialization instead of targeting a widened compilation signature that may not be cached. This avoids unsupported dynamic invokes, including the multidimensional bounds-error paths introduced in Julia 1.14.

For backends without a device heap, provide a null-returning allocator when their runtime module does not define `malloc`. Valid inputs can then compile and execute even when an error path needs to box an exception; attempted allocations follow the existing out-of-memory path. Backend-provided allocators retain precedence. This addresses #906.

The branch includes the Metal atomic-lowering fix from #904 through its base. Add a Bool-conversion regression with an opaque allocator so LLVM cannot erase the heap-reference stores before AIR lowering, as the usual constant-null test allocator does.

The existing `optimization_params(job)` hook remains available for backend overrides. Unlike `infer_compilation_signature`, which also infers widened signatures, disabling `compilesig_invokes` preserves the specialization selected by inference.