### PR TITLE
Use identity comparison during type mangling

### DIFF
--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -34,7 +34,7 @@ safe_name(@nospecialize(x)) = safe_name(repr(x))
 # profilers, support them (grouping different instantiations of the same kernel together).
 
 function mangle_param(@nospecialize(t), substitutions = Any[], top = false)
-    t == Nothing && return "v"
+    t === Nothing && return "v"
 
     # Manual lookup instead of `findfirst(isequal(x), substitutions)`: the latter
     # builds a `Base.Fix{2, isequal, typeof(x)}` that specializes `findfirst` per

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -67,6 +67,10 @@ end
     @test mangle(identity) == "identity"
     @test mangle(identity, Nothing) == "identity()"
 
+    # `missing` as a type parameter: comparing against `Nothing` with `==` returns
+    # `missing` instead of `false`, which used to throw a `TypeError` in a boolean context.
+    @test mangle(identity, Val{missing}) == "identity(Val<missing>)"
+
     # primitive types
     @test mangle(identity, Int32) == "identity(Int32)"
     @test mangle(identity, Int64) == "identity(Int64)"


### PR DESCRIPTION
Fixes issue #909 

The proposed change is to use an identity instead of value comparison when checking for absent type parameters during type mangling.

A test was added that confirms that `missing` is a valid type parameter.