### PR TITLE
Resolve runtime library functions through the job's method table

### DIFF
--- a/src/jlgen.jl
+++ b/src/jlgen.jl
@@ -71,10 +71,16 @@ pass at run time. For non-concrete signatures, use `generic_methodinstance` inst
 methodinstance
 
 function generic_methodinstance(@nospecialize(ft::Type), @nospecialize(tt::Type),
-                                world::Integer=tls_world_age())
+                                world::Integer=tls_world_age();
+                                method_table_view::Union{Nothing,CC.MethodTableView}=nothing)
     sig = signature_type_by_tt(ft, tt)
 
-    match, _ = CC._findsup(sig, nothing, world)
+    match = if method_table_view === nothing
+        first(CC._findsup(sig, nothing, world))
+    else
+        # e.g. an overlay table: prefer its methods, falling back to the global table
+        first(CC.findsup(sig, method_table_view))
+    end
     match === nothing && throw(MethodError(ft, tt, world))
 
     mi = CC.specialize_method(match)

--- a/src/rtlib.jl
+++ b/src/rtlib.jl
@@ -148,8 +148,14 @@ function runtime_method_instance(@nospecialize(job::CompilerJob), method)
     end
     # Resolve at the requesting job's explicit world, rather than this task's TLS world.
     # Runtime methods may be redefined while a long-lived compilation task is running.
+    #
+    # Look up through the job's method table, so that back-ends can define runtime
+    # functions as overlay methods only (without a definition in the global method
+    # table, where ahead-of-time compilation would compile the GPU-only code for the
+    # host; see JuliaGPU/GPUCompiler.jl#611).
     return generic_methodinstance(
-        typeof(def), Base.to_tuple_type(method.types), job.world)
+        typeof(def), Base.to_tuple_type(method.types), job.world;
+        method_table_view=method_table_view(job))
 end
 
 function runtime_code_instance(@nospecialize(job::CompilerJob))

--- a/test/native.jl
+++ b/test/native.jl
@@ -1697,6 +1697,36 @@ end
     end
 end
 
+@testset "runtime functions from overlay methods" begin
+    # runtime library functions (`signal_exception`, `malloc`, ...) should be resolved
+    # through the job's method table, so that back-ends can keep GPU-only code out of
+    # the global method table (JuliaGPU/GPUCompiler.jl#611)
+    isdefined(Native.Runtime, :signal_exception) ||
+        @eval Native.Runtime signal_exception() = nothing
+
+    mod = @eval module $(gensym())
+        using ..GPUCompiler
+        import ..Native
+
+        Base.Experimental.@MethodTable(method_table)
+
+        Base.Experimental.@overlay method_table Native.Runtime.signal_exception() = nothing
+
+        kernel(x) = x
+    end
+
+    method = GPUCompiler.Runtime.methods[:signal_exception]
+
+    job, _ = Native.create_job(mod.kernel, (Int,); method_table=mod.method_table)
+    mi = GPUCompiler.runtime_method_instance(job, method)
+    @test mi.def.module === mod
+
+    # the global definition is used with the global method table
+    job, _ = Native.create_job(mod.kernel, (Int,); method_table=GPUCompiler.GLOBAL_METHOD_TABLE)
+    mi = GPUCompiler.runtime_method_instance(job, method)
+    @test mi.def.module === Native.Runtime
+end
+
 @testset "semi-concrete interpretation + overlay methods" begin
     # issue 366, caused dynamic deispatch
     mod = @eval module $(gensym())

--- a/test/ptx/precompile.jl
+++ b/test/ptx/precompile.jl
@@ -7,7 +7,10 @@ precompile_test_harness("Inference caching") do load_path
         import PTXCompiler
         using PrecompileTools
 
+        # use a target-specific intrinsic, so that any leak of this foreign code into
+        # native compilation (of the package image) fails loudly (GPUCompiler.jl#611)
         function kernel()
+            ccall("llvm.nvvm.barrier0", llvmcall, Cvoid, ())
             return
         end
 


### PR DESCRIPTION
Back-ends provide the runtime library functions (`signal_exception`, `report_exception*`, `report_oom`, `malloc`, ...) by defining them in their `runtime_module`. `runtime_method_instance` looked those definitions up in the global method table only, so they had to be ordinary global methods, even though their bodies are GPU-only: CUDA's `signal_exception()` reads the kernel state through `julia.gpu.state_getter`, for instance.

That is a problem for ahead-of-time compilation (#611). Julia's compile-all pass (`--output-o`: PackageCompiler.jl, juliac) compiles every concretely-typed method in every loaded module whether or not it is called, so such definitions end up as undefined symbols in system images and executables, and compiling them on the CPU kills the JIT (`JIT session error: Symbols not found: [ julia.gpu.state_getter ]`, the error from the original report).

## Changes

- `runtime_method_instance` now resolves through `method_table_view(job)`: a method in the job's overlay table wins, the global method table is the fallback. `generic_methodinstance` gained a `method_table_view` keyword for that. Back-ends can thus define runtime functions as overlay-only methods, or pair them with erroring CPU stubs like CUDA's `@device_function` does; back-ends using the global table see no change.
- Test in `test/native.jl` checking that an overlaid `signal_exception` is picked up with the overlay table and the global definition with the global table.
- `test/ptx/precompile.jl`: the precompiled kernel calls `llvm.nvvm.barrier0` instead of being empty, so a leak of foreign CodeInstances into native compilation of the package image would abort the build instead of going unnoticed.