### PR TITLE
Metal: canonicalize local value symbol tables

### DIFF
--- a/src/metal.jl
+++ b/src/metal.jl
@@ -814,6 +814,32 @@ function normalize_julia_symbol_names!(mod::LLVM.Module)
             end
         end
     end
+
+    # LLVM's function-local value symbol table preserves insertion history, which is not
+    # visible in textual IR but does affect bitcode string-table order. Transformations above
+    # can create the same named values through pointer-keyed worklists in different orders.
+    # Reinsert every local name in IR order so equivalent modules serialize identically.
+    for f in functions(mod)
+        named_values = Pair{LLVM.Value,String}[]
+        for value in parameters(f)
+            name = LLVM.name(value)
+            isempty(name) || push!(named_values, value => name)
+        end
+        for bb in blocks(f)
+            name = LLVM.name(bb)
+            isempty(name) || push!(named_values, bb => name)
+            for inst in instructions(bb)
+                name = LLVM.name(inst)
+                isempty(name) || push!(named_values, inst => name)
+            end
+        end
+        for (value, _) in named_values
+            LLVM.name!(value, "")
+        end
+        for (value, name) in named_values
+            LLVM.name!(value, name)
+        end
+    end
     return
 end
 

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -490,6 +490,46 @@ end
         @test occursin("@julia_probe_12bar", ir)
         dispose(m)
     end
+
+    # A function's value symbol table retains name-insertion order even though textual IR
+    # only exposes value order. Recreate the same block names in different orders, as
+    # pointer-keyed lowering worklists can, and ensure normalization canonicalizes the
+    # otherwise-different bitcode string tables.
+    function named_block_module(order)
+        m = parse(LLVM.Module, """
+            define void @probe(i1 %cond) {
+            conversion:
+              br i1 %cond, label %julia_throw_boundserror_5.exit, label %L25
+            julia_throw_boundserror_5.exit:
+              br label %ret
+            L25:
+              br label %ret
+            ret:
+              ret void
+            }
+            """)
+        bbs = collect(blocks(functions(m)["probe"]))
+        names = LLVM.name.(bbs)
+        for bb in bbs
+            LLVM.name!(bb, "")
+        end
+        for i in order
+            LLVM.name!(bbs[i], names[i])
+        end
+        return m
+    end
+
+    JuliaContext() do ctx
+        a = named_block_module(1:4)
+        b = named_block_module((4, 2, 1, 3))
+        @test string(a) == string(b)
+        GPUCompiler.normalize_julia_symbol_names!(a)
+        GPUCompiler.normalize_julia_symbol_names!(b)
+        bytes(mod) = (io = IOBuffer(); write(io, mod); take!(io))
+        @test bytes(a) == bytes(b)
+        dispose(a)
+        dispose(b)
+    end
 end
 
 @testset "reproducible output" begin


### PR DESCRIPTION
LLVM preserves local-name insertion history in the bitcode string table, so textually identical AIR could serialize differently and break content-keyed metallib caches. Reinsert names in IR order before downgrade and cover differing histories.