### PR TITLE
Support launch bounds on the GCN target

### DIFF
--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -13,6 +13,19 @@ Base.@kwdef struct GCNCompilerTarget <: AbstractCompilerTarget
     features::String=""
 
     backend::Symbol = isavailable(AMDGPU_LLVM_Backend_jll) ? :external : :inprocess
+
+    # optional launch bounds (scalar or per-dimension; flattened to their product)
+    minthreads::Union{Nothing,Int,NTuple{<:Any,Int}} = nothing
+    maxthreads::Union{Nothing,Int,NTuple{<:Any,Int}} = nothing
+end
+
+function Base.hash(target::GCNCompilerTarget, h::UInt)
+    h = hash(target.dev_isa, h)
+    h = hash(target.features, h)
+    h = hash(target.backend, h)
+    h = hash(target.minthreads, h)
+    h = hash(target.maxthreads, h)
+    h
 end
 GCNCompilerTarget(dev_isa; kwargs...) = GCNCompilerTarget(; dev_isa, kwargs...)
 
@@ -56,6 +69,16 @@ function finish_module!(@nospecialize(job::CompilerJob{GCNCompilerTarget}),
     if job.config.kernel
         # calling convention
         callconv!(entry, LLVM.API.LLVMAMDGPUKERNELCallConv)
+
+        # workgroup size bounds; the backend sizes its register budget for the
+        # worst case (1,1024) when unset
+        if job.config.target.minthreads !== nothing ||
+           job.config.target.maxthreads !== nothing
+            lo = prod(something(job.config.target.minthreads, 1))
+            hi = prod(something(job.config.target.maxthreads, 1024))
+            push!(function_attributes(entry),
+                  StringAttribute("amdgpu-flat-work-group-size", "$lo,$hi"))
+        end
     end
 
     return entry

--- a/test/gcn.jl
+++ b/test/gcn.jl
@@ -57,6 +57,33 @@ end
     end
 end
 
+@testset "launch bounds" begin
+    mod = @eval module $(gensym())
+        kernel() = return
+    end
+
+    @test @filecheck begin
+        @check_not "amdgpu-flat-work-group-size"
+        GCN.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true)
+    end
+
+    @test @filecheck begin
+        @check "\"amdgpu-flat-work-group-size\"=\"1,42\""
+        GCN.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true, maxthreads=42)
+    end
+
+    @test @filecheck begin
+        @check "\"amdgpu-flat-work-group-size\"=\"256,256\""
+        GCN.code_llvm(mod.kernel, Tuple{}; dump_module=true, kernel=true,
+                      minthreads=256, maxthreads=256)
+    end
+
+    @test @filecheck begin
+        @check ".max_flat_workgroup_size: 42"
+        GCN.code_native(mod.kernel, Tuple{}; dump_module=true, kernel=true, maxthreads=42)
+    end
+end
+
 @testset "bounds errors" begin
     mod = @eval module $(gensym())
         function kernel()

--- a/test/helpers/gcn.jl
+++ b/test/helpers/gcn.jl
@@ -14,10 +14,11 @@ GPUCompiler.relocation_lowering(@nospecialize(job::CompilerJob{<:Any,CompilerPar
     job.config.params.patch ? :patch : :bake
 
 function create_job(@nospecialize(func), @nospecialize(types); backend::Symbol=:external,
+                    minthreads=nothing, maxthreads=nothing,
                     patch::Bool=false, kwargs...)
     config_kwargs, kwargs = split_kwargs(kwargs, GPUCompiler.CONFIG_KWARGS)
     source = methodinstance(typeof(func), Base.to_tuple_type(types), Base.get_world_counter())
-    target = GCNCompilerTarget(dev_isa="gfx900"; backend)
+    target = GCNCompilerTarget(dev_isa="gfx900"; backend, minthreads, maxthreads)
     params = CompilerParams(patch)
     config = CompilerConfig(target, params; kernel=false, config_kwargs...)
     CompilerJob(source, config), kwargs


### PR DESCRIPTION
The GCN target compiles every kernel with the backend's default `amdgpu-flat-work-group-size` of `1,1024`, so the register allocator always budgets for 1024-item workgroups: on gfx942 that is a 128-VGPR cap, and register-heavy kernels spill even when they will only ever be launched with smaller workgroups. HIP C++ exposes this via `__launch_bounds__`; the PTX target already exposes it as `minthreads`/`maxthreads`.

This adds the same two fields to `GCNCompilerTarget`, emitted as `amdgpu-flat-work-group-size` on kernels. LLVM derives the minimum waves/EU from the attribute's maximum (`AMDGPUSubtarget::getEffectiveWavesPerEU`), which sets the VGPR budget (`GCNSubtarget::getBaseMaxNumVGPRs`).

Measured on MI300A (gfx942, ROCm 7.2.4, Julia 1.12) with a register-tiled FP32 GEMM from AMDGPU.jl (16×16 workgroup, 8×8 accumulator microtile per thread, 4096³):

| | default (1,1024) | `maxthreads=256` |
|---|---|---|
| VGPRs | 64 arch + 64 accum (at the 128 cap) | 136, no accum |
| scratch | 120 B, 29 spill/29 reload | 0 |
| occupancy | 4 | 3 |
| runtime | 8.61 ms, 15.96 TFLOPS | 4.89 ms, **28.11 TFLOPS** |

A companion AMDGPU.jl PR plumbs this through `@roc maxthreads=` and sets it automatically for KernelAbstractions kernels with static workgroup sizes, mirroring CUDA.jl. As a bonus the bound lands in the code object's `.max_flat_workgroup_size`, so HIP itself rejects out-of-bounds launches that were previously silent UB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
