### PR TITLE
Handle allocation failure when boxing

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -243,6 +243,11 @@ end
     quote
         ptr = malloc($(Csize_t(allocsz)))
 
+        if ptr == C_NULL
+            report_oom($(Csize_t(allocsz)))
+            throw(OutOfMemoryError())
+        end
+
         # store the type tag
         ptr = convert(Ptr{tag_type}, ptr)
         Core.Intrinsics.pointerset(ptr, $tag | $gc_bits, #=index=# 1, #=align=# $tag_size)

--- a/test/spirv.jl
+++ b/test/spirv.jl
@@ -46,6 +46,32 @@ end
     end
 end
 
+@testset "failed runtime boxing" begin
+    mod = @eval module $(gensym())
+        import ..GPUCompiler
+
+        function kernel(x::Float32)
+            throw(GPUCompiler.Runtime.box_float32(x))
+        end
+    end
+
+    # Call the helper directly because Julia's lowering of boxed exception fields varies by
+    # version. The allocator-less SPIR-V runtime should take a real OOM path before the stores.
+    @test @filecheck begin
+        @check_label "define spir_kernel void @_Z6kernel"
+        @check "gpu_malloc"
+        @check "icmp eq"
+        @check "br i1"
+        @check "gpu_report_oom"
+        @check "gpu_signal_exception"
+        @check "store"
+        @check "store"
+        @check "gpu_report_exception"
+        @check "gpu_signal_exception"
+        SPIRV.code_llvm(mod.kernel, Tuple{Float32}; backend, kernel=true, dump_module=true)
+    end
+end
+
 @testset "baked boxed relocation cleanup" begin
     mod = @eval module $(gensym())
         @noinline produce(cond::Bool, value::Int32) = cond ? value : 1.5


### PR DESCRIPTION
`Runtime.box` wrote the type tag and payload through every pointer returned by `malloc`. OpenCL has no device allocator and returns `C_NULL`; after inlining, back-end optimizers can treat those stores as undefined and remove the throwing path, including `signal_exception`.

Use the same failure path as `gc_pool_alloc`: report OOM and throw `OutOfMemoryError` before writing. This prevents an invalid Julia object from escaping and gives optimization a real exceptional path. Cover both allocator-less SPIR-V back-ends and verify the OOM and original exception paths.