### PR TITLE
Mangle a `Vararg` whose length is still a `TypeVar`

### DIFF
--- a/src/mangling.jl
+++ b/src/mangling.jl
@@ -120,10 +120,14 @@ function mangle_param(@nospecialize(t), substitutions = Any[], top = false)
         mangle_param(Base.unwrap_unionall(t), substitutions)
     elseif isa(t, Core.TypeofVararg)
         T = isdefined(t, :T) ? t.T : Any
-        if isdefined(t, :N)
+        # `N` is a `TypeVar` when the length is still parametric, which is what unwrapping a
+        # `UnionAll` such as `NTuple{N,Int}` leaves behind. There is no count to repeat then,
+        # so the type is mangled like the unbounded `Vararg{T}` it is equal to.
+        N = isdefined(t, :N) && isa(t.N, Integer) ? t.N : nothing
+        if N !== nothing
             # For NTuple, repeat the type as needed
             str = ""
-            for _ in 1:t.N
+            for _ in 1:N
                 str *= mangle_param(T, substitutions)
             end
             str

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -100,6 +100,10 @@ end
     @test mangle(identity, Tuple{1, 2}, Tuple{}, Tuple) == "identity(Tuple<1, 2>, Tuple<>, Tuple)"
     @test mangle(identity, NTuple{2, Int}) == "identity(Tuple<Int64, Int64>)"
     @test mangle(identity, Tuple{Vararg{Int}}) == "identity(Tuple<>)"
+    # A `Vararg` whose length is still a `TypeVar`, which is what unwrapping a `UnionAll`
+    # leaves behind. It is the same type as the unbounded `Vararg` above, so it mangles alike.
+    @test mangle(identity, NTuple{N, Int} where {N}) == "identity(Tuple<>)"
+    @test mangle(identity, Val{NTuple{N, Int} where {N}}) == "identity(Val<Tuple<>>)"
 
     # many substitutions
     @test mangle(identity, Val{1}, Val{2}, Val{3}, Val{4}, Val{5}, Val{6}, Val{7}, Val{8},


### PR DESCRIPTION
`mangle_param` repeats the element type `N` times for an `NTuple`, but `N` is a `TypeVar` rather than an integer whenever the length is still parametric — which is exactly what the `UnionAll` branch just above it leaves behind after `unwrap_unionall`. `1:t.N` then throws:

```
MethodError: no method matching (::Colon)(::Int64, ::TypeVar)
  [1] mangle_param(t::Any, substitutions::Vector{Any}, top::Bool)
    @ GPUCompiler src/mangling.jl:126
  ...
  [8] mangle_sig(sig::Any)
    @ GPUCompiler src/mangling.jl:189
  [9] relocation_namespace
    @ src/relocation.jl:326 [inlined]
 [10] collect_julia_value_relocations!(job, mod, gv_to_value)
    @ GPUCompiler src/relocation.jl:338
 [11] irgen(job::GPUCompiler.CompilerJob)
```

Such a type is `==` to the unbounded `Vararg{T}`, so this mangles it the same way — `NTuple{N,Int} where N` and `Tuple{Vararg{Int}}` both give `Tuple<>`. A concrete count is unaffected.

This became reachable from *any* job once `relocation_namespace` started mangling every job's signature rather than only a kernel's: Enzyme.jl hits it on GPUCompiler 2.x (EnzymeAD/Enzyme.jl#3512) while compiling a signature that carries one of these types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmMWGrDGbAaajpehN7cAhW