### PR TITLE
Allow CompilerCaching 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ HighlightsExt = "Highlights"
 
 [compat]
 AMDGPU_LLVM_Backend_jll = "22"
-CompilerCaching = "0.4"
+CompilerCaching = "0.4, 0.5"
 ExprTools = "0.1"
 Highlights = "0.6"
 InteractiveUtils = "1"


### PR DESCRIPTION
Allow CompilerCaching 0.5 alongside 0.4. GPUCompiler uses the generic inference and results APIs, which are unchanged by 0.5's const-specialized entry API update.

This unblocks dependency resolution for JuliaGPU/cuTile.jl#310: cuTile requires CompilerCaching 0.5, while its CUDA dependencies require GPUCompiler.

Validated with CompilerCaching 0.5.0 on Julia 1.12.7: native and PTX tests, including their precompilation tests, passed (476 passed, 2 broken).
