### PR TITLE
Allow CompilerCaching 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ HighlightsExt = "Highlights"
 
 [compat]
 AMDGPU_LLVM_Backend_jll = "22"
-CompilerCaching = "0.4"
+CompilerCaching = "0.4, 0.5"
 ExprTools = "0.1"
 Highlights = "0.6"
 InteractiveUtils = "1"


### PR DESCRIPTION
CompilerCaching 0.5 changes the const-specialized entry API. GPUCompiler uses the unchanged generic inference and results APIs, so it can support both 0.4 and 0.5 without source changes. Allow 0.5 so CUDA and cuTile can resolve together when cuTile adopts the new API.