### PR TITLE
Emit native test objects with the JIT target machine

### DIFF
--- a/test/helpers/native.jl
+++ b/test/helpers/native.jl
@@ -56,7 +56,11 @@ end
 
 function GPUCompiler.mcgen(@nospecialize(job::NativeCompilerJob), mod::LLVM.Module,
                            format=LLVM.API.LLVMAssemblyFile)
-    if job.config.params.relocations !== :bake
+    # objects only exist to be loaded into `load`'s ORC JIT, so always emit them with the
+    # JIT's target machine: the default one uses the small code model with static
+    # relocations, whose 32-bit absolute references to e.g. constant pools cannot reach
+    # the addresses the JIT loads code at (and, on Windows, it emits COFF where ORC wants ELF)
+    if job.config.params.relocations !== :bake || format == LLVM.API.LLVMObjectFile
         target = job.config.target
         @dispose tm=JITTargetMachine(GPUCompiler.llvm_triple(target), target.cpu,
                                      target.features) begin


### PR DESCRIPTION
Test-infrastructure fix split out of #926.

The native test helper's `mcgen` override only used `JITTargetMachine` for `:patch` and `:table` jobs; `:bake` objects fell through to the stock target machine, which uses the small code model with static relocations. Objects built that way only work when loaded below 2 GiB, which ORC does not guarantee:

- Linux, Julia 1.12: JITLink rejects the object with `relocation target .rodata.cst32 ... is out of range of Pointer32Signed fixup` as soon as the code has a constant pool.
- Linux, Julia 1.10/1.11: older JITLink has no range check, the truncated address is used, and the test worker segfaults.
- Windows: the stock machine emits COFF while the ORC JIT is configured for ELF (`JITTargetMachine` appends `-elf` to the triple), giving garbage return values and a later crash in `LLVMOrcDisposeLLJIT`.
- macOS was unaffected because Mach-O on arm64 is position independent by construction, which is why this went unnoticed.

Every `:obj` request now goes through `JITTargetMachine`, whose `JITDefault` code model resolves to large on x86-64 and whose Windows triple is `*-elf`. Assembly output (what most native tests inspect) is unchanged.

The existing `Native.load` users all pass `:patch` or `:table` and were already on this path; the first `:bake` + `load` tests arrive with #926 (device-library providers and the softfloat native test, which has vector constants), so this needs to land before or with those.