### PR TITLE
Use the GPU LLVM tools as in-process libraries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUCompiler"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "2.6.0"
+version = "2.7.0"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
 
 [workspace]
@@ -30,24 +30,26 @@ AMDGPU_LLVM_Backend_jll = "cc5c0156-bd05-5a77-8a68-bb0aafb29019"
 Highlights = "eafb193a-b7ab-5a9e-9068-77385905fa72"
 LLVMDowngrader_jll = "f52de702-fb25-5922-94ba-81dd59b07444"
 NVPTX_LLVM_Backend_jll = "ef6e0fe3-e6ef-59c0-bde6-4989574699e0"
+SPIRV_LLVM_Backend_jll = "4376b9bf-cff8-51b6-bb48-39421dff0d0c"
 
 [extensions]
 HighlightsExt = "Highlights"
 
 [compat]
-AMDGPU_LLVM_Backend_jll = "22"
+AMDGPU_LLVM_Backend_jll = "23"
 CompilerCaching = "0.4, 0.5"
 ExprTools = "0.1"
 Highlights = "0.6"
 InteractiveUtils = "1"
 LLVM = "9.13"
-LLVMDowngrader_jll = "0.9"
+LLVMDowngrader_jll = "0.10"
 Libdl = "1"
 Logging = "1"
-NVPTX_LLVM_Backend_jll = "22"
+NVPTX_LLVM_Backend_jll = "23"
 PrecompileTools = "1.0.2"
 Preferences = "1"
 REPL = "1"
+SPIRV_LLVM_Backend_jll = "23"
 ScopedValues = "1.5"
 TOML = "1"
 Tracy = "0.1.4"

--- a/src/gcn.jl
+++ b/src/gcn.jl
@@ -183,6 +183,16 @@ function add_kernarg_address_spaces!(
     return new_f
 end
 
+# mirrors `AMDGPUCompileOptions` and `AMDGPUFileType` from libamdgpu.h
+struct AMDGPUCompileOptions
+    cpu::Cstring
+    features::Cstring
+    opt_level::Cint
+    filetype::Cint
+end
+const AMDGPUAssemblyFile = Cint(0)
+const AMDGPUObjectFile = Cint(1)
+
 @unlocked function mcgen(@nospecialize(job::CompilerJob{GCNCompilerTarget}),
                          mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
     target = job.config.target
@@ -203,48 +213,29 @@ end
         error("The :external GCN back-end requires AMDGPU_LLVM_Backend_jll, which " *
               "should be installed and loaded first.")
     end
+    backend = ExternalBackend(AMDGPU_LLVM_Backend_jll.libamdgpu, "AMDGPU")
 
     filetype = if format == LLVM.API.LLVMAssemblyFile
-        "asm"
+        AMDGPUAssemblyFile
     elseif format == LLVM.API.LLVMObjectFile
-        "obj"
+        AMDGPUObjectFile
     else
         error("Unsupported GCN output format $format")
     end
 
-    input  = tempname(cleanup=false) * ".bc"
-    output = tempname(cleanup=false) * (filetype == "asm" ? ".s" : ".o")
-    write(input, mod)
-
-    cmd = `$(AMDGPU_LLVM_Backend_jll.llc()) $input
-              -mtriple=$(llvm_triple(target))
-              -mcpu=$(target.dev_isa)
-              -mattr=$(target.features)
-              --relocation-model=pic
-              -filetype=$filetype
-              -o $output`
-    out = Pipe()
-    proc = run(pipeline(ignorestatus(cmd); stdout=out, stderr=out); wait=false)
-    close(out.in)
-    log = strip(read(out, String))
-    wait(proc)
-    if !success(proc)
-        # keep the input around for debugging
-        msg = "Failed to compile to GCN with external llc"
-        isempty(log) || (msg *= ":\n" * log)
-        msg *= "\nIf you think this is a bug, please file an issue and attach $(input)."
-        isfile(output) && rm(output)
-        error(msg)
-    elseif !isempty(log)
-        # llc only diagnoses on stderr; even successful compilation may e.g. have
-        # ignored an unrecognized CPU or feature, so make sure this surfaces.
-        @safe_warn "External llc reported:\n$log"
+    # the back-end targets amdgcn-amd-amdhsa with the PIC relocation model; unlike `llc`,
+    # it rejects unknown processors and features instead of silently falling back.
+    cpu = target.dev_isa
+    features = target.features
+    code = GC.@preserve cpu features begin
+        options = Ref(AMDGPUCompileOptions(Base.unsafe_convert(Cstring, cpu),
+                                           Base.unsafe_convert(Cstring, features),
+                                           #=opt_level=# 2, filetype))
+        external_compile(backend, bitcode(mod), options,
+                         "Failed to compile to GCN with the AMDGPU back-end";
+                         warn=msg->@safe_warn(msg))
     end
-
-    code = filetype == "asm" ? read(output, String) : String(read(output))
-    rm(input)
-    rm(output)
-    return code
+    return String(code)
 end
 
 

--- a/src/metal.jl
+++ b/src/metal.jl
@@ -843,20 +843,35 @@ end
     # downgrade to AIR. Metal's metallib loader is a backward-compatible reader that accepts
     # real LLVM <= 15 bitcode; target LLVM 14 (typed pointers, but with native `bfloat` —
     # unlike the 5.0/7.0 targets) so BFloat16 kernels compile on Julia 1.13+, where Julia
-    # emits the native `bfloat` IR type (JuliaGPU/Metal.jl#817). `llvm-downgrade` reads
-    # bitcode, so hand it the module's bitcode rather than its textual form.
-    bitcode = let io = IOBuffer()
-        write(io, mod)
-        take!(io)
-    end
-    air = run_tool(`$(LLVMDowngrader_jll.llvm_downgrade()) --bitcode-version=14.0 -o - -`, bitcode)
+    # emits the native `bfloat` IR type (JuliaGPU/Metal.jl#817).
+    air = downgrade(bitcode(mod), v"14.0")
 
     if format == LLVM.API.LLVMAssemblyFile
-        # disassemble the bitcode again to AIR assembly, i.e. LLVM 14 era textual IR
-        String(run_tool(`$(LLVMDowngrader_jll.llvm_dis_14()) -o - -`, air))
+        # disassemble the AIR again. the downgrader no longer ships the legacy `llvm-dis`,
+        # so parse the bitcode with the in-process LLVM instead; it auto-upgrades on load,
+        # so this is textual IR in the in-process LLVM's dialect rather than LLVM 14's.
+        Context() do ctx
+            @dispose air_mod = parse(LLVM.Module, air) begin
+                string(air_mod)
+            end
+        end
     else
         air
     end
+end
+
+# downgrade bitcode to the format of an older LLVM through libllvm_downgrade
+function downgrade(input::Vector{UInt8}, version::VersionNumber)
+    backend = ExternalBackend(LLVMDowngrader_jll.libllvm_downgrade, "LLVMDG")
+    buffer = Ref{Ptr{Cvoid}}(C_NULL)
+    message = Ref{Cstring}(C_NULL)
+    status = @ccall $(api(backend, "Downgrade"))(input::Ptr{UInt8}, length(input)::Csize_t,
+                                                 version.major::Cuint, version.minor::Cuint,
+                                                 buffer::Ptr{Ptr{Cvoid}},
+                                                 message::Ptr{Cstring})::Cint
+    external_result(backend, status, "Failed to downgrade bitcode to LLVM $(version)",
+                    message[], String[], input)
+    return take_buffer(backend, buffer[])
 end
 
 

--- a/src/ptx.jl
+++ b/src/ptx.jl
@@ -293,55 +293,42 @@ function optimize_module!(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
     end
 end
 
+# mirrors `NVPTXCompileOptions` from libnvptx.h
+struct NVPTXCompileOptions
+    cpu::Cstring
+    ptx_major::Cuint
+    ptx_minor::Cuint
+    is_64bit::Cint
+    opt_level::Cint
+    fma_contraction::Cint
+    verbose::Cint
+end
+
 @unlocked function mcgen(@nospecialize(job::CompilerJob{PTXCompilerTarget}),
                          mod::LLVM.Module, format=LLVM.API.LLVMAssemblyFile)
     if !isavailable(NVPTX_LLVM_Backend_jll) || !NVPTX_LLVM_Backend_jll.is_available()
         error("NVPTX LLVM back-end not loaded; cannot compile to PTX.")
     end
+    if format != LLVM.API.LLVMAssemblyFile
+        error("Unsupported PTX output format $format; the NVPTX back-end only emits PTX assembly.")
+    end
+    backend = ExternalBackend(NVPTX_LLVM_Backend_jll.libnvptx, "NVPTX")
 
+    # the back-end derives the triple and datalayout from these options; unlike `llc`,
+    # it rejects unknown processors and PTX versions instead of silently falling back.
+    # FMA contraction is requested as `-nvptx-fma-level=1` was: match nvcc by leaving
+    # eligible multiply-add pairs contractible for ptxas.
     target = job.config.target
-    filetype = if format == LLVM.API.LLVMAssemblyFile
-        "asm"
-    elseif format == LLVM.API.LLVMObjectFile
-        "obj"
-    else
-        error("Unsupported PTX output format $format")
+    cpu = cpu_name(target)
+    ptx = GC.@preserve cpu begin
+        options = Ref(NVPTXCompileOptions(Base.unsafe_convert(Cstring, cpu),
+                                          target.ptx.major, target.ptx.minor,
+                                          Int === Int64, #=opt_level=# 2,
+                                          #=fma_contraction=# true, #=verbose=# true))
+        external_compile(backend, bitcode(mod), options,
+                         "Failed to compile to PTX with the NVPTX back-end")
     end
-
-    input  = tempname(cleanup=false) * ".bc"
-    output = tempname(cleanup=false) * (filetype == "asm" ? ".ptx" : ".cubin")
-    write(input, mod)
-
-    # Match nvcc by leaving eligible multiply-add pairs contractible for ptxas.
-    cmd = `$(NVPTX_LLVM_Backend_jll.llc()) $input
-              -mtriple=$(llvm_triple(target))
-              -mcpu=$(cpu_name(target))
-              -mattr=+ptx$(target.ptx.major)$(target.ptx.minor)
-              -nvptx-fma-level=1
-              -filetype=$filetype
-              -o $output`
-    out = Pipe()
-    proc = run(pipeline(ignorestatus(cmd); stdout=out, stderr=out); wait=false)
-    close(out.in)
-    log = strip(read(out, String))
-    wait(proc)
-    if !success(proc)
-        # keep the input around for debugging
-        msg = "Failed to compile to PTX with external llc"
-        isempty(log) || (msg *= ":\n" * log)
-        msg *= "\nIf you think this is a bug, please file an issue and attach $(input)."
-        isfile(output) && rm(output)
-        error(msg)
-    elseif !isempty(log)
-        # llc only diagnoses on stderr; even successful compilation may e.g. have
-        # ignored an unrecognized CPU or feature, so make sure this surfaces.
-        @warn "External llc reported:\n$log"
-    end
-
-    code = filetype == "asm" ? read(output, String) : String(read(output))
-    rm(input)
-    rm(output)
-    return code
+    return String(ptx)
 end
 
 function llvm_debug_info(@nospecialize(job::CompilerJob{PTXCompilerTarget}))

--- a/src/spirv.jl
+++ b/src/spirv.jl
@@ -147,8 +147,19 @@ function finish_ir!(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
     return entry
 end
 
+# mirrors `SPIRVCompileOptions` from libspirv.h
+struct SPIRVCompileOptions
+    is_64bit::Cint
+    version_major::Cuint
+    version_minor::Cuint
+    extensions::Cstring
+    opt_level::Cint
+end
+
 @unlocked function mcgen(job::CompilerJob{SPIRVCompilerTarget}, mod::LLVM.Module,
                          format=LLVM.API.LLVMAssemblyFile)
+    target = job.config.target
+
     # The SPIRV Tools don't handle Julia's debug info, rejecting DW_LANG_Julia...
     strip_debuginfo!(mod)
 
@@ -157,16 +168,25 @@ end
     rm_freeze!(job, mod)
 
     # translate to SPIR-V
-    input = tempname(cleanup=false) * ".bc"
-    translated = tempname(cleanup=false) * ".spv"
-    write(input, mod)
-    if job.config.target.backend === :llvm
-        cmd = `$(SPIRV_LLVM_Backend_jll.llc()) $input -filetype=obj -o $translated`
-
-        if !isempty(job.config.target.extensions)
-            cmd = `$(cmd) -spirv-ext=$(job.config.target.extensions)`
+    input = bitcode(mod)
+    dump_input() = let path = tempname(cleanup=false) * ".bc"
+        write(path, input)
+        path
+    end
+    spirv = if target.backend === :llvm
+        # compile in-process through libspirv. the back-end derives the triple from the
+        # options; unlike `llc`, it rejects unknown extensions instead of ignoring them.
+        backend = ExternalBackend(SPIRV_LLVM_Backend_jll.libspirv, "SPIRV")
+        version = something(target.version, v"0.0")
+        extensions = target.extensions
+        GC.@preserve extensions begin
+            options = Ref(SPIRVCompileOptions(Int === Int64, version.major, version.minor,
+                                              Base.unsafe_convert(Cstring, extensions),
+                                              #=opt_level=# 2))
+            external_compile(backend, input, options,
+                             "Failed to compile to SPIR-V with the SPIR-V back-end")
         end
-    elseif job.config.target.backend === :khronos
+    elseif target.backend === :khronos
         translator = if isavailable(SPIRV_LLVM_Translator_jll)
             SPIRV_LLVM_Translator_jll.llvm_spirv()
         elseif isavailable(SPIRV_LLVM_Translator_unified_jll)
@@ -174,57 +194,67 @@ end
         else
             error("This functionality requires the SPIRV_LLVM_Translator_jll or SPIRV_LLVM_Translator_unified_jll package, which should be installed and loaded first.")
         end
-        cmd = `$translator -o $translated $input --spirv-debug-info-version=ocl-100`
+        input_path = dump_input()
+        translated = tempname(cleanup=false) * ".spv"
+        cmd = `$translator -o $translated $input_path --spirv-debug-info-version=ocl-100`
 
-        if !isempty(job.config.target.extensions)
-            cmd = `$(cmd) --spirv-ext=$(job.config.target.extensions)`
+        if !isempty(target.extensions)
+            cmd = `$(cmd) --spirv-ext=$(target.extensions)`
         end
 
-        if job.config.target.version !== nothing
-            cmd = `$(cmd) --spirv-max-version=$(job.config.target.version.major).$(job.config.target.version.minor)`
+        if target.version !== nothing
+            cmd = `$(cmd) --spirv-max-version=$(target.version.major).$(target.version.minor)`
         end
+        try
+            run(cmd)
+        catch e
+            error("""Failed to translate LLVM code to SPIR-V.
+                     If you think this is a bug, please file an issue and attach $(input_path).""")
+        end
+        rm(input_path)
+        code = read(translated)
+        rm(translated)
+        code
+    else
+        error("Unsupported SPIR-V back-end $(repr(target.backend)); expected :llvm or :khronos.")
     end
-    try
-        run(cmd)
-    catch e
-        error("""Failed to translate LLVM code to SPIR-V.
-                 If you think this is a bug, please file an issue and attach $(input).""")
-    end
+
+    # the SPIR-V tools work on files
+    translated = tempname(cleanup=false) * ".spv"
+    write(translated, spirv)
 
     # validate
-    if job.config.target.validate
+    if target.validate
         try
             run(`$(SPIRV_Tools_jll.spirv_val()) $translated`)
         catch e
             error("""Failed to validate generated SPIR-V.
-                     If you think this is a bug, please file an issue and attach $(input) and $(translated).""")
+                     If you think this is a bug, please file an issue and attach $(dump_input()) and $(translated).""")
         end
     end
 
     # optimize
-    optimized = tempname(cleanup=false) * ".spv"
-    if job.config.target.optimize
+    if target.optimize
+        optimized = tempname(cleanup=false) * ".spv"
         try
             run(```$(SPIRV_Tools_jll.spirv_opt()) -O --skip-validation
                                                   $translated -o $optimized```)
         catch
             error("""Failed to optimize generated SPIR-V.
-                     If you think this is a bug, please file an issue and attach $(input) and $(translated).""")
+                     If you think this is a bug, please file an issue and attach $(dump_input()) and $(translated).""")
         end
-    else
-        cp(translated, optimized)
+        spirv = read(optimized)
+        rm(optimized)
     end
 
     output = if format == LLVM.API.LLVMObjectFile
-        read(optimized)
+        spirv
     else
         # disassemble
-        read(`$(SPIRV_Tools_jll.spirv_dis()) $optimized`, String)
+        write(translated, spirv)
+        read(`$(SPIRV_Tools_jll.spirv_dis()) $translated`, String)
     end
-
-    rm(input)
     rm(translated)
-    rm(optimized)
 
     return output
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,34 +59,91 @@ function Base.getproperty(lazy_mod::LazyModule, sym::Symbol)
 end
 
 
-## external tools
+## external back-ends
 
-# run an external tool (e.g. from a JLL package), feeding `input` to its standard input
-# and returning its standard output. throws on failure, including the tool's standard
-# error output in the exception. for tools that instead communicate through files, e.g.,
-# because the inputs should be preserved for error reporting, use `run` directly.
-function run_tool(cmd::Cmd, input)
-    stdin_pipe = Pipe()
-    stdout_pipe = Pipe()
-    stderr_pipe = Pipe()
+# The LLVM back-ends for PTX, GCN and SPIR-V and the bitcode downgrader ship as
+# symbol-hidden shared libraries with a small C API modelled after llvm-c: status as the
+# return value, an error message through an out-pointer on failure, results as opaque
+# memory buffers, and diagnostics that the tools used to print to stderr delivered through
+# a callback. The libraries share the shape of this API, differing only in the prefix of
+# their entry points, so this is implemented once against function pointers.
 
-    proc = run(pipeline(cmd; stdin=stdin_pipe, stdout=stdout_pipe, stderr=stderr_pipe);
-               wait=false)
-    close(stdout_pipe.in)
-    close(stderr_pipe.in)
+struct ExternalBackend
+    library::String     # path to the shared library, as exported by its JLL
+    prefix::String      # e.g. "NVPTX" for `NVPTXCompile`
+end
 
-    writer = @async begin
-        write(stdin_pipe, input)
-        close(stdin_pipe)
+function api(backend::ExternalBackend, name::String)
+    # `dlopen` returns the handle of an already-loaded library, so this is only a lookup
+    Libdl.dlsym(Libdl.dlopen(backend.library), Symbol(backend.prefix * name))
+end
+
+function external_diagnostic(severity::Cint, message::Cstring, ctx::Ptr{Cvoid})
+    diagnostics = unsafe_pointer_to_objref(ctx)::Vector{String}
+    # errors are folded into the failure message by the back-end; only keep what would
+    # otherwise be lost (warnings, remarks and notes).
+    severity == 0 || push!(diagnostics, unsafe_string(message))
+    return nothing
+end
+
+# compile `input` (bitcode) with the back-end's `Compile` entry point. `options` is a
+# reference to the back-end's option struct, whose string fields the caller keeps alive.
+function external_compile(backend::ExternalBackend, input::Vector{UInt8}, options::Ref,
+                          what::String; warn=(msg)->@warn(msg))
+    diagnostics = String[]
+    buffer = Ref{Ptr{Cvoid}}(C_NULL)
+    message = Ref{Cstring}(C_NULL)
+    compile = api(backend, "Compile")
+    handler = @cfunction(external_diagnostic, Cvoid, (Cint, Cstring, Ptr{Cvoid}))
+    status = GC.@preserve diagnostics begin
+        @ccall $compile(input::Ptr{UInt8}, length(input)::Csize_t, options::Ptr{Cvoid},
+                        handler::Ptr{Cvoid}, pointer_from_objref(diagnostics)::Ptr{Cvoid},
+                        buffer::Ptr{Ptr{Cvoid}}, message::Ptr{Cstring})::Cint
     end
-    reader = @async read(stdout_pipe)
-    logger = @async read(stderr_pipe, String)
+    external_result(backend, status, what, message[], diagnostics, input; warn)
+    return take_buffer(backend, buffer[])
+end
 
-    wait(proc)
-    if !success(proc)
-        error("Failed to run $(basename(cmd.exec[1])):\n" * fetch(logger))
+# report the outcome of a back-end invocation: raise `what` on failure with the error
+# message and a bitcode file to attach, and surface collected diagnostics otherwise.
+function external_result(backend::ExternalBackend, status, what::String, message::Cstring,
+                         diagnostics::Vector{String}, input::Vector{UInt8};
+                         warn=(msg)->@warn(msg))
+    if status != 0
+        path = tempname(cleanup=false) * ".bc"
+        write(path, input)
+        msg = what
+        message == C_NULL || (msg *= ":\n" * take_message(backend, message))
+        isempty(diagnostics) || (msg *= "\n" * join(diagnostics, "\n"))
+        msg *= "\nIf you think this is a bug, please file an issue and attach $(path)."
+        error(msg)
+    elseif !isempty(diagnostics)
+        warn("The $(backend.prefix) back-end reported:\n" * join(diagnostics, "\n"))
     end
-    fetch(reader)
+    return
+end
+
+# copy out and dispose of an opaque memory buffer
+function take_buffer(backend::ExternalBackend, buffer::Ptr{Cvoid})
+    start = @ccall $(api(backend, "GetBufferStart"))(buffer::Ptr{Cvoid})::Ptr{UInt8}
+    size = @ccall $(api(backend, "GetBufferSize"))(buffer::Ptr{Cvoid})::Csize_t
+    data = copy(unsafe_wrap(Array, start, size))
+    @ccall $(api(backend, "DisposeMemoryBuffer"))(buffer::Ptr{Cvoid})::Cvoid
+    return data
+end
+
+# copy out and dispose of a message
+function take_message(backend::ExternalBackend, message::Cstring)
+    str = unsafe_string(message)
+    @ccall $(api(backend, "DisposeMessage"))(message::Cstring)::Cvoid
+    return str
+end
+
+# serialize a module to bitcode
+function bitcode(mod::LLVM.Module)
+    io = IOBuffer()
+    write(io, mod)
+    take!(io)
 end
 
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -24,4 +24,3 @@ demumble_jll = "1e29f10c-031c-5a83-9565-69cddfc27673"
 [compat]
 Aqua = "0.8"
 ParallelTestRunner = "2"
-SPIRV_LLVM_Backend_jll = "22"

--- a/test/metal.jl
+++ b/test/metal.jl
@@ -427,7 +427,7 @@ end
         # the table base is loaded out of the kernel-state argument, and the words out of the
         # table -- a bake would instead leave a private constant holding the resolved address
         @test occursin("reloc_table", air)
-        @test occursin(r"load i64, i64 addrspace\(1\)\*", air)
+        @test occursin(r"load i64, (i64 addrspace\(1\)\*|ptr addrspace\(1\))", air)
         # nothing is left of the site globals the records named
         for rec in relocs.records
             @test !occursin("@$(rec.name) ", air)


### PR DESCRIPTION
NVPTX_LLVM_Backend_jll, AMDGPU_LLVM_Backend_jll, SPIRV_LLVM_Backend_jll 23 and LLVMDowngrader_jll 0.10 replace their `llc`, `lld` and `llvm-downgrade` executables with shared libraries exposing a small llvm-c style API (JuliaPackaging/Yggdrasil#14727). Call those instead of spawning processes and round-tripping through temporary files: bitcode goes in as a byte buffer, PTX, GCN assembly or objects, SPIR-V and AIR come back as one.

The libraries share the shape of their API, so a single implementation in utils.jl drives them through function pointers: `external_compile` handles the compile call, the diagnostic callback (what the tools printed to stderr, surfaced as warnings as before), error reporting (which now dumps the bitcode to a temporary file only on failure, for attaching to issues), and buffer ownership. Each back-end only mirrors its option struct.

Unlike `llc`, the libraries reject unknown processors, features, PTX versions and SPIR-V extensions instead of silently falling back.

Metal's textual output used to come from the legacy `llvm-dis-14` shipped with the downgrader, which is gone; the downgraded bitcode is now parsed back by the in-process LLVM, so it reads as that LLVM's dialect (opaque pointers) rather than LLVM 14's. The PTX back-end no longer accepts an object output format, which NVPTX never supported anyway.